### PR TITLE
Chore: gitignore local IDE and third-party agent skill dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,34 @@ _deps/
 *~
 .DS_Store
 
+# Local IDE / coding-agent droppings — never FlexAIDdS source
+.cursor/
+.windsurf/
+.continue/
+.gemini/
+.kilocode/
+.kiro/
+.opencode/
+.qoder/
+.roo/
+.trae/
+.warp/
+.augment/
+.codebuddy/
+.codewhale/
+.factory/
+.github/prompts/
+
+# Third-party design/brand skills dumped under .agents/skills/
+# Do not ignore .agents/skills/flexaidds-benchmarking or shannon (tracked).
+.agents/skills/banner-design/
+.agents/skills/brand/
+.agents/skills/design-system/
+.agents/skills/design/
+.agents/skills/slides/
+.agents/skills/ui-styling/
+.agents/skills/ui-ux-pro-max/
+
 # Test / coverage artifacts
 .pytest_cache/
 .coverage


### PR DESCRIPTION
## Summary

Last hygiene leftover from this thread: `git status` on `main` was noisy with untracked IDE/agent droppings (`.cursor/`, `.windsurf/`, dumped design/brand skills). Ignore those. Do **not** ignore tracked `.agents/skills/flexaidds-benchmarking` or `shannon`.

## Change class (pick **one** primary)

- [x] **CI / hygiene**

## Science-Impact

- [x] none (cannot move docked coordinates or CF ranking)

## Scope

- [x] CI / release engineering

## Release impact

- [x] no user-facing release impact

## Validation

`git status` no longer lists those directories. `git check-ignore` matches `.cursor/` and `.agents/skills/brand/`. Tracked FlexAIDdS skills stay tracked.

- [x] manual validation

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] no benchmark claim involved

## Notes

Not in this PR (next thread, not this cleanup): Coverage Analysis and Tier-1 Benchmark are red on `main` and do not discriminate. Ungated local `do-not-merge/ungated-science-robustness-3cdce531` stays unpushed.

Made with [Cursor](https://cursor.com)