### PR TITLE
Fix: hoist get_yval LUT flag and lock-free LUT lookups

### DIFF
--- a/LIB/EnvFlags.h
+++ b/LIB/EnvFlags.h
@@ -82,4 +82,30 @@ inline bool parallel_reproduce_enabled() noexcept
     return env_bool("FLEXAIDDS_PARALLEL_REPRODUCE", false);
 }
 
+/// FLEXAIDDS_GET_YVAL_LUT — DEFAULT OFF (METHODOLOGY.md §1).
+/// Snapshots getenv once (C++11 magic static) so the per-contact hot loop
+/// never calls std::getenv. Live re-read remains env_bool("FLEXAIDDS_GET_YVAL_LUT")
+/// / get_yval_lut_enabled() in get_yval.h. Do not default this ON without a
+/// §1 parity result that LUT-ON CF matches LUT-OFF (current default).
+inline bool get_yval_lut_enabled_cached() noexcept
+{
+    static const bool enabled = env_bool("FLEXAIDDS_GET_YVAL_LUT", false);
+    return enabled;
+}
+
+/// FLEXAIDDS_GET_YVAL_LUT_BINS — snapshotted with the LUT flag (default 256,
+/// clamp 16..1024). Live re-read: get_yval_lut_bins() in get_yval.h.
+inline int get_yval_lut_bins_cached() noexcept
+{
+    static const int bins = []() noexcept {
+        const char* s = std::getenv("FLEXAIDDS_GET_YVAL_LUT_BINS");
+        if (!s || !*s) return 256;
+        int n = std::atoi(s);
+        if (n < 16) n = 16;
+        if (n > 1024) n = 1024;
+        return n;
+    }();
+    return bins;
+}
+
 }  // namespace flexaids

--- a/LIB/get_yval.cpp
+++ b/LIB/get_yval.cpp
@@ -3,6 +3,9 @@
 
 #include "get_yval.h"
 
+#include <algorithm>
+#include <atomic>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -19,8 +22,17 @@ double get_yval_scan(struct energy_matrix* em, double relative_area)
 	if(!fx || !fy) return 0.0;
 	if(ra < fx[0]) return 0.0;
 	if(ra >= fx[n-1]) return (double)fy[n-1];
+	if(n < 2 || !em->flat_slope) return 0.0;
+	// Binary search for the same i as `while (i < n-2 && ra >= fx[i+1]) ++i`.
+	// NaN fails both early-outs (every comparison is false) and the historical
+	// linear scan left i = 0; keep that.
 	int i = 0;
-	while(i < n-2 && ra >= fx[i+1]) ++i;
+	if (ra == ra) {
+		const float* ub = std::upper_bound(fx, fx + n, ra);
+		i = static_cast<int>(ub - fx) - 1;
+		if (i < 0) i = 0;
+		if (i > n - 2) i = n - 2;
+	}
 	return (double)(fy[i] + em->flat_slope[i] * (ra - fx[i]));
 }
 
@@ -31,47 +43,83 @@ struct Lut {
 	std::vector<double> y;
 };
 
-std::mutex g_mu;
-std::unordered_map<const energy_matrix*, Lut> g_luts;
+using LutMap = std::unordered_map<const energy_matrix*, std::shared_ptr<const Lut>>;
 
-// Copy the two lerp samples (or the last bin) while the mutex is held so a
-// concurrent first-insert of another energy_matrix* cannot rehash g_luts
-// under a live reference (OpenMP vcfunction).
+// Copy-on-write map of per-matrix LUTs. After a key is published, readers
+// atomic-load the snapshot pointer and hash-find with no mutex (ShannonMetalBridge
+// once-then-immutable pattern). g_publish_mu is only for first-insert of a
+// new energy_matrix* (fixed per dock). Snapshots are immortal so a reader
+// that loaded an older pointer cannot see it freed. libc++ on this SDK has
+// no std::atomic<std::shared_ptr<T>> (requires trivially copyable T).
+std::atomic<const LutMap*> g_luts{nullptr};
+std::mutex g_publish_mu;
+std::vector<std::unique_ptr<const LutMap>> g_keep_alive;
+
+std::shared_ptr<const Lut> lut_for(energy_matrix* em, int bins)
+{
+	if (const LutMap* map = g_luts.load(std::memory_order_acquire)) {
+		auto it = map->find(em);
+		if (it != map->end() && it->second && it->second->bins == bins)
+			return it->second;
+	}
+
+	auto built = std::make_shared<Lut>();
+	built->bins = bins;
+	built->y.resize(static_cast<size_t>(bins));
+	const double denom = static_cast<double>(bins - 1);
+	for (int b = 0; b < bins; ++b) {
+		const double ra = static_cast<double>(b) / denom;
+		built->y[static_cast<size_t>(b)] = get_yval_scan(em, ra);
+	}
+
+	std::lock_guard<std::mutex> lock(g_publish_mu);
+	if (const LutMap* map = g_luts.load(std::memory_order_relaxed)) {
+		auto it = map->find(em);
+		if (it != map->end() && it->second && it->second->bins == bins)
+			return it->second;
+		auto next = std::make_unique<LutMap>(*map);
+		(*next)[em] = built;
+		const LutMap* raw = next.get();
+		g_keep_alive.push_back(std::move(next));
+		g_luts.store(raw, std::memory_order_release);
+		return built;
+	}
+	auto next = std::make_unique<LutMap>();
+	(*next)[em] = built;
+	const LutMap* raw = next.get();
+	g_keep_alive.push_back(std::move(next));
+	g_luts.store(raw, std::memory_order_release);
+	return built;
+}
+
+// Lock-free const reads after lut_for() returns. Copy y0/y1 out so a later
+// COW republish cannot invalidate the caller's references.
 bool lut_samples(energy_matrix* em, int bins, int i, double* y0, double* y1)
 {
-	std::lock_guard<std::mutex> lock(g_mu);
-	Lut& lut = g_luts[em];
-	if (lut.bins != bins || (int)lut.y.size() != bins) {
-		lut.bins = bins;
-		lut.y.resize(static_cast<size_t>(bins));
-		const double denom = static_cast<double>(bins - 1);
-		for (int b = 0; b < bins; ++b) {
-			const double ra = static_cast<double>(b) / denom;
-			lut.y[static_cast<size_t>(b)] = get_yval_scan(em, ra);
-		}
-	}
-	if (lut.y.empty()) return false;
+	auto lut = lut_for(em, bins);
+	if (!lut || lut->y.empty()) return false;
+	const auto& y = lut->y;
 	if (i >= bins - 1) {
-		*y0 = lut.y.back();
-		*y1 = lut.y.back();
+		*y0 = y.back();
+		*y1 = y.back();
 		return true;
 	}
 	if (i < 0) i = 0;
-	*y0 = lut.y[static_cast<size_t>(i)];
-	*y1 = lut.y[static_cast<size_t>(i + 1)];
+	*y0 = y[static_cast<size_t>(i)];
+	*y1 = y[static_cast<size_t>(i + 1)];
 	return true;
 }
 
 }  // namespace
 
-double get_yval(struct energy_matrix* em, double relative_area)
+double get_yval(struct energy_matrix* em, double relative_area, bool use_lut)
 {
-	if (!flexaids::get_yval_lut_enabled())
+	if (!use_lut)
 		return get_yval_scan(em, relative_area);
 	if (!em) return 0.0;
 	if (relative_area < 0.0 || relative_area > 1.0)
 		return get_yval_scan(em, relative_area);
-	const int bins = flexaids::get_yval_lut_bins();
+	const int bins = flexaids::get_yval_lut_bins_cached();
 	const double t = relative_area * static_cast<double>(bins - 1);
 	int i = static_cast<int>(t);
 	if (i < 0) i = 0;
@@ -81,4 +129,9 @@ double get_yval(struct energy_matrix* em, double relative_area)
 	if (i >= bins - 1) return y0;
 	const double f = t - static_cast<double>(i);
 	return y0 * (1.0 - f) + y1 * f;
+}
+
+double get_yval(struct energy_matrix* em, double relative_area)
+{
+	return get_yval(em, relative_area, flexaids::get_yval_lut_enabled_cached());
 }

--- a/LIB/get_yval.h
+++ b/LIB/get_yval.h
@@ -1,8 +1,11 @@
 // get_yval.h — piecewise-linear energy-matrix lookup + optional LUT
 //
-// FLEXAIDDS_GET_YVAL_LUT default OFF: get_yval() is the linear scan (bit-identical
-// to the pre-LUT vcfunction.cpp implementation). ON: 256-bin lerp of the same
-// scan, resolution knob FLEXAIDDS_GET_YVAL_LUT_BINS (default 256, clamp 16..1024).
+// Default path: get_yval_scan() — binary search + lerp on the flat knot table
+// (same knots/slopes as the historical linear scan; LUT still OFF).
+// FLEXAIDDS_GET_YVAL_LUT default OFF (METHODOLOGY.md §1): get_yval() is that
+// scan. ON: 256-bin lerp of the same scan, resolution knob
+// FLEXAIDDS_GET_YVAL_LUT_BINS (default 256, clamp 16..1024). LUT stays opt-in
+// until a §1 parity run shows ranking-preserving / bit-identical CF vs LUT-OFF.
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
@@ -15,11 +18,13 @@
 
 namespace flexaids {
 
+/// Live getenv. Hot-loop code must use get_yval_lut_enabled_cached() instead.
 inline bool get_yval_lut_enabled() noexcept
 {
     return env_bool("FLEXAIDDS_GET_YVAL_LUT", false);
 }
 
+/// Live getenv. Hot-loop code must use get_yval_lut_bins_cached() instead.
 inline int get_yval_lut_bins() noexcept
 {
     const char* s = std::getenv("FLEXAIDDS_GET_YVAL_LUT_BINS");
@@ -32,8 +37,12 @@ inline int get_yval_lut_bins() noexcept
 
 }  // namespace flexaids
 
-/// Linear-scan interpolation (the historical get_yval body).
+/// Piecewise-linear interpolation on em->flat_* (binary search on knots).
 double get_yval_scan(struct energy_matrix* em, double relative_area);
 
-/// Dispatch: scan unless FLEXAIDDS_GET_YVAL_LUT is on.
+/// Dispatch: scan unless the cached FLEXAIDDS_GET_YVAL_LUT snapshot is on.
 double get_yval(struct energy_matrix* em, double relative_area);
+
+/// Same dispatch with an explicit LUT flag (vcfunction hoists the snapshot;
+/// tests can exercise LUT ON without mutating the process-wide cache).
+double get_yval(struct energy_matrix* em, double relative_area, bool use_lut);

--- a/LIB/vcfunction.cpp
+++ b/LIB/vcfunction.cpp
@@ -8,6 +8,7 @@
 #include "ProtocolConfig.h"
 #include "ca_rec_flat.h"
 #include "EnvFlags.h"
+#include "get_yval.h"
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -41,6 +42,10 @@ static const float con_r0 = []() {
     return v;
 }();
 static const bool no_sas = (std::getenv("FLEXAIDDS_NO_SAS") != nullptr);
+// FLEXAIDDS_GET_YVAL_LUT default OFF (METHODOLOGY.md §1). Same magic-static
+// hoist as the flags above — getenv is never in the per-contact loop.
+// LUT remains opt-in; the 3-arg get_yval uses this snapshot.
+static const bool get_yval_use_lut = flexaids::get_yval_lut_enabled_cached();
 
 // FLEXAIDDS_POLAR_DESOLV_WEIGHT (float >= 0, default 0.0 = OFF): per-ligand-atom
 // polar-burial desolvation penalty, folded into the cfs->sas channel (which
@@ -505,7 +510,7 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 
 			//double yval = get_yval(energy_matrix,area/((surfA+surfB)/2.0));
 			// always use normalized areas in density functions
-			double yval = get_yval(energy_matrix,area/surfA);
+			double yval = get_yval(energy_matrix,area/surfA, get_yval_use_lut);
 			
 			SAS -= area;
 			
@@ -928,7 +933,7 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
 										 (FA->ntypes-1)];
 			//printf("type1: %d\ttype2: %d\n", energy_matrix->type1, energy_matrix->type2);
 			
-			double yval = get_yval(energy_matrix,SAS/surfA);
+			double yval = get_yval(energy_matrix,SAS/surfA, get_yval_use_lut);
 			
 			if(energy_matrix->weight){
 				if(FA->normalize_area){
@@ -1460,4 +1465,4 @@ double vcfunction(FA_Global* FA,VC_Global* VC,atom* atoms,resid* residue, std::v
   
 }
 
-// get_yval lives in get_yval.cpp (scan + opt-in LUT).
+// get_yval lives in get_yval.cpp (binary-search scan + opt-in lock-free LUT).

--- a/tests/test_get_yval_lut.cpp
+++ b/tests/test_get_yval_lut.cpp
@@ -4,8 +4,10 @@
 #include <gtest/gtest.h>
 #include "get_yval.h"
 
+#include <atomic>
 #include <cmath>
 #include <cstdlib>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -43,14 +45,56 @@ struct Piecewise {
     }
 };
 
+// Historical linear scan — the binary-search path must match this exactly.
+double scan_linear(energy_matrix* em, double relative_area)
+{
+    if (!em || !em->energy_values) return 0.0;
+    if (em->weight) return (double)em->energy_values->y;
+    const int n = em->flat_n;
+    if (n == 0) return 0.0;
+    const float ra = (float)relative_area;
+    const float* fx = em->flat_x;
+    const float* fy = em->flat_y;
+    if (!fx || !fy) return 0.0;
+    if (ra < fx[0]) return 0.0;
+    if (ra >= fx[n - 1]) return (double)fy[n - 1];
+    int i = 0;
+    while (i < n - 2 && ra >= fx[i + 1]) ++i;
+    return (double)(fy[i] + em->flat_slope[i] * (ra - fx[i]));
+}
+
 }  // namespace
 
 TEST(GetYval, DefaultOffUsesScan) {
     unset_env("FLEXAIDDS_GET_YVAL_LUT");
     EXPECT_FALSE(flexaids::get_yval_lut_enabled());
     Piecewise p;
-    EXPECT_DOUBLE_EQ(get_yval(&p.em, 0.25), get_yval_scan(&p.em, 0.25));
-    EXPECT_NEAR(get_yval(&p.em, 0.25), 5.0, 1e-5);
+    EXPECT_DOUBLE_EQ(get_yval(&p.em, 0.25, false), get_yval_scan(&p.em, 0.25));
+    EXPECT_NEAR(get_yval(&p.em, 0.25, false), 5.0, 1e-5);
+}
+
+TEST(GetYval, CachedLutFlagIgnoresLaterGetenv) {
+    const bool cached = flexaids::get_yval_lut_enabled_cached();
+    Piecewise p;
+    const double via_cache = get_yval(&p.em, 0.25);
+    const double via_flag = get_yval(&p.em, 0.25, cached);
+    EXPECT_DOUBLE_EQ(via_cache, via_flag);
+
+    if (cached) {
+        unset_env("FLEXAIDDS_GET_YVAL_LUT");
+    } else {
+        set_env("FLEXAIDDS_GET_YVAL_LUT", "1");
+    }
+    EXPECT_EQ(flexaids::get_yval_lut_enabled_cached(), cached);
+    EXPECT_EQ(flexaids::get_yval_lut_enabled(), !cached)
+        << "live getenv must be independent of the hot-loop snapshot";
+    EXPECT_DOUBLE_EQ(get_yval(&p.em, 0.25), via_flag);
+
+    if (cached) {
+        set_env("FLEXAIDDS_GET_YVAL_LUT", "1");
+    } else {
+        unset_env("FLEXAIDDS_GET_YVAL_LUT");
+    }
 }
 
 TEST(GetYval, LutOnInterpolatesScanSamples) {
@@ -58,30 +102,85 @@ TEST(GetYval, LutOnInterpolatesScanSamples) {
     EXPECT_TRUE(flexaids::get_yval_lut_enabled());
     Piecewise p;
     const double scan = get_yval_scan(&p.em, 0.25);
-    const double lut = get_yval(&p.em, 0.25);
+    const double lut = get_yval(&p.em, 0.25, true);
     EXPECT_NEAR(lut, scan, 0.1);  // 256-bin lerp of the same scan
-    EXPECT_DOUBLE_EQ(get_yval(&p.em, -0.5), get_yval_scan(&p.em, -0.5));
+    EXPECT_DOUBLE_EQ(get_yval(&p.em, -0.5, true), get_yval_scan(&p.em, -0.5));
     unset_env("FLEXAIDDS_GET_YVAL_LUT");
 }
 
 TEST(GetYval, OutOfRangeFallsBackToScan) {
-    set_env("FLEXAIDDS_GET_YVAL_LUT", "1");
     Piecewise p;
-    EXPECT_DOUBLE_EQ(get_yval(&p.em, 1.5), get_yval_scan(&p.em, 1.5));
-    unset_env("FLEXAIDDS_GET_YVAL_LUT");
+    EXPECT_DOUBLE_EQ(get_yval(&p.em, 1.5, true), get_yval_scan(&p.em, 1.5));
 }
 
-TEST(GetYval, TwoMatricesLutCopiesUnderLock) {
-    set_env("FLEXAIDDS_GET_YVAL_LUT", "1");
+TEST(GetYval, TwoMatricesLutIndependent) {
     Piecewise a, b;
     b.ys = {0.f, 20.f, 8.f};
     b.sl = {(20.f - 0.f) / 0.5f, (8.f - 20.f) / 0.5f};
-    // Inserting a second key must not invalidate interpolation of the first.
-    const double a0 = get_yval(&a.em, 0.25);
-    const double b0 = get_yval(&b.em, 0.25);
-    const double a1 = get_yval(&a.em, 0.25);
+    const double a0 = get_yval(&a.em, 0.25, true);
+    const double b0 = get_yval(&b.em, 0.25, true);
+    const double a1 = get_yval(&a.em, 0.25, true);
     EXPECT_DOUBLE_EQ(a0, a1);
     EXPECT_NEAR(a0, get_yval_scan(&a.em, 0.25), 0.1);
     EXPECT_NEAR(b0, get_yval_scan(&b.em, 0.25), 0.1);
-    unset_env("FLEXAIDDS_GET_YVAL_LUT");
+}
+
+TEST(GetYval, BinarySearchMatchesLinearScan) {
+    energy_values ev{};
+    ev.next_value = nullptr;
+    std::vector<float> xs{0.f, 0.2f, 0.5f, 0.75f, 1.f};
+    std::vector<float> ys{1.f, 3.f, -1.f, 4.f, 2.f};
+    std::vector<float> sl(xs.size() - 1);
+    for (size_t i = 0; i < sl.size(); ++i)
+        sl[i] = (ys[i + 1] - ys[i]) / (xs[i + 1] - xs[i]);
+    energy_matrix em{};
+    em.weight = 0;
+    em.energy_values = &ev;
+    em.flat_n = static_cast<int>(xs.size());
+    em.flat_x = xs.data();
+    em.flat_y = ys.data();
+    em.flat_slope = sl.data();
+
+    const double samples[] = {
+        -0.5, 0.0, 0.1, 0.2, 0.35, 0.5, 0.625, 0.75, 0.9, 1.0, 1.5,
+    };
+    for (double ra : samples) {
+        EXPECT_DOUBLE_EQ(get_yval_scan(&em, ra), scan_linear(&em, ra)) << "ra=" << ra;
+    }
+    for (int k = 0; k <= 40; ++k) {
+        const double ra = -0.05 + 0.03 * static_cast<double>(k);
+        EXPECT_DOUBLE_EQ(get_yval_scan(&em, ra), scan_linear(&em, ra)) << "ra=" << ra;
+    }
+
+    Piecewise p;
+    EXPECT_DOUBLE_EQ(get_yval_scan(&p.em, 0.0), scan_linear(&p.em, 0.0));
+    EXPECT_DOUBLE_EQ(get_yval_scan(&p.em, 0.25), scan_linear(&p.em, 0.25));
+    EXPECT_DOUBLE_EQ(get_yval_scan(&p.em, 0.5), scan_linear(&p.em, 0.5));
+    EXPECT_DOUBLE_EQ(get_yval_scan(&p.em, 0.75), scan_linear(&p.em, 0.75));
+    EXPECT_DOUBLE_EQ(get_yval_scan(&p.em, 1.0), scan_linear(&p.em, 1.0));
+}
+
+TEST(GetYval, LutLookupsConcurrentSafe) {
+    Piecewise a, b;
+    b.ys = {0.f, 20.f, 8.f};
+    b.sl = {(20.f - 0.f) / 0.5f, (8.f - 20.f) / 0.5f};
+    std::atomic<int> mismatches{0};
+    auto worker = [&](int seed) {
+        energy_matrix* ems[2] = {&a.em, &b.em};
+        for (int k = 0; k < 2000; ++k) {
+            energy_matrix* em = ems[(seed + k) & 1];
+            const double ra = 0.01 * static_cast<double>((k * 17 + seed) % 100);
+            const double lut = get_yval(em, ra, true);
+            const double scan = get_yval_scan(em, ra);
+            if (std::abs(lut - scan) > 0.15)
+                mismatches.fetch_add(1, std::memory_order_relaxed);
+        }
+    };
+    std::vector<std::thread> ts;
+    ts.reserve(8);
+    for (int t = 0; t < 8; ++t)
+        ts.emplace_back(worker, t);
+    for (auto& th : ts)
+        th.join();
+    EXPECT_EQ(mismatches.load(), 0);
 }


### PR DESCRIPTION
## Summary
Precision-safe hot-loop work for `get_yval` / `vcfunction` (DeepSeek v4 Pro items **#1–#3 only**). **No ranking change.** Default CF path is still the scan; **LUT remains opt-in** via `FLEXAIDDS_GET_YVAL_LUT` (default OFF). Wave 0 claim hygiene is a **separate PR**.

- **#1 P0:** Stop `std::getenv` in the per-contact loop. `FLEXAIDDS_GET_YVAL_LUT` / bins are snapshotted once (`get_yval_lut_enabled_cached()` magic static in `EnvFlags.h`). `vcfunction` hoists the snapshot like its other env flags and passes it into `get_yval(..., use_lut)`.
- **#2 P0 when LUT ON:** LUT tables are built once per `energy_matrix*` (fixed per dock) and published as an immortal COW snapshot. After init, lookups are lock-free const reads (no `g_mu` on the hot path). Pattern matches ShannonMetalBridge once-then-immutable; libc++ on this SDK has no `std::atomic<std::shared_ptr<T>>`, so the snapshot is an `atomic<const LutMap*>`.
- **#3 P1:** Scan fallback is binary search (`std::upper_bound`) with the same knot index as the historical linear `while`. Default path does **not** turn LUT ON.

**METHODOLOGY.md §1:** this PR does not change default-flag behavior except replacing linear scan with an equivalent binary search (unit-tested `EXPECT_DOUBLE_EQ` vs the old while-loop). LUT-ON is still behind the existing env flag. No in-session 1G9V elected-CF / 10-pose byte-identity dock was run; OPS should still run §1 on merge. Do **not** default LUT ON until that parity exists for LUT-ON vs LUT-OFF.

## Test plan
- [x] Worktree-only configure: `cmake -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release` (not the primary checkout `build/`)
- [x] `ctest -R GetYvalLutTests` — 7/7 (cache vs live getenv, binary vs linear including endpoints/mid-bin, concurrent LUT)
- [x] `ctest -R Chunk5LayoutTests` — pass
- [x] `ctest -R GAValidationTests` — pass
- [x] `ctest -R FlexaiddsFlagsTests` — pass
- [x] `flexaid_core` compiles (`vcfunction.cpp` 3-arg call sites)
- [ ] OPS: METHODOLOGY.md §1 parity dock (1G9V, `FLEXAID_SEED=12345`, default flags) before merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional lookup-table acceleration for value calculations.
  * Added configurable lookup-table bin counts, supporting 16–1024 bins.
  * Added an API option to explicitly choose lookup-table or scan-based calculation.

* **Performance**
  * Improved interpolation lookups and enabled concurrent, lock-free table reads.

* **Bug Fixes**
  * Preserved behavior for boundary values, NaN inputs, and independent calculation matrices.

* **Tests**
  * Expanded coverage for configuration caching, lookup accuracy, boundaries, and concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->