### PR TITLE
Fix: STRICT numerator, RMSD <= 2.0, register_result, cache shell, tENCoM pairing, std::abs dedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1462,6 +1462,17 @@ flexaids_add_unit_test(test_protocol_config
         TEST_NAME TENCoMDiffTests
     )
 
+    # test_tencom_output — FlexPopulation mode↔structure pairing after sort
+    flexaids_add_unit_test(test_tencom_output
+        SOURCES
+            tests/test_tencom_output.cpp
+            LIB/tENCoM/tencom_output.cpp
+            LIB/tENCoM/pdb_calpha.cpp
+        LINK_LIBRARIES Eigen3::Eigen
+        DEFINES FLEXAIDS_HAS_EIGEN
+        TEST_NAME TENCoMOutputTests
+    )
+
     # test_ptm_attachment — PTMAttachment module tests
     flexaids_add_unit_test(test_ptm_attachment
         SOURCES

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -4577,13 +4577,15 @@ std::vector<DatasetEntry> DatasetRunner::fetch_posebusters() {
     // Clone or update the PoseBusters benchmark repo
     std::string repo_dir = pb_dir + "/PoseBusters-Benchmark";
     if (!fs::exists(repo_dir)) {
-        std::string cmd = "git clone --depth 1 https://github.com/maabuu/posebusters_benchmark.git \""
-                          + repo_dir + "\" 2>&1";
+        // cache_dir_ is user-controlled (--cache); quote for /bin/sh -c via exec_cmd.
+        const std::string quoted_repo = shell_quote(repo_dir);
+        std::string cmd = "git clone --depth 1 https://github.com/maabuu/posebusters_benchmark.git "
+                          + quoted_repo + " 2>&1";
         int ret = exec_cmd(cmd);
         if (ret != 0) {
             // Try alternate URL
-            cmd = "git clone --depth 1 https://github.com/degrado-lab/PoseBusters-Benchmark.git \""
-                  + repo_dir + "\" 2>&1";
+            cmd = "git clone --depth 1 https://github.com/degrado-lab/PoseBusters-Benchmark.git "
+                  + quoted_repo + " 2>&1";
             exec_cmd(cmd);
         }
     }
@@ -7741,6 +7743,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
 
         // Publication gate: official PoseBusters and ligand tENCoM/Eigen must
         // all have consumed the exact elected pose represented by pose_sha256.
+        // Per-complex flag only. STRICT n/85 (numerator ∩ frozen Astex-85
+        // manifest) is aggregated in scripts/aggregate_claim_metrics.py.
         result.claim_ready =
             result.success_pb &&
             result.protocol_claim_eligible &&
@@ -7808,7 +7812,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     sess.log_Z = -static_cast<double>(result.predicted_dG) /
                                  (statmech::kB_kcal * static_cast<double>(config.temperature));
                 }
-                // TODO: best_center / conformer_populations from actual BindingMode data                ts_it2->second->register_result(sess);
+                // TODO: best_center / conformer_populations from actual BindingMode data.
+                // Live call — do not comment this out; GPF/TargetServer depends on it.
+                ts_it2->second->register_result(sess);
             }
         }
 

--- a/LIB/EnvFlags.h
+++ b/LIB/EnvFlags.h
@@ -108,4 +108,12 @@ inline int get_yval_lut_bins_cached() noexcept
     return bins;
 }
 
+/// FLEXAIDDS_DEDUP_STDABS — DEFAULT ON.
+/// Use std::abs on gene `to_ic` deltas so |Δ|<1 is not truncated by abs(int).
+/// Set 0/false/off to restore historical abs(int) truncation for A/B.
+inline bool dedup_stdabs_enabled() noexcept
+{
+    return env_bool("FLEXAIDDS_DEDUP_STDABS", true);
+}
+
 }  // namespace flexaids

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -13,6 +13,7 @@
 #include "niche_distance.h"
 #include "niche_hash.h"
 #include "new_search_arch.h"
+#include "EnvFlags.h"
 
 #include <random>
 #include <functional>
@@ -4211,13 +4212,18 @@ int cmp_chrom2rotlist(psFlexDEE_Node psFlexDEE_INI_Node, const chromosome* chrom
 /***********************************************************************/
 int cmp_chrom2pop(const chromosome* chrom,const gene* genes, int num_genes,int start, int last){
 	int i,j,flag;
+	const bool use_stdabs = flexaids::dedup_stdabs_enabled();
 
 	for(i=start;i<last;i++){
 		flag=0;
 		for(j=0;j<num_genes;j++){
 			//printf("individuals[%d][%d].gene[%d]=%.3f\t%.3f\n", start-1, i, j,
 			//       genes[j].to_ic, chrom[i].genes[j].to_ic);
-			flag += abs(genes[j].to_ic - chrom[i].genes[j].to_ic) < GA_GENE_MATCH_TOLERANCE;
+			const double d = genes[j].to_ic - chrom[i].genes[j].to_ic;
+			const double ad = use_stdabs
+				? std::abs(d)
+				: static_cast<double>(std::abs(static_cast<int>(d)));
+			flag += ad < GA_GENE_MATCH_TOLERANCE;
 		}
 
 		//printf("flag=%d\n",flag);
@@ -4805,12 +4811,17 @@ int remove_dups(chromosome* chrom, int num_chrom, int num_genes){
 	int i=0;
 	int j;
 	if (num_chrom<=1) return num_chrom;
+	const bool use_stdabs = flexaids::dedup_stdabs_enabled();
 
 	for (j=1;j<num_chrom;j++)
 	{
 		int flag = 0;
 		for(int l=0;l<num_genes;l++){
-			flag += abs(chrom[j].genes[l].to_ic - chrom[i].genes[l].to_ic) < 0.1;
+			const double d = chrom[j].genes[l].to_ic - chrom[i].genes[l].to_ic;
+			const double ad = use_stdabs
+				? std::abs(d)
+				: static_cast<double>(std::abs(static_cast<int>(d)));
+			flag += ad < 0.1;
 		}
 		if(flag != num_genes)
 		{

--- a/LIB/tENCoM/tencom_main.cpp
+++ b/LIB/tENCoM/tencom_main.cpp
@@ -297,6 +297,7 @@ static void run_analysis_at_temperature(
 
     tencom_output::FlexMode ref_mode;
     ref_mode.mode_id = 0;
+    ref_mode.structure_index = 0;
     ref_mode.pdb_path = opts.pdb_files[0];
     ref_mode.label = "reference";
     ref_mode.S_vib = ref_svib.S_vib_kcal_mol_K;
@@ -333,6 +334,7 @@ static void run_analysis_at_temperature(
 
         tencom_output::FlexMode tgt_mode;
         tgt_mode.mode_id = static_cast<int>(t + 1);
+        tgt_mode.structure_index = t + 1;
         tgt_mode.pdb_path = opts.pdb_files[t + 1];
         tgt_mode.label = opts.pdb_files[t + 1];
         tgt_mode.S_vib = diff.svib_tgt.S_vib_kcal_mol_K;
@@ -354,9 +356,16 @@ static void run_analysis_at_temperature(
     population.print_summary();
 
     if (opts.output_pdb) {
-        int n = std::min(all_structures.size(), population.modes.size());
-        for (int i = 0; i < static_cast<int>(n); ++i) {
-            population.write_mode_pdb(population.modes[i], all_structures[i]);
+        for (const auto& mode : population.modes) {
+            const auto* st = tencom_output::FlexPopulation::paired_structure(
+                mode, all_structures);
+            if (!st) {
+                std::cerr << "Error: mode " << mode.mode_id
+                          << " structure_index " << mode.structure_index
+                          << " out of range\n";
+                continue;
+            }
+            population.write_mode_pdb(mode, *st);
         }
     }
     if (opts.output_json) {

--- a/LIB/tENCoM/tencom_output.cpp
+++ b/LIB/tENCoM/tencom_output.cpp
@@ -39,6 +39,16 @@ void FlexPopulation::sort_by_free_energy() {
               });
 }
 
+const tencom_pdb::CalphaStructure*
+FlexPopulation::paired_structure(
+    const FlexMode& mode,
+    const std::vector<tencom_pdb::CalphaStructure>& structures)
+{
+    if (mode.structure_index >= structures.size())
+        return nullptr;
+    return &structures[mode.structure_index];
+}
+
 // ─── FlexPopulation::write_mode_pdb ─────────────────────────────────────────
 
 void FlexPopulation::write_mode_pdb(const FlexMode& mode,
@@ -270,9 +280,15 @@ void FlexPopulation::output_all(
                   << ") != mode count (" << modes.size() << ")\n";
     }
 
-    int n = std::min(structures.size(), modes.size());
-    for (int i = 0; i < n; ++i) {
-        write_mode_pdb(modes[i], structures[i]);
+    for (const auto& mode : modes) {
+        const auto* st = paired_structure(mode, structures);
+        if (!st) {
+            std::cerr << "Error: mode " << mode.mode_id
+                      << " structure_index " << mode.structure_index
+                      << " out of range (" << structures.size() << " structures)\n";
+            continue;
+        }
+        write_mode_pdb(mode, *st);
     }
 
     std::cout << "\ntENCoM analysis complete. "
@@ -320,12 +336,11 @@ void FlexPopulation::write_json(
         ofs << "      \"n_modes\": " << m.n_modes << ",\n";
         ofs << "      \"n_residues\": " << m.n_residues << ",\n";
 
-        // Composition
-        if (mi < structures.size()) {
-            const auto& s = structures[mi];
-            ofs << "      \"composition\": {\"protein\": " << s.n_protein
-                << ", \"dna\": " << s.n_dna
-                << ", \"rna\": " << s.n_rna << "},\n";
+        // Composition — pair by construction index, not post-sort slot.
+        if (const auto* s = paired_structure(m, structures)) {
+            ofs << "      \"composition\": {\"protein\": " << s->n_protein
+                << ", \"dna\": " << s->n_dna
+                << ", \"rna\": " << s->n_rna << "},\n";
         }
 
         // B-factors

--- a/LIB/tENCoM/tencom_output.h
+++ b/LIB/tENCoM/tencom_output.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include <cstddef>
 
 namespace tencom_output {
 
@@ -46,6 +47,11 @@ struct FlexMode {
 
     int n_modes   = 0;          // number of non-trivial normal modes
     int n_residues = 0;
+
+    // Index into the parallel CalphaStructure vector at construction.
+    // Survives sort_by_free_energy() so PDB/JSON writers pair coordinates to
+    // the mode they were computed from (N>2 permutes modes[1:]).
+    std::size_t structure_index = 0;
 };
 
 // Population of FlexModes — analogous to BindingPopulation
@@ -56,6 +62,11 @@ struct FlexPopulation {
 
     // Sort modes by delta_F_vib (ascending, most stabilizing first)
     void sort_by_free_energy();
+
+    // Resolve the Cα structure this mode was built from (stable across sort).
+    static const tencom_pdb::CalphaStructure*
+    paired_structure(const FlexMode& mode,
+                     const std::vector<tencom_pdb::CalphaStructure>& structures);
 
     // Write PDB file for a given mode with REMARK thermodynamic metadata
     void write_mode_pdb(const FlexMode& mode,

--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -715,8 +715,8 @@ class BenchmarkSummary:
 
     Attributes:
         n_systems: Total number of systems.
-        flexaidds_success_rate: Fraction with RMSD < threshold.
-        boltz2_success_rate: Fraction with RMSD < threshold.
+        flexaidds_success_rate: Fraction with RMSD <= threshold.
+        boltz2_success_rate: Fraction with RMSD <= threshold.
         flexaidds_median_rmsd_angstrom: Median best-pose RMSD.
         boltz2_median_rmsd_angstrom: Median best-pose RMSD.
         rank_correlation_spearman: Spearman rho between methods' score rankings.
@@ -821,7 +821,12 @@ class BenchmarkResult:
         threshold = self.rmsd_threshold_angstrom
 
         def _success(rmsds: List[float]) -> Optional[float]:
-            return sum(1 for r in rmsds if r < threshold) / len(rmsds) if rmsds else None
+            # Inclusive 2.0 Å gate (METHODOLOGY.md §0). Ranking/election unchanged.
+            return (
+                sum(1 for r in rmsds if 0.0 <= r <= threshold) / len(rmsds)
+                if rmsds
+                else None
+            )
 
         def _median(vals: List[float]) -> Optional[float]:
             if not vals:

--- a/python/flexaidds/dataset_runner/metrics.py
+++ b/python/flexaidds/dataset_runner/metrics.py
@@ -10,7 +10,7 @@ Metric catalogue
 * enrichment_factor     — EF at any percentile
 * log_auc               — Logarithmic AUC for early enrichment
 * scoring_power         — Pearson r + RMSE vs experimental affinities
-* docking_power         — % top-ranked poses with RMSD < threshold
+* docking_power         — % top-ranked poses with RMSD <= threshold
 * target_specificity_zscore — Z-score of binder scores vs random background
 * hit_rate_top_n        — Fraction of true binders in top-N predictions
 * bootstrap_ci          — 95% CI via non-parametric bootstrapping
@@ -62,6 +62,15 @@ class PoseScore:
     ensemble_log_Z: Optional[float] = None  # P3 grand canonical: real log_Z from ensemble (for conc-weighted Xi)
 
 
+def rmsd_is_success(rmsd: float, threshold: float = 2.0) -> bool:
+    """Inclusive RMSD success gate (METHODOLOGY.md §0).
+
+    Success ⇔ ``0.0 <= rmsd <= threshold``. Sentinel values (-1 = not
+    computed, 999 = no pose) never succeed. Ranking/election is unchanged.
+    """
+    return 0.0 <= rmsd <= threshold
+
+
 # ---------------------------------------------------------------------------
 # Entropy rescue rate (Shannon Energy Collapse)
 # ---------------------------------------------------------------------------
@@ -81,7 +90,7 @@ def entropy_rescue_rate(
 
     A rescue event for target *t* requires all of the following:
     1. The crystal pose (lowest RMSD across all poses for *t*) has
-       ``rmsd < rmsd_threshold``.
+       ``0.0 <= rmsd <= rmsd_threshold``.
     2. Its enthalpy rank > ``rank_threshold`` (missed by enthalpy alone).
     3. Its entropy-corrected rank ≤ ``rank_threshold`` (rescued by ΔS).
 
@@ -113,7 +122,7 @@ def entropy_rescue_rate(
         if not valid:
             continue
         crystal = min(valid, key=lambda p: p.rmsd)
-        if crystal.rmsd >= rmsd_threshold:
+        if not rmsd_is_success(crystal.rmsd, rmsd_threshold):
             continue  # no reference pose within threshold
 
         # Rank by enthalpy (lower = better)
@@ -301,7 +310,7 @@ def docking_power(
     """Fraction of targets where the top-N poses contain a near-native pose.
 
     A target is a "success" if *any* of its top-``top_n`` ranked poses (by
-    ``total_score``) has ``0.0 <= rmsd < rmsd_threshold``.  Sentinel RMSD
+    ``total_score``) has ``0.0 <= rmsd <= rmsd_threshold``.  Sentinel RMSD
     values (-1 = not computed, 999 = no pose emitted) are never successes.
 
     The denominator is the number of targets *attempted*, not the number that
@@ -331,7 +340,7 @@ def docking_power(
         # Rank over every emitted pose. Filtering the sentinels out first would
         # promote a worse-scoring pose into the top-N and inflate the rate.
         ranked = sorted(target_poses, key=lambda p: p.total_score)[:top_n]
-        if any(0.0 <= p.rmsd < rmsd_threshold for p in ranked):
+        if any(rmsd_is_success(p.rmsd, rmsd_threshold) for p in ranked):
             n_success += 1
 
     denom = n_targets if n_targets is not None else len(by_target)
@@ -526,7 +535,7 @@ def compute_all_metrics(
         for p in poses:
             # Exclude both sentinels: -1 (not computed) and 999 (no pose
             # emitted).  Averaging 999 would silently poison the aggregate,
-            # unlike docking_power where the rmsd < 2.0 threshold neutralises it.
+            # unlike docking_power where the rmsd <= 2.0 threshold neutralises it.
             if 0.0 <= p.rmsd < 999.0:
                 _rmsd_by_target[p.target_id].append(p.rmsd)
         best_rmsds = sorted(min(v) for v in _rmsd_by_target.values() if v)

--- a/python/tests/test_benchmark.py
+++ b/python/tests/test_benchmark.py
@@ -460,9 +460,9 @@ class TestBenchmarkResult:
     def test_summary(self, three_system_result):
         summary = three_system_result.summary()
         assert summary.n_systems == 3
-        # FlexAIDdS: rmsds [1.5, 3.0, 0.8], success (< 2.0) = 2/3
+        # FlexAIDdS: rmsds [1.5, 3.0, 0.8], success (<= 2.0) = 2/3
         assert summary.flexaidds_success_rate == pytest.approx(2 / 3)
-        # Boltz-2: rmsds [2.5, 1.0, 1.8], success (< 2.0) = 2/3
+        # Boltz-2: rmsds [2.5, 1.0, 1.8], success (<= 2.0) = 2/3
         assert summary.boltz2_success_rate == pytest.approx(2 / 3)
         # Both methods should have timing
         assert summary.flexaidds_mean_time_seconds == pytest.approx(10.0)
@@ -472,6 +472,26 @@ class TestBenchmarkResult:
         assert summary.rank_correlation_kendall is not None
         assert summary.flexaidds_dg_r_squared is not None
         assert summary.boltz2_dg_r_squared is not None
+
+    def test_rmsd_exactly_2_0_counts_as_success(self):
+        sys = BenchmarkSystem(
+            system_id="edge",
+            protein_pdb_path=Path("."),
+            protein_sequence="M",
+            ligand_mol2_path=Path("."),
+            ligand_smiles="C",
+            reference_pose_pdb_path=Path("."),
+        )
+        fa = MethodResult(
+            method="flexaidds",
+            system_id="edge",
+            best_pose_rmsd_angstrom=2.0,
+            wall_time_seconds=1.0,
+        )
+        result = BenchmarkResult(
+            systems=[SystemBenchmarkResult(system=sys, flexaidds_result=fa)]
+        )
+        assert result.summary().flexaidds_success_rate == pytest.approx(1.0)
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_metrics_docking_power.py
+++ b/python/tests/test_metrics_docking_power.py
@@ -3,7 +3,7 @@
 These pin the two ways a reported success rate can be silently inflated:
 dropping targets that produced no usable pose from the denominator, and
 letting a sentinel RMSD (-1 = not computed, 999 = no pose) satisfy the
-``rmsd < 2.0`` comparison.
+``0.0 <= rmsd <= 2.0`` comparison.
 """
 
 from flexaidds.dataset_runner.metrics import PoseScore, docking_power
@@ -41,6 +41,12 @@ def test_n_targets_pins_the_full_dataset_size():
     # Only two targets reported anything at all; the rest never ran.
     poses = [_pose("HIT", 1.2, -10.0), _pose("MISS", 5.0, -9.0)]
     assert docking_power(poses, n_targets=85) == 1.0 / 85.0
+
+
+def test_rmsd_exactly_2_0_counts_as_success():
+    """METHODOLOGY.md §0: success ⇔ rank-0 in-place RMSD <= 2.0 Å."""
+    assert docking_power([_pose("T1", 2.0, -10.0)]) == 1.0
+    assert docking_power([_pose("T1", 2.0001, -10.0)]) == 0.0
 
 
 def test_sentinel_pose_still_occupies_its_rank():

--- a/scripts/aggregate_claim_metrics.py
+++ b/scripts/aggregate_claim_metrics.py
@@ -384,10 +384,12 @@ def aggregate_rows(
         denom = len(manifest_codes)
         missing_targets = sorted(set(manifest_codes) - observed_ids)
         denom_source = f"frozen_manifest(N={denom},sha={manifest_sha[:12]})"
+        manifest_set: set[str] | None = {c.upper() for c in manifest_codes}
     else:
         denom = n
         missing_targets = []
         denom_source = "claim_eligible_rows(legacy)"
+        manifest_set = None
 
     s1_ids: list[str] = []
     s2_ids: list[str] = []
@@ -414,7 +416,11 @@ def aggregate_rows(
             s1_fail_ids.append(pid)
         if s2:
             s2_ids.append(pid)
-        if strict:
+        # STRICT numerator is ∩ the frozen 85-target manifest. Off-manifest
+        # extras must not inflate n while the denominator stays 85.
+        if strict and (
+            manifest_set is None or pid.strip().upper() in manifest_set
+        ):
             strict_ids.append(pid)
         if s3:
             s3_ids.append(pid)
@@ -455,7 +461,10 @@ def aggregate_rows(
                 "ids": s2_ids,
             },
             "STRICT": {
-                "definition": "claim_ready==1 with PB + tENCoM/Eigen + hash receipts",
+                "definition": (
+                    "claim_ready==1 with PB + tENCoM/Eigen + hash receipts; "
+                    "numerator ∩ frozen 85-target manifest"
+                ),
                 "role": "primary_headline",
                 "n": len(strict_ids),
                 "rate": rate(len(strict_ids)),

--- a/tests/p0_claim_contract/test_fixed_denominator.py
+++ b/tests/p0_claim_contract/test_fixed_denominator.py
@@ -79,6 +79,12 @@ rep3 = agg.aggregate_rows(extra, PIN, "test", fixed_denominator=True)
 check("denominator stays 85 with an off-manifest extra row",
       rep3["N_denominator"] == 85)
 
+# --- Invariant 5: off-manifest success must not inflate STRICT numerator ------
+check("STRICT n stays 85 (off-manifest extra does not inflate numerator)",
+      rep3["metrics"]["STRICT"]["n"] == 85)
+check("STRICT ids exclude off-manifest 9XXX",
+      "9XXX" not in {str(x).upper() for x in rep3["metrics"]["STRICT"]["ids"]})
+
 print(f"\n{'ALL PASS' if not failures else f'{len(failures)} FAILURES: {failures}'}")
 
 # Only exit the interpreter when run as a script. Under pytest this module is

--- a/tests/test_aggregate_claim_metrics.py
+++ b/tests/test_aggregate_claim_metrics.py
@@ -116,7 +116,7 @@ def _row(
 def test_claim_filter_drops_seeded_rows(tmp_path: Path):
     mod = _load()
     rows = [
-        _row("GOOD1", rmsd_ordered=1.2, bcr=0.8, pb=1, claim_ready=1),
+        _row("1G9V", rmsd_ordered=1.2, bcr=0.8, pb=1, claim_ready=1),
         _row("SEED1", rmsd_ordered=0.5, bcr=0.4, pb=1, seed_echo=1, claim=0, claim_ready=0),
         _row("NAT1", rmsd_ordered=0.9, bcr=0.7, pb=1, native_seeded=1, claim=0, claim_ready=0),
         _row("GOOD2", rmsd_ordered=3.5, bcr=1.1, pb=0, claim_ready=0),
@@ -125,10 +125,10 @@ def test_claim_filter_drops_seeded_rows(tmp_path: Path):
     pin, src = mod.load_matrix_pin(camp, None)
     assert pin == DEFAULT_PIN
     report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
-    # Only GOOD1 has claim_ready=1
+    # Only 1G9V has claim_ready=1 (and is on the frozen 85-target manifest)
     assert report["N_claim"] == 1
     assert report["metrics"]["STRICT"]["n"] == 1
-    assert report["metrics"]["S1"]["ids"] == ["GOOD1"]
+    assert report["metrics"]["S1"]["ids"] == ["1G9V"]
 
 
 def test_s1_uses_ordered_not_hungarian(tmp_path: Path):
@@ -160,7 +160,7 @@ def test_s1_uses_ordered_not_hungarian(tmp_path: Path):
 def test_s1_vs_s3_diverge_election_gap(tmp_path: Path):
     mod = _load()
     rows = [
-        _row("HIT", rmsd_ordered=1.5, bcr=0.9, pb=1, claim_ready=1),
+        _row("1G9V", rmsd_ordered=1.5, bcr=0.9, pb=1, claim_ready=1),
         _row("GAP1", rmsd_ordered=5.7, bcr=1.6, pb=0, claim_ready=0),
         _row("GAP2", rmsd_ordered=4.2, bcr=1.9, pb=0, claim_ready=0),
         _row("MISS", rmsd_ordered=6.0, bcr=3.5, pb=0, claim_ready=0),
@@ -213,7 +213,7 @@ def test_cli_headline_s3_exits_nonzero(tmp_path: Path):
 
 def test_cli_happy_path_json(tmp_path: Path):
     rows = [
-        _row("P1", rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1),
+        _row("1G9V", rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1),
         _row("P2", rmsd_ordered=4.0, bcr=1.5, pb=0, claim_ready=0),
         _row("SEED", rmsd_ordered=0.1, bcr=0.1, pb=1, seed_echo=1, claim=0, claim_ready=0),
     ]
@@ -291,6 +291,22 @@ def test_success_s1_flag_cannot_override_high_rmsd(tmp_path: Path):
     rep = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, "test", str(camp))
     assert rep["N_claim"] == 1
     assert rep["metrics"]["S1"]["n"] == 0
+
+
+def test_off_manifest_strict_success_does_not_inflate_numerator():
+    """An off-manifest claim_ready row must not bump STRICT n (denom stays 85)."""
+    mod = _load()
+    codes, _ = mod.load_target_manifest()
+    assert codes and len(codes) == 85
+    on = _row(codes[0], rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1)
+    extra = _row("9XXX", rmsd_ordered=0.4, bcr=0.3, pb=1, claim_ready=1)
+    report = mod.aggregate_rows([on, extra], DEFAULT_PIN, "test", fixed_denominator=True)
+    assert report["N_denominator"] == 85
+    assert report["metrics"]["STRICT"]["n"] == 1
+    assert report["headline"]["n"] == 1
+    ids = {str(x).upper() for x in report["metrics"]["STRICT"]["ids"]}
+    assert codes[0].upper() in ids
+    assert "9XXX" not in ids
 
 
 def test_seed_echo_0_0_accepted():

--- a/tests/test_gaboom.cpp
+++ b/tests/test_gaboom.cpp
@@ -452,6 +452,70 @@ TEST(RemoveDups, WithinTolerance) {
     EXPECT_EQ(result, 1);
 }
 
+namespace {
+
+void set_dedup_env(const char* val) {
+#if defined(_WIN32)
+    if (val) _putenv_s("FLEXAIDDS_DEDUP_STDABS", val);
+    else _putenv_s("FLEXAIDDS_DEDUP_STDABS", "");
+#else
+    if (val) setenv("FLEXAIDDS_DEDUP_STDABS", val, 1);
+    else unsetenv("FLEXAIDDS_DEDUP_STDABS");
+#endif
+}
+
+struct DedupAbsGuard {
+    DedupAbsGuard(const char* val) {
+        const char* prev = std::getenv("FLEXAIDDS_DEDUP_STDABS");
+        had_ = prev != nullptr;
+        if (had_) prev_ = prev;
+        set_dedup_env(val);
+    }
+    ~DedupAbsGuard() {
+        if (had_) set_dedup_env(prev_.c_str());
+        else set_dedup_env(nullptr);
+    }
+    bool had_ = false;
+    std::string prev_;
+};
+
+}  // namespace
+
+// Δ=0.5 would false-match under abs(int) truncation (abs((int)0.5)==0 < 0.1).
+TEST(RemoveDups, HalfDeltaKeptWithStdAbsDefaultOn) {
+    DedupAbsGuard unset(nullptr);
+    ChromArray ca(2, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    ca[1].genes[0].to_ic = 1.5;
+    EXPECT_EQ(remove_dups(ca.data(), 2, 1), 2);
+}
+
+TEST(RemoveDups, HalfDeltaFalseMatchWithAbsIntOffFlag) {
+    DedupAbsGuard off("0");
+    ChromArray ca(2, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    ca[1].genes[0].to_ic = 1.5;
+    EXPECT_EQ(remove_dups(ca.data(), 2, 1), 1);
+}
+
+TEST(CmpChrom2Pop, HalfDeltaNotMatchWithStdAbsDefaultOn) {
+    DedupAbsGuard unset(nullptr);
+    ChromArray ca(1, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    gene query{};
+    query.to_ic = 1.5;
+    EXPECT_EQ(cmp_chrom2pop(ca.data(), &query, 1, 0, 1), 0);
+}
+
+TEST(CmpChrom2Pop, HalfDeltaFalseMatchWithAbsIntOffFlag) {
+    DedupAbsGuard off("0");
+    ChromArray ca(1, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    gene query{};
+    query.to_ic = 1.5;
+    EXPECT_EQ(cmp_chrom2pop(ca.data(), &query, 1, 0, 1), 1);
+}
+
 // ===========================================================================
 // FITNESS STATISTICS
 // ===========================================================================

--- a/tests/test_tencom_output.cpp
+++ b/tests/test_tencom_output.cpp
@@ -1,0 +1,95 @@
+// tests/test_tencom_output.cpp
+// tENCoM FlexPopulation mode↔structure pairing after sort_by_free_energy.
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+
+#include "tENCoM/tencom_output.h"
+#include "tENCoM/pdb_calpha.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string write_synthetic_pdb(const std::string& prefix, int n_residues)
+{
+    std::string path = std::filesystem::temp_directory_path().string()
+                       + "/" + prefix + ".pdb";
+    std::ofstream ofs(path);
+    const float turn = 100.0f * 3.14159265f / 180.0f;
+    const float radius = 2.3f;
+    const float rise = 1.5f;
+    for (int r = 0; r < n_residues; ++r) {
+        float x = radius * std::cos(r * turn);
+        float y = radius * std::sin(r * turn);
+        float z = r * rise;
+        char line[82];
+        std::snprintf(line, sizeof(line),
+            "ATOM  %5d  CA  ALA A%4d    %8.3f%8.3f%8.3f  1.00  0.00           C",
+            r + 1, r + 1, x, y, z);
+        ofs << line << "\n";
+    }
+    ofs << "END\n";
+    return path;
+}
+
+}  // namespace
+
+TEST(TencomOutput, SortPreservesStructurePairingWhenNgt2)
+{
+    using tencom_output::FlexMode;
+    using tencom_output::FlexPopulation;
+
+    FlexPopulation pop;
+    std::vector<tencom_pdb::CalphaStructure> structures;
+    const int nres[] = {8, 12, 16, 20};
+    const double dF[] = {0.0, 3.0, 1.0, 2.0};
+    std::vector<std::string> paths;
+
+    for (int i = 0; i < 4; ++i) {
+        auto path = write_synthetic_pdb("tencom_pair_" + std::to_string(i), nres[i]);
+        paths.push_back(path);
+        auto st = tencom_pdb::read_pdb_calpha(path);
+        FlexMode m;
+        m.mode_id = i;
+        m.structure_index = static_cast<std::size_t>(i);
+        m.pdb_path = path;
+        m.n_residues = st.res_cnt;
+        m.delta_F_vib = dF[i];
+        pop.modes.push_back(std::move(m));
+        structures.push_back(std::move(st));
+    }
+
+    for (std::size_t i = 0; i < pop.modes.size(); ++i) {
+        EXPECT_EQ(structures[i].res_cnt, pop.modes[i].n_residues);
+    }
+
+    pop.sort_by_free_energy();
+
+    ASSERT_EQ(pop.modes.size(), 4u);
+    EXPECT_EQ(pop.modes[0].structure_index, 0u);
+    EXPECT_EQ(pop.modes[1].structure_index, 2u);  // ΔF=1 was original index 2
+    EXPECT_EQ(pop.modes[2].structure_index, 3u);  // ΔF=2 was original index 3
+    EXPECT_EQ(pop.modes[3].structure_index, 1u);  // ΔF=3 was original index 1
+
+    bool old_index_pairing_broken = false;
+    for (std::size_t i = 0; i < pop.modes.size(); ++i) {
+        const auto* st = FlexPopulation::paired_structure(pop.modes[i], structures);
+        ASSERT_NE(st, nullptr);
+        EXPECT_EQ(st->res_cnt, pop.modes[i].n_residues);
+        EXPECT_EQ(st->filename, pop.modes[i].pdb_path);
+        if (structures[i].res_cnt != pop.modes[i].n_residues) {
+            old_index_pairing_broken = true;
+        }
+    }
+    EXPECT_TRUE(old_index_pairing_broken)
+        << "this test is vacuous unless sort permutes modes relative to structures";
+
+    for (const auto& p : paths) {
+        std::remove(p.c_str());
+    }
+}

--- a/tests/test_wave2_source_contracts.py
+++ b/tests/test_wave2_source_contracts.py
@@ -1,0 +1,30 @@
+"""Wave 2 source contracts: live register_result, quoted PoseBusters cache path."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATASET_RUNNER = ROOT / "LIB" / "DatasetRunner.cpp"
+
+
+def _fetch_posebusters_body(text: str) -> str:
+    start = text.find("DatasetRunner::fetch_posebusters")
+    end = text.find("DatasetRunner::fetch_bindingdb_itc")
+    assert start != -1 and end != -1 and end > start
+    return text[start:end]
+
+
+def test_register_result_call_is_not_commented_out():
+    text = DATASET_RUNNER.read_text(encoding="utf-8")
+    live = [
+        line.strip()
+        for line in text.splitlines()
+        if "register_result(sess)" in line and not line.strip().startswith("//")
+    ]
+    assert live, "register_result(sess) must actually run in DatasetRunner"
+    assert any("ts_it2" in line for line in live)
+
+
+def test_fetch_posebusters_quotes_cache_path_for_execve():
+    body = _fetch_posebusters_body(DATASET_RUNNER.read_text(encoding="utf-8"))
+    assert "shell_quote(repo_dir)" in body
+    assert "+ repo_dir +" not in body


### PR DESCRIPTION
## Summary

Wave 2 claim-path correctness on an isolated worktree from `origin/main` (`1f214d94`, after PR 437/438). Does **not** touch Wave 1 (`docs/wave1-science-surface-honesty` / PR 439). Does not merge.

- **2.1 STRICT numerator ∩ frozen 85-target manifest.** `scripts/aggregate_claim_metrics.py` no longer lets off-manifest `claim_ready` rows inflate STRICT `n` while the denominator stays 85. C++ `claim_ready` (~7744) is the per-complex flag and was already correct; STRICT `n/85` lives in the aggregator.
- **2.2 Inclusive RMSD `<= 2.0 Å`.** Python `docking_power` / `benchmark.py` now match METHODOLOGY.md §0 and C++ `rmsd_report <= 2.0f`. Ranking/election unchanged.
- **2.3 Live `register_result(sess)`.** The jammed `// TODO ... register_result(sess);` line is split; the call actually runs. Errors are not swallowed.
- **2.4 Quote PoseBusters cache path.** `fetch_posebusters` `git clone` destinations go through `shell_quote` before `/bin/sh -c` / `execve`. No PoseBusters science change.
- **2.5 tENCoM mode↔structure pairing.** `structure_index` survives `sort_by_free_energy()` so PDB/JSON writers pair coordinates to the mode they were computed from when N>2. Standalone tENCoM CLI only; not wired into election.
- **2.6 `FLEXAIDDS_DEDUP_STDABS` default ON.** `cmp_chrom2pop` / `remove_dups` use `std::abs` on `double to_ic` so `|Δ|<1` is not truncated by `abs(int)`. Set `0` for A/B. Search-affecting; election unchanged.

## Test plan

- [x] `python3 -m pytest tests/p0_claim_contract/test_fixed_denominator.py tests/test_aggregate_claim_metrics.py tests/test_wave2_source_contracts.py tests/test_thermo_claim_firewall.py tests/test_check_published_astex_rates.py`
- [x] `PYTHONPATH=python python3 -m pytest python/tests/test_metrics_docking_power.py python/tests/test_benchmark.py`
- [x] `python3 scripts/check_repo_hygiene.py`
- [x] Worktree `build/` only: `test_gaboom`, `test_ga_validation`, `test_get_yval_lut`, `test_tencom_output`, `test_tencom_diff`, `test_tencom_entropy_diff`, `test_shell_exec`, `test_target_server`, `benchmark_datasets` (DatasetRunner compile)
- [ ] CI on this PR (do not wait on Wave 1)

Do not merge from this PR. Do not land on `main` except via review.

Made with [Cursor](https://cursor.com)