### PR TITLE
Fix: ParallelDock last-atom copy and thread_local ParEvalWS

### DIFF
--- a/LIB/AtomCopyExtent.h
+++ b/LIB/AtomCopyExtent.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// FlexAID atom[] and residue[] are 1-based: live entries occupy [1, count].
+// A half-open C++ copy of `count` elements is [0, count) and DROPS the last
+// live entry. Gaboom's ParEvalWS copies `atoms + natm + 1` (LIB/gaboom.cpp).
+// ParallelDock create_workspace must use the same extent.
+inline int flexaid_one_based_copy_n(int count) noexcept {
+    return count + 1;
+}

--- a/LIB/ParallelDock.cpp
+++ b/LIB/ParallelDock.cpp
@@ -65,8 +65,11 @@ ParallelDockManager::RegionWorkspace ParallelDockManager::create_workspace() con
     ws.gb = *GB_;
     ws.vc = *VC_;
 
-    // Deep copy mutable arrays
-    ws.atoms_copy.assign(atoms_, atoms_ + FA_->atm_cnt);
+    // Deep copy mutable arrays. atom[] is 1-based: live atoms occupy
+    // atoms[1]..atoms[atm_cnt] (gaboom.cpp ParEvalWS: atoms + natm + 1).
+    // residue[] is the same layout (res_cnt+1 already). Using atm_cnt as a
+    // half-open C++ end drops atoms[atm_cnt] — the last 1-based atom.
+    ws.atoms_copy.assign(atoms_, atoms_ + flexaid_one_based_copy_n(FA_->atm_cnt));
     ws.residue_copy.assign(residue_, residue_ + FA_->res_cnt + 1);
 
     return ws;

--- a/LIB/ParallelDock.h
+++ b/LIB/ParallelDock.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "flexaid.h"
+#include "AtomCopyExtent.h"
 #include "gaboom.h"
 #include "GAContext.h"
 #include "statmech.h"

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -3126,8 +3126,14 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			// fields: scorable_list, n_scorable, scorable_cap, fastpath_used).
 			std::vector<std::vector<int>>         tl_scorable;
 		};
-		static ParEvalWS ws;   // resident across generations (serial init: GA
-		                       // parallelism lives strictly inside this loop).
+		thread_local ParEvalWS ws;  // resident across generations on THIS thread.
+		                       // Must not be process-wide static: --parallel-dock
+		                       // runs GA() under an outer OpenMP parallel-for
+		                       // (ParallelDock.cpp). A shared static races on
+		                       // rebuild and tl_* buffers. Inner eval still
+		                       // shares this thread's tl_* via references
+		                       // captured before the inner omp for, so the
+		                       // serial claim path is unchanged.
 
 		const bool ws_valid =
 			ws.n_thr == n_thr && ws.natm == natm && ws.nres == nres &&

--- a/tests/test_parallel_dock.cpp
+++ b/tests/test_parallel_dock.cpp
@@ -6,6 +6,8 @@
 #include <set>
 #include <numeric>
 #include <thread>
+#include <vector>
+#include "../LIB/AtomCopyExtent.h"
 #include "../LIB/GridDecomposer.h"
 #include "../LIB/SharedPosePool.h"
 #include "../LIB/statmech.h"
@@ -335,4 +337,75 @@ TEST(GridDecomposer, RegionBoundsCorrect) {
     EXPECT_EQ(r.num_points, 5);
 
     free(grid);
+}
+
+// ============================================================================
+// 1-based atom[] copy (ParallelDock create_workspace)
+// ============================================================================
+// FlexAID stores live atoms at indices [1, atm_cnt]. Gaboom ParEvalWS copies
+// `atoms + natm + 1`. The old ParallelDock line was:
+//   ws.atoms_copy.assign(atoms_, atoms_ + FA_->atm_cnt);
+// which is a half-open range of length atm_cnt and drops atoms[atm_cnt].
+// flexaid_one_based_copy_n is what create_workspace uses; if it returned
+// atm_cnt this test fails.
+
+TEST(ParallelDockWorkspace, AtomCopyExtentIsAtmCntPlusOne) {
+    EXPECT_EQ(flexaid_one_based_copy_n(0), 1);
+    EXPECT_EQ(flexaid_one_based_copy_n(1), 2);
+    EXPECT_EQ(flexaid_one_based_copy_n(7), 8);
+    EXPECT_NE(flexaid_one_based_copy_n(7), 7);
+}
+
+TEST(ParallelDockWorkspace, AtomCopyIncludesLastOneBasedAtom) {
+    const int atm_cnt = 3;
+    atom atoms[4]{};
+    atoms[1].number = 101;
+    atoms[2].number = 102;
+    atoms[3].number = 103;
+    atoms[3].coor[0] = 42.0f;
+
+    std::vector<atom> dropped(atoms, atoms + atm_cnt);
+    std::vector<atom> kept(atoms, atoms + flexaid_one_based_copy_n(atm_cnt));
+
+    ASSERT_EQ(dropped.size(), static_cast<size_t>(atm_cnt));
+    ASSERT_EQ(kept.size(), static_cast<size_t>(atm_cnt) + 1);
+    EXPECT_EQ(dropped.back().number, 102) << "assign(..., atm_cnt) stops at atoms[atm_cnt-1]";
+    EXPECT_EQ(kept[atm_cnt].number, 103);
+    EXPECT_FLOAT_EQ(kept[atm_cnt].coor[0], 42.0f);
+}
+
+// ============================================================================
+// thread_local workspace isolation (gaboom ParEvalWS under --parallel-dock)
+// ============================================================================
+// Not a race test: two threads write distinct sentinels and publish addresses
+// after join. A process-wide static would share one object; thread_local must
+// not. Production: thread_local ParEvalWS in gaboom.cpp calculate_fitness.
+
+TEST(ParEvalWSIsolation, ThreadLocalWorkspacesDoNotShare) {
+    struct WS { int sentinel = 0; };
+    thread_local WS ws;
+
+    WS* p0 = nullptr;
+    WS* p1 = nullptr;
+    int v0 = -1;
+    int v1 = -1;
+
+    std::thread t0([&] {
+        ws.sentinel = 7;
+        p0 = &ws;
+        v0 = ws.sentinel;
+    });
+    std::thread t1([&] {
+        ws.sentinel = 9;
+        p1 = &ws;
+        v1 = ws.sentinel;
+    });
+    t0.join();
+    t1.join();
+
+    ASSERT_NE(p0, nullptr);
+    ASSERT_NE(p1, nullptr);
+    EXPECT_NE(p0, p1);
+    EXPECT_EQ(v0, 7);
+    EXPECT_EQ(v1, 9);
 }


### PR DESCRIPTION
## Summary
- **Last-atom copy (`--parallel-dock` only):** `ParallelDockManager::create_workspace` copied `atoms_` with a half-open range of length `atm_cnt`, which drops the last 1-based atom `atoms[atm_cnt]`. Gaboom’s ParEvalWS already copies `atoms + natm + 1`. The workspace now uses `flexaid_one_based_copy_n(atm_cnt)` (`atm_cnt + 1`). Residue copy was already `res_cnt + 1`. Vcontacts math is unchanged.
- **`static ParEvalWS` race (`--parallel-dock` only):** `calculate_fitness` kept a process-wide `static ParEvalWS`. ParallelDock runs `GA()` under an outer OpenMP parallel-for, so region threads raced on workspace rebuild and `tl_*` buffers. It is now `thread_local`. Inner eval still shares that calling thread’s `tl_*` via references captured before the inner `omp parallel for`, so the serial claim path is unchanged. `--parallel-dock` stays off by default.
- ParallelDock.cpp around the TargetServer/`log_Z` block (~142) has **no** `ParEvalWS`; the race lived in `gaboom.cpp`.

## Source citations
- Bug (pre-fix): `LIB/ParallelDock.cpp` `assign(atoms_, atoms_ + FA_->atm_cnt)`
- Layout contract: `LIB/gaboom.cpp:3153` `atoms + natm + 1` (also `:3304`, `:4022`); `LIB/flexaid.h` `atm_cnt` is the last live 1-based index (`read_pdb.cpp` same class of off-by-one)
- Fix: `LIB/ParallelDock.cpp:72` `flexaid_one_based_copy_n(FA_->atm_cnt)`; helper `LIB/AtomCopyExtent.h`
- Race (pre-fix): `LIB/gaboom.cpp` `static ParEvalWS ws`
- Fix: `LIB/gaboom.cpp:3129` `thread_local ParEvalWS ws`
- Outer OpenMP: `LIB/ParallelDock.cpp` `#pragma omp parallel for` over regions

## Tests
- `ParallelDockWorkspace.AtomCopyExtentIsAtmCntPlusOne` — fails if the helper returns `atm_cnt`
- `ParallelDockWorkspace.AtomCopyIncludesLastOneBasedAtom` — last 1-based atom is present after the `+1` copy and missing after `assign(..., atm_cnt)`
- `ParEvalWSIsolation.ThreadLocalWorkspacesDoNotShare` — deterministic address/sentinel isolation (not a flaky race test)

Isolated worktree build (`/tmp/flexaidds-wave3/build`): `flexaid_core` (includes `gaboom.cpp` + `ParallelDock.cpp`) and `test_parallel_dock` compiled clean. `ctest -R ParallelDockTests` passed (3 new tests + existing suite). `python3 scripts/check_repo_hygiene.py` OK.

## Out of scope
- Does **not** enable `--parallel-dock` by default
- Does **not** change ranking on the serial claim path
- Does **not** touch GIST/elec/Softβ, Astex rates, `FlexAIDdS_deck`, or docs/audit rewrite
- Independent of Wave 1/2 (`docs/wave1-science-surface-honesty`, `fix/wave2-claim-path`, PRs 439/440) — do not merge those here

## Test plan
- [x] `flexaid_core` compiles `gaboom.cpp` and `ParallelDock.cpp`
- [x] `ctest -R ParallelDockTests --output-on-failure`
- [x] `python3 scripts/check_repo_hygiene.py`
- [ ] Reviewer: confirm `--parallel-dock` remains opt-in in `LIB/top.cpp`


Made with [Cursor](https://cursor.com)