### PR TITLE
Fix: STRICT claim numerator intersects frozen 85-target manifest

### DIFF
--- a/scripts/aggregate_claim_metrics.py
+++ b/scripts/aggregate_claim_metrics.py
@@ -384,10 +384,12 @@ def aggregate_rows(
         denom = len(manifest_codes)
         missing_targets = sorted(set(manifest_codes) - observed_ids)
         denom_source = f"frozen_manifest(N={denom},sha={manifest_sha[:12]})"
+        manifest_set: set[str] | None = {c.upper() for c in manifest_codes}
     else:
         denom = n
         missing_targets = []
         denom_source = "claim_eligible_rows(legacy)"
+        manifest_set = None
 
     s1_ids: list[str] = []
     s2_ids: list[str] = []
@@ -414,7 +416,11 @@ def aggregate_rows(
             s1_fail_ids.append(pid)
         if s2:
             s2_ids.append(pid)
-        if strict:
+        # STRICT numerator is ∩ the frozen 85-target manifest. Off-manifest
+        # extras must not inflate n while the denominator stays 85.
+        if strict and (
+            manifest_set is None or pid.strip().upper() in manifest_set
+        ):
             strict_ids.append(pid)
         if s3:
             s3_ids.append(pid)
@@ -455,7 +461,10 @@ def aggregate_rows(
                 "ids": s2_ids,
             },
             "STRICT": {
-                "definition": "claim_ready==1 with PB + tENCoM/Eigen + hash receipts",
+                "definition": (
+                    "claim_ready==1 with PB + tENCoM/Eigen + hash receipts; "
+                    "numerator ∩ frozen 85-target manifest"
+                ),
                 "role": "primary_headline",
                 "n": len(strict_ids),
                 "rate": rate(len(strict_ids)),

--- a/tests/p0_claim_contract/test_fixed_denominator.py
+++ b/tests/p0_claim_contract/test_fixed_denominator.py
@@ -79,6 +79,12 @@ rep3 = agg.aggregate_rows(extra, PIN, "test", fixed_denominator=True)
 check("denominator stays 85 with an off-manifest extra row",
       rep3["N_denominator"] == 85)
 
+# --- Invariant 5: off-manifest success must not inflate STRICT numerator ------
+check("STRICT n stays 85 (off-manifest extra does not inflate numerator)",
+      rep3["metrics"]["STRICT"]["n"] == 85)
+check("STRICT ids exclude off-manifest 9XXX",
+      "9XXX" not in {str(x).upper() for x in rep3["metrics"]["STRICT"]["ids"]})
+
 print(f"\n{'ALL PASS' if not failures else f'{len(failures)} FAILURES: {failures}'}")
 
 # Only exit the interpreter when run as a script. Under pytest this module is

--- a/tests/test_aggregate_claim_metrics.py
+++ b/tests/test_aggregate_claim_metrics.py
@@ -116,7 +116,7 @@ def _row(
 def test_claim_filter_drops_seeded_rows(tmp_path: Path):
     mod = _load()
     rows = [
-        _row("GOOD1", rmsd_ordered=1.2, bcr=0.8, pb=1, claim_ready=1),
+        _row("1G9V", rmsd_ordered=1.2, bcr=0.8, pb=1, claim_ready=1),
         _row("SEED1", rmsd_ordered=0.5, bcr=0.4, pb=1, seed_echo=1, claim=0, claim_ready=0),
         _row("NAT1", rmsd_ordered=0.9, bcr=0.7, pb=1, native_seeded=1, claim=0, claim_ready=0),
         _row("GOOD2", rmsd_ordered=3.5, bcr=1.1, pb=0, claim_ready=0),
@@ -125,10 +125,10 @@ def test_claim_filter_drops_seeded_rows(tmp_path: Path):
     pin, src = mod.load_matrix_pin(camp, None)
     assert pin == DEFAULT_PIN
     report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
-    # Only GOOD1 has claim_ready=1
+    # Only 1G9V has claim_ready=1 (and is on the frozen 85-target manifest)
     assert report["N_claim"] == 1
     assert report["metrics"]["STRICT"]["n"] == 1
-    assert report["metrics"]["S1"]["ids"] == ["GOOD1"]
+    assert report["metrics"]["S1"]["ids"] == ["1G9V"]
 
 
 def test_s1_uses_ordered_not_hungarian(tmp_path: Path):
@@ -160,7 +160,7 @@ def test_s1_uses_ordered_not_hungarian(tmp_path: Path):
 def test_s1_vs_s3_diverge_election_gap(tmp_path: Path):
     mod = _load()
     rows = [
-        _row("HIT", rmsd_ordered=1.5, bcr=0.9, pb=1, claim_ready=1),
+        _row("1G9V", rmsd_ordered=1.5, bcr=0.9, pb=1, claim_ready=1),
         _row("GAP1", rmsd_ordered=5.7, bcr=1.6, pb=0, claim_ready=0),
         _row("GAP2", rmsd_ordered=4.2, bcr=1.9, pb=0, claim_ready=0),
         _row("MISS", rmsd_ordered=6.0, bcr=3.5, pb=0, claim_ready=0),
@@ -213,7 +213,7 @@ def test_cli_headline_s3_exits_nonzero(tmp_path: Path):
 
 def test_cli_happy_path_json(tmp_path: Path):
     rows = [
-        _row("P1", rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1),
+        _row("1G9V", rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1),
         _row("P2", rmsd_ordered=4.0, bcr=1.5, pb=0, claim_ready=0),
         _row("SEED", rmsd_ordered=0.1, bcr=0.1, pb=1, seed_echo=1, claim=0, claim_ready=0),
     ]
@@ -291,6 +291,22 @@ def test_success_s1_flag_cannot_override_high_rmsd(tmp_path: Path):
     rep = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, "test", str(camp))
     assert rep["N_claim"] == 1
     assert rep["metrics"]["S1"]["n"] == 0
+
+
+def test_off_manifest_strict_success_does_not_inflate_numerator():
+    """An off-manifest claim_ready row must not bump STRICT n (denom stays 85)."""
+    mod = _load()
+    codes, _ = mod.load_target_manifest()
+    assert codes and len(codes) == 85
+    on = _row(codes[0], rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1)
+    extra = _row("9XXX", rmsd_ordered=0.4, bcr=0.3, pb=1, claim_ready=1)
+    report = mod.aggregate_rows([on, extra], DEFAULT_PIN, "test", fixed_denominator=True)
+    assert report["N_denominator"] == 85
+    assert report["metrics"]["STRICT"]["n"] == 1
+    assert report["headline"]["n"] == 1
+    ids = {str(x).upper() for x in report["metrics"]["STRICT"]["ids"]}
+    assert codes[0].upper() in ids
+    assert "9XXX" not in ids
 
 
 def test_seed_echo_0_0_accepted():


### PR DESCRIPTION
## Summary
- STRICT `n` counts only targets on the frozen 85-target manifest; off-manifest `claim_ready` rows no longer inflate STRICT n.
- Split from #440 (Wave 2.1). Independent of the other Wave 2 slices.

## Test plan
- [ ] `python3 -m pytest tests/p0_claim_contract/test_fixed_denominator.py tests/test_aggregate_claim_metrics.py -q`


Made with [Cursor](https://cursor.com)