### PR TITLE
Fix: docking-power success uses inclusive RMSD <= 2.0 Å

### DIFF
--- a/python/flexaidds/benchmark.py
+++ b/python/flexaidds/benchmark.py
@@ -715,8 +715,8 @@ class BenchmarkSummary:
 
     Attributes:
         n_systems: Total number of systems.
-        flexaidds_success_rate: Fraction with RMSD < threshold.
-        boltz2_success_rate: Fraction with RMSD < threshold.
+        flexaidds_success_rate: Fraction with RMSD <= threshold.
+        boltz2_success_rate: Fraction with RMSD <= threshold.
         flexaidds_median_rmsd_angstrom: Median best-pose RMSD.
         boltz2_median_rmsd_angstrom: Median best-pose RMSD.
         rank_correlation_spearman: Spearman rho between methods' score rankings.
@@ -821,7 +821,12 @@ class BenchmarkResult:
         threshold = self.rmsd_threshold_angstrom
 
         def _success(rmsds: List[float]) -> Optional[float]:
-            return sum(1 for r in rmsds if r < threshold) / len(rmsds) if rmsds else None
+            # Inclusive 2.0 Å gate (METHODOLOGY.md §0). Ranking/election unchanged.
+            return (
+                sum(1 for r in rmsds if 0.0 <= r <= threshold) / len(rmsds)
+                if rmsds
+                else None
+            )
 
         def _median(vals: List[float]) -> Optional[float]:
             if not vals:

--- a/python/flexaidds/dataset_runner/metrics.py
+++ b/python/flexaidds/dataset_runner/metrics.py
@@ -10,7 +10,7 @@ Metric catalogue
 * enrichment_factor     — EF at any percentile
 * log_auc               — Logarithmic AUC for early enrichment
 * scoring_power         — Pearson r + RMSE vs experimental affinities
-* docking_power         — % top-ranked poses with RMSD < threshold
+* docking_power         — % top-ranked poses with RMSD <= threshold
 * target_specificity_zscore — Z-score of binder scores vs random background
 * hit_rate_top_n        — Fraction of true binders in top-N predictions
 * bootstrap_ci          — 95% CI via non-parametric bootstrapping
@@ -62,6 +62,15 @@ class PoseScore:
     ensemble_log_Z: Optional[float] = None  # P3 grand canonical: real log_Z from ensemble (for conc-weighted Xi)
 
 
+def rmsd_is_success(rmsd: float, threshold: float = 2.0) -> bool:
+    """Inclusive RMSD success gate (METHODOLOGY.md §0).
+
+    Success ⇔ ``0.0 <= rmsd <= threshold``. Sentinel values (-1 = not
+    computed, 999 = no pose) never succeed. Ranking/election is unchanged.
+    """
+    return 0.0 <= rmsd <= threshold
+
+
 # ---------------------------------------------------------------------------
 # Entropy rescue rate (Shannon Energy Collapse)
 # ---------------------------------------------------------------------------
@@ -81,7 +90,7 @@ def entropy_rescue_rate(
 
     A rescue event for target *t* requires all of the following:
     1. The crystal pose (lowest RMSD across all poses for *t*) has
-       ``rmsd < rmsd_threshold``.
+       ``0.0 <= rmsd <= rmsd_threshold``.
     2. Its enthalpy rank > ``rank_threshold`` (missed by enthalpy alone).
     3. Its entropy-corrected rank ≤ ``rank_threshold`` (rescued by ΔS).
 
@@ -113,7 +122,7 @@ def entropy_rescue_rate(
         if not valid:
             continue
         crystal = min(valid, key=lambda p: p.rmsd)
-        if crystal.rmsd >= rmsd_threshold:
+        if not rmsd_is_success(crystal.rmsd, rmsd_threshold):
             continue  # no reference pose within threshold
 
         # Rank by enthalpy (lower = better)
@@ -301,7 +310,7 @@ def docking_power(
     """Fraction of targets where the top-N poses contain a near-native pose.
 
     A target is a "success" if *any* of its top-``top_n`` ranked poses (by
-    ``total_score``) has ``0.0 <= rmsd < rmsd_threshold``.  Sentinel RMSD
+    ``total_score``) has ``0.0 <= rmsd <= rmsd_threshold``.  Sentinel RMSD
     values (-1 = not computed, 999 = no pose emitted) are never successes.
 
     The denominator is the number of targets *attempted*, not the number that
@@ -331,7 +340,7 @@ def docking_power(
         # Rank over every emitted pose. Filtering the sentinels out first would
         # promote a worse-scoring pose into the top-N and inflate the rate.
         ranked = sorted(target_poses, key=lambda p: p.total_score)[:top_n]
-        if any(0.0 <= p.rmsd < rmsd_threshold for p in ranked):
+        if any(rmsd_is_success(p.rmsd, rmsd_threshold) for p in ranked):
             n_success += 1
 
     denom = n_targets if n_targets is not None else len(by_target)
@@ -526,7 +535,7 @@ def compute_all_metrics(
         for p in poses:
             # Exclude both sentinels: -1 (not computed) and 999 (no pose
             # emitted).  Averaging 999 would silently poison the aggregate,
-            # unlike docking_power where the rmsd < 2.0 threshold neutralises it.
+            # unlike docking_power where the rmsd <= 2.0 threshold neutralises it.
             if 0.0 <= p.rmsd < 999.0:
                 _rmsd_by_target[p.target_id].append(p.rmsd)
         best_rmsds = sorted(min(v) for v in _rmsd_by_target.values() if v)

--- a/python/tests/test_benchmark.py
+++ b/python/tests/test_benchmark.py
@@ -460,9 +460,9 @@ class TestBenchmarkResult:
     def test_summary(self, three_system_result):
         summary = three_system_result.summary()
         assert summary.n_systems == 3
-        # FlexAIDdS: rmsds [1.5, 3.0, 0.8], success (< 2.0) = 2/3
+        # FlexAIDdS: rmsds [1.5, 3.0, 0.8], success (<= 2.0) = 2/3
         assert summary.flexaidds_success_rate == pytest.approx(2 / 3)
-        # Boltz-2: rmsds [2.5, 1.0, 1.8], success (< 2.0) = 2/3
+        # Boltz-2: rmsds [2.5, 1.0, 1.8], success (<= 2.0) = 2/3
         assert summary.boltz2_success_rate == pytest.approx(2 / 3)
         # Both methods should have timing
         assert summary.flexaidds_mean_time_seconds == pytest.approx(10.0)
@@ -472,6 +472,26 @@ class TestBenchmarkResult:
         assert summary.rank_correlation_kendall is not None
         assert summary.flexaidds_dg_r_squared is not None
         assert summary.boltz2_dg_r_squared is not None
+
+    def test_rmsd_exactly_2_0_counts_as_success(self):
+        sys = BenchmarkSystem(
+            system_id="edge",
+            protein_pdb_path=Path("."),
+            protein_sequence="M",
+            ligand_mol2_path=Path("."),
+            ligand_smiles="C",
+            reference_pose_pdb_path=Path("."),
+        )
+        fa = MethodResult(
+            method="flexaidds",
+            system_id="edge",
+            best_pose_rmsd_angstrom=2.0,
+            wall_time_seconds=1.0,
+        )
+        result = BenchmarkResult(
+            systems=[SystemBenchmarkResult(system=sys, flexaidds_result=fa)]
+        )
+        assert result.summary().flexaidds_success_rate == pytest.approx(1.0)
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_metrics_docking_power.py
+++ b/python/tests/test_metrics_docking_power.py
@@ -3,7 +3,7 @@
 These pin the two ways a reported success rate can be silently inflated:
 dropping targets that produced no usable pose from the denominator, and
 letting a sentinel RMSD (-1 = not computed, 999 = no pose) satisfy the
-``rmsd < 2.0`` comparison.
+``0.0 <= rmsd <= 2.0`` comparison.
 """
 
 from flexaidds.dataset_runner.metrics import PoseScore, docking_power
@@ -41,6 +41,12 @@ def test_n_targets_pins_the_full_dataset_size():
     # Only two targets reported anything at all; the rest never ran.
     poses = [_pose("HIT", 1.2, -10.0), _pose("MISS", 5.0, -9.0)]
     assert docking_power(poses, n_targets=85) == 1.0 / 85.0
+
+
+def test_rmsd_exactly_2_0_counts_as_success():
+    """METHODOLOGY.md §0: success ⇔ rank-0 in-place RMSD <= 2.0 Å."""
+    assert docking_power([_pose("T1", 2.0, -10.0)]) == 1.0
+    assert docking_power([_pose("T1", 2.0001, -10.0)]) == 0.0
 
 
 def test_sentinel_pose_still_occupies_its_rank():


### PR DESCRIPTION
## Summary
- Python `docking_power` / benchmark success is inclusive `0.0 <= rmsd <= 2.0`, matching METHODOLOGY.md §0 and the C++ claim path.
- Split from #440 (Wave 2.2). Does not change pose election.

## Test plan
- [ ] `python3 -m pytest python/tests/test_benchmark.py python/tests/test_metrics_docking_power.py -q`


Made with [Cursor](https://cursor.com)