### PR TITLE
Fix: live register_result and quoted PoseBusters cache path

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -4577,13 +4577,15 @@ std::vector<DatasetEntry> DatasetRunner::fetch_posebusters() {
     // Clone or update the PoseBusters benchmark repo
     std::string repo_dir = pb_dir + "/PoseBusters-Benchmark";
     if (!fs::exists(repo_dir)) {
-        std::string cmd = "git clone --depth 1 https://github.com/maabuu/posebusters_benchmark.git \""
-                          + repo_dir + "\" 2>&1";
+        // cache_dir_ is user-controlled (--cache); quote for /bin/sh -c via exec_cmd.
+        const std::string quoted_repo = shell_quote(repo_dir);
+        std::string cmd = "git clone --depth 1 https://github.com/maabuu/posebusters_benchmark.git "
+                          + quoted_repo + " 2>&1";
         int ret = exec_cmd(cmd);
         if (ret != 0) {
             // Try alternate URL
-            cmd = "git clone --depth 1 https://github.com/degrado-lab/PoseBusters-Benchmark.git \""
-                  + repo_dir + "\" 2>&1";
+            cmd = "git clone --depth 1 https://github.com/degrado-lab/PoseBusters-Benchmark.git "
+                  + quoted_repo + " 2>&1";
             exec_cmd(cmd);
         }
     }
@@ -7741,6 +7743,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
 
         // Publication gate: official PoseBusters and ligand tENCoM/Eigen must
         // all have consumed the exact elected pose represented by pose_sha256.
+        // Per-complex flag only. STRICT n/85 (numerator ∩ frozen Astex-85
+        // manifest) is aggregated in scripts/aggregate_claim_metrics.py.
         result.claim_ready =
             result.success_pb &&
             result.protocol_claim_eligible &&
@@ -7808,7 +7812,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     sess.log_Z = -static_cast<double>(result.predicted_dG) /
                                  (statmech::kB_kcal * static_cast<double>(config.temperature));
                 }
-                // TODO: best_center / conformer_populations from actual BindingMode data                ts_it2->second->register_result(sess);
+                // TODO: best_center / conformer_populations from actual BindingMode data.
+                // Live call — do not comment this out; GPF/TargetServer depends on it.
+                ts_it2->second->register_result(sess);
             }
         }
 

--- a/tests/test_wave2_source_contracts.py
+++ b/tests/test_wave2_source_contracts.py
@@ -1,0 +1,30 @@
+"""Wave 2 source contracts: live register_result, quoted PoseBusters cache path."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATASET_RUNNER = ROOT / "LIB" / "DatasetRunner.cpp"
+
+
+def _fetch_posebusters_body(text: str) -> str:
+    start = text.find("DatasetRunner::fetch_posebusters")
+    end = text.find("DatasetRunner::fetch_bindingdb_itc")
+    assert start != -1 and end != -1 and end > start
+    return text[start:end]
+
+
+def test_register_result_call_is_not_commented_out():
+    text = DATASET_RUNNER.read_text(encoding="utf-8")
+    live = [
+        line.strip()
+        for line in text.splitlines()
+        if "register_result(sess)" in line and not line.strip().startswith("//")
+    ]
+    assert live, "register_result(sess) must actually run in DatasetRunner"
+    assert any("ts_it2" in line for line in live)
+
+
+def test_fetch_posebusters_quotes_cache_path_for_execve():
+    body = _fetch_posebusters_body(DATASET_RUNNER.read_text(encoding="utf-8"))
+    assert "shell_quote(repo_dir)" in body
+    assert "+ repo_dir +" not in body


### PR DESCRIPTION
## Summary
- Uncomments the jammed `register_result(sess)` call so TargetServer actually records the session.
- `shell_quote`s the PoseBusters `--cache` clone destination before `/bin/sh -c`.
- Split from #440 (Wave 2.3–2.4). Coupled DatasetRunner changes kept together.

## Test plan
- [ ] `python3 -m pytest tests/test_wave2_source_contracts.py -q`


Made with [Cursor](https://cursor.com)