### PR TITLE
Fix: tENCoM mode-structure pairing after sort

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1462,6 +1462,17 @@ flexaids_add_unit_test(test_protocol_config
         TEST_NAME TENCoMDiffTests
     )
 
+    # test_tencom_output — FlexPopulation mode↔structure pairing after sort
+    flexaids_add_unit_test(test_tencom_output
+        SOURCES
+            tests/test_tencom_output.cpp
+            LIB/tENCoM/tencom_output.cpp
+            LIB/tENCoM/pdb_calpha.cpp
+        LINK_LIBRARIES Eigen3::Eigen
+        DEFINES FLEXAIDS_HAS_EIGEN
+        TEST_NAME TENCoMOutputTests
+    )
+
     # test_ptm_attachment — PTMAttachment module tests
     flexaids_add_unit_test(test_ptm_attachment
         SOURCES

--- a/LIB/tENCoM/tencom_main.cpp
+++ b/LIB/tENCoM/tencom_main.cpp
@@ -297,6 +297,7 @@ static void run_analysis_at_temperature(
 
     tencom_output::FlexMode ref_mode;
     ref_mode.mode_id = 0;
+    ref_mode.structure_index = 0;
     ref_mode.pdb_path = opts.pdb_files[0];
     ref_mode.label = "reference";
     ref_mode.S_vib = ref_svib.S_vib_kcal_mol_K;
@@ -333,6 +334,7 @@ static void run_analysis_at_temperature(
 
         tencom_output::FlexMode tgt_mode;
         tgt_mode.mode_id = static_cast<int>(t + 1);
+        tgt_mode.structure_index = t + 1;
         tgt_mode.pdb_path = opts.pdb_files[t + 1];
         tgt_mode.label = opts.pdb_files[t + 1];
         tgt_mode.S_vib = diff.svib_tgt.S_vib_kcal_mol_K;
@@ -354,9 +356,16 @@ static void run_analysis_at_temperature(
     population.print_summary();
 
     if (opts.output_pdb) {
-        int n = std::min(all_structures.size(), population.modes.size());
-        for (int i = 0; i < static_cast<int>(n); ++i) {
-            population.write_mode_pdb(population.modes[i], all_structures[i]);
+        for (const auto& mode : population.modes) {
+            const auto* st = tencom_output::FlexPopulation::paired_structure(
+                mode, all_structures);
+            if (!st) {
+                std::cerr << "Error: mode " << mode.mode_id
+                          << " structure_index " << mode.structure_index
+                          << " out of range\n";
+                continue;
+            }
+            population.write_mode_pdb(mode, *st);
         }
     }
     if (opts.output_json) {

--- a/LIB/tENCoM/tencom_output.cpp
+++ b/LIB/tENCoM/tencom_output.cpp
@@ -39,6 +39,16 @@ void FlexPopulation::sort_by_free_energy() {
               });
 }
 
+const tencom_pdb::CalphaStructure*
+FlexPopulation::paired_structure(
+    const FlexMode& mode,
+    const std::vector<tencom_pdb::CalphaStructure>& structures)
+{
+    if (mode.structure_index >= structures.size())
+        return nullptr;
+    return &structures[mode.structure_index];
+}
+
 // ─── FlexPopulation::write_mode_pdb ─────────────────────────────────────────
 
 void FlexPopulation::write_mode_pdb(const FlexMode& mode,
@@ -270,9 +280,15 @@ void FlexPopulation::output_all(
                   << ") != mode count (" << modes.size() << ")\n";
     }
 
-    int n = std::min(structures.size(), modes.size());
-    for (int i = 0; i < n; ++i) {
-        write_mode_pdb(modes[i], structures[i]);
+    for (const auto& mode : modes) {
+        const auto* st = paired_structure(mode, structures);
+        if (!st) {
+            std::cerr << "Error: mode " << mode.mode_id
+                      << " structure_index " << mode.structure_index
+                      << " out of range (" << structures.size() << " structures)\n";
+            continue;
+        }
+        write_mode_pdb(mode, *st);
     }
 
     std::cout << "\ntENCoM analysis complete. "
@@ -320,12 +336,11 @@ void FlexPopulation::write_json(
         ofs << "      \"n_modes\": " << m.n_modes << ",\n";
         ofs << "      \"n_residues\": " << m.n_residues << ",\n";
 
-        // Composition
-        if (mi < structures.size()) {
-            const auto& s = structures[mi];
-            ofs << "      \"composition\": {\"protein\": " << s.n_protein
-                << ", \"dna\": " << s.n_dna
-                << ", \"rna\": " << s.n_rna << "},\n";
+        // Composition — pair by construction index, not post-sort slot.
+        if (const auto* s = paired_structure(m, structures)) {
+            ofs << "      \"composition\": {\"protein\": " << s->n_protein
+                << ", \"dna\": " << s->n_dna
+                << ", \"rna\": " << s->n_rna << "},\n";
         }
 
         // B-factors

--- a/LIB/tENCoM/tencom_output.h
+++ b/LIB/tENCoM/tencom_output.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include <cstddef>
 
 namespace tencom_output {
 
@@ -46,6 +47,11 @@ struct FlexMode {
 
     int n_modes   = 0;          // number of non-trivial normal modes
     int n_residues = 0;
+
+    // Index into the parallel CalphaStructure vector at construction.
+    // Survives sort_by_free_energy() so PDB/JSON writers pair coordinates to
+    // the mode they were computed from (N>2 permutes modes[1:]).
+    std::size_t structure_index = 0;
 };
 
 // Population of FlexModes — analogous to BindingPopulation
@@ -56,6 +62,11 @@ struct FlexPopulation {
 
     // Sort modes by delta_F_vib (ascending, most stabilizing first)
     void sort_by_free_energy();
+
+    // Resolve the Cα structure this mode was built from (stable across sort).
+    static const tencom_pdb::CalphaStructure*
+    paired_structure(const FlexMode& mode,
+                     const std::vector<tencom_pdb::CalphaStructure>& structures);
 
     // Write PDB file for a given mode with REMARK thermodynamic metadata
     void write_mode_pdb(const FlexMode& mode,

--- a/tests/test_tencom_output.cpp
+++ b/tests/test_tencom_output.cpp
@@ -1,0 +1,95 @@
+// tests/test_tencom_output.cpp
+// tENCoM FlexPopulation mode↔structure pairing after sort_by_free_energy.
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+
+#include "tENCoM/tencom_output.h"
+#include "tENCoM/pdb_calpha.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string write_synthetic_pdb(const std::string& prefix, int n_residues)
+{
+    std::string path = std::filesystem::temp_directory_path().string()
+                       + "/" + prefix + ".pdb";
+    std::ofstream ofs(path);
+    const float turn = 100.0f * 3.14159265f / 180.0f;
+    const float radius = 2.3f;
+    const float rise = 1.5f;
+    for (int r = 0; r < n_residues; ++r) {
+        float x = radius * std::cos(r * turn);
+        float y = radius * std::sin(r * turn);
+        float z = r * rise;
+        char line[82];
+        std::snprintf(line, sizeof(line),
+            "ATOM  %5d  CA  ALA A%4d    %8.3f%8.3f%8.3f  1.00  0.00           C",
+            r + 1, r + 1, x, y, z);
+        ofs << line << "\n";
+    }
+    ofs << "END\n";
+    return path;
+}
+
+}  // namespace
+
+TEST(TencomOutput, SortPreservesStructurePairingWhenNgt2)
+{
+    using tencom_output::FlexMode;
+    using tencom_output::FlexPopulation;
+
+    FlexPopulation pop;
+    std::vector<tencom_pdb::CalphaStructure> structures;
+    const int nres[] = {8, 12, 16, 20};
+    const double dF[] = {0.0, 3.0, 1.0, 2.0};
+    std::vector<std::string> paths;
+
+    for (int i = 0; i < 4; ++i) {
+        auto path = write_synthetic_pdb("tencom_pair_" + std::to_string(i), nres[i]);
+        paths.push_back(path);
+        auto st = tencom_pdb::read_pdb_calpha(path);
+        FlexMode m;
+        m.mode_id = i;
+        m.structure_index = static_cast<std::size_t>(i);
+        m.pdb_path = path;
+        m.n_residues = st.res_cnt;
+        m.delta_F_vib = dF[i];
+        pop.modes.push_back(std::move(m));
+        structures.push_back(std::move(st));
+    }
+
+    for (std::size_t i = 0; i < pop.modes.size(); ++i) {
+        EXPECT_EQ(structures[i].res_cnt, pop.modes[i].n_residues);
+    }
+
+    pop.sort_by_free_energy();
+
+    ASSERT_EQ(pop.modes.size(), 4u);
+    EXPECT_EQ(pop.modes[0].structure_index, 0u);
+    EXPECT_EQ(pop.modes[1].structure_index, 2u);  // ΔF=1 was original index 2
+    EXPECT_EQ(pop.modes[2].structure_index, 3u);  // ΔF=2 was original index 3
+    EXPECT_EQ(pop.modes[3].structure_index, 1u);  // ΔF=3 was original index 1
+
+    bool old_index_pairing_broken = false;
+    for (std::size_t i = 0; i < pop.modes.size(); ++i) {
+        const auto* st = FlexPopulation::paired_structure(pop.modes[i], structures);
+        ASSERT_NE(st, nullptr);
+        EXPECT_EQ(st->res_cnt, pop.modes[i].n_residues);
+        EXPECT_EQ(st->filename, pop.modes[i].pdb_path);
+        if (structures[i].res_cnt != pop.modes[i].n_residues) {
+            old_index_pairing_broken = true;
+        }
+    }
+    EXPECT_TRUE(old_index_pairing_broken)
+        << "this test is vacuous unless sort permutes modes relative to structures";
+
+    for (const auto& p : paths) {
+        std::remove(p.c_str());
+    }
+}


### PR DESCRIPTION
## Summary
- `FlexMode::structure_index` survives `sort_by_free_energy()` so PDB/JSON writers pair modes with the correct structure when N>2.
- Standalone tENCoM CLI only; does not elect Astex poses.
- Split from #440 (Wave 2.5).

## Test plan
- [ ] `ctest --test-dir build -R TencomOutput --output-on-failure` (or the new `test_tencom_output` binary)


Made with [Cursor](https://cursor.com)