### PR TITLE
Fix: std::abs chromosome dedup behind FLEXAIDDS_DEDUP_STDABS

### DIFF
--- a/LIB/EnvFlags.h
+++ b/LIB/EnvFlags.h
@@ -108,4 +108,12 @@ inline int get_yval_lut_bins_cached() noexcept
     return bins;
 }
 
+/// FLEXAIDDS_DEDUP_STDABS — DEFAULT ON.
+/// Use std::abs on gene `to_ic` deltas so |Δ|<1 is not truncated by abs(int).
+/// Set 0/false/off to restore historical abs(int) truncation for A/B.
+inline bool dedup_stdabs_enabled() noexcept
+{
+    return env_bool("FLEXAIDDS_DEDUP_STDABS", true);
+}
+
 }  // namespace flexaids

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -13,6 +13,7 @@
 #include "niche_distance.h"
 #include "niche_hash.h"
 #include "new_search_arch.h"
+#include "EnvFlags.h"
 
 #include <random>
 #include <functional>
@@ -4211,13 +4212,18 @@ int cmp_chrom2rotlist(psFlexDEE_Node psFlexDEE_INI_Node, const chromosome* chrom
 /***********************************************************************/
 int cmp_chrom2pop(const chromosome* chrom,const gene* genes, int num_genes,int start, int last){
 	int i,j,flag;
+	const bool use_stdabs = flexaids::dedup_stdabs_enabled();
 
 	for(i=start;i<last;i++){
 		flag=0;
 		for(j=0;j<num_genes;j++){
 			//printf("individuals[%d][%d].gene[%d]=%.3f\t%.3f\n", start-1, i, j,
 			//       genes[j].to_ic, chrom[i].genes[j].to_ic);
-			flag += abs(genes[j].to_ic - chrom[i].genes[j].to_ic) < GA_GENE_MATCH_TOLERANCE;
+			const double d = genes[j].to_ic - chrom[i].genes[j].to_ic;
+			const double ad = use_stdabs
+				? std::abs(d)
+				: static_cast<double>(std::abs(static_cast<int>(d)));
+			flag += ad < GA_GENE_MATCH_TOLERANCE;
 		}
 
 		//printf("flag=%d\n",flag);
@@ -4805,12 +4811,17 @@ int remove_dups(chromosome* chrom, int num_chrom, int num_genes){
 	int i=0;
 	int j;
 	if (num_chrom<=1) return num_chrom;
+	const bool use_stdabs = flexaids::dedup_stdabs_enabled();
 
 	for (j=1;j<num_chrom;j++)
 	{
 		int flag = 0;
 		for(int l=0;l<num_genes;l++){
-			flag += abs(chrom[j].genes[l].to_ic - chrom[i].genes[l].to_ic) < 0.1;
+			const double d = chrom[j].genes[l].to_ic - chrom[i].genes[l].to_ic;
+			const double ad = use_stdabs
+				? std::abs(d)
+				: static_cast<double>(std::abs(static_cast<int>(d)));
+			flag += ad < 0.1;
 		}
 		if(flag != num_genes)
 		{

--- a/tests/test_gaboom.cpp
+++ b/tests/test_gaboom.cpp
@@ -452,6 +452,70 @@ TEST(RemoveDups, WithinTolerance) {
     EXPECT_EQ(result, 1);
 }
 
+namespace {
+
+void set_dedup_env(const char* val) {
+#if defined(_WIN32)
+    if (val) _putenv_s("FLEXAIDDS_DEDUP_STDABS", val);
+    else _putenv_s("FLEXAIDDS_DEDUP_STDABS", "");
+#else
+    if (val) setenv("FLEXAIDDS_DEDUP_STDABS", val, 1);
+    else unsetenv("FLEXAIDDS_DEDUP_STDABS");
+#endif
+}
+
+struct DedupAbsGuard {
+    DedupAbsGuard(const char* val) {
+        const char* prev = std::getenv("FLEXAIDDS_DEDUP_STDABS");
+        had_ = prev != nullptr;
+        if (had_) prev_ = prev;
+        set_dedup_env(val);
+    }
+    ~DedupAbsGuard() {
+        if (had_) set_dedup_env(prev_.c_str());
+        else set_dedup_env(nullptr);
+    }
+    bool had_ = false;
+    std::string prev_;
+};
+
+}  // namespace
+
+// Δ=0.5 would false-match under abs(int) truncation (abs((int)0.5)==0 < 0.1).
+TEST(RemoveDups, HalfDeltaKeptWithStdAbsDefaultOn) {
+    DedupAbsGuard unset(nullptr);
+    ChromArray ca(2, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    ca[1].genes[0].to_ic = 1.5;
+    EXPECT_EQ(remove_dups(ca.data(), 2, 1), 2);
+}
+
+TEST(RemoveDups, HalfDeltaFalseMatchWithAbsIntOffFlag) {
+    DedupAbsGuard off("0");
+    ChromArray ca(2, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    ca[1].genes[0].to_ic = 1.5;
+    EXPECT_EQ(remove_dups(ca.data(), 2, 1), 1);
+}
+
+TEST(CmpChrom2Pop, HalfDeltaNotMatchWithStdAbsDefaultOn) {
+    DedupAbsGuard unset(nullptr);
+    ChromArray ca(1, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    gene query{};
+    query.to_ic = 1.5;
+    EXPECT_EQ(cmp_chrom2pop(ca.data(), &query, 1, 0, 1), 0);
+}
+
+TEST(CmpChrom2Pop, HalfDeltaFalseMatchWithAbsIntOffFlag) {
+    DedupAbsGuard off("0");
+    ChromArray ca(1, 1);
+    ca[0].genes[0].to_ic = 1.0;
+    gene query{};
+    query.to_ic = 1.5;
+    EXPECT_EQ(cmp_chrom2pop(ca.data(), &query, 1, 0, 1), 1);
+}
+
 // ===========================================================================
 // FITNESS STATISTICS
 // ===========================================================================


### PR DESCRIPTION
## Summary
- Gene `to_ic` dedup uses `std::abs` on `double` so `|Δ| = 0.5` is not truncated to int 0.
- `FLEXAIDDS_DEDUP_STDABS` defaults ON; set `0` for A/B.
- Split from #440 (Wave 2.6). This is the ranking-adjacent flagged change.

## Test plan
- [ ] `ctest --test-dir build -R Gaboom --output-on-failure`


Made with [Cursor](https://cursor.com)