### PR TITLE
Fix: exclude oversized Astex receptors and pin the Tier-1 seed in YAML

### DIFF
--- a/.github/workflows/benchmark-tier1.yml
+++ b/.github/workflows/benchmark-tier1.yml
@@ -214,15 +214,15 @@ jobs:
           # makes G3' (a repeat is bit-identical) testable. FLEXAID_SEED is single-D
           # (RngSeed.h:28); empty => time(0) fallback (gaboom.cpp:337).
           FLEXAID_SEED: ${{ inputs.seed }}
-          # Tier-1 draw seed, PINNED (WO-3): without this the seed falls through
-          # to the UTC date, so every PR the same day draws the same 4 targets
-          # and the verdict rotates at midnight with no code change — the gate
-          # answers "today's dice", not "did this PR change anything". Pinned to
-          # 20260816 (the date this was traced): draws 1gpk 1mq6 1x8x 2c3i
-          # (anchors + 1x8x measured at 1219 s / 1619 s / 2455 s). Rotate the
-          # value deliberately via a direct commit or scheduled job — never
-          # per-PR — and only alongside a green run that establishes the new
-          # draw's expectations.
+          # Tier-1 draw seed, PINNED (WO-3 / addendum C-5): env overrides yaml
+          # tier1_seed. Do not change this value here without rotating yaml
+          # tier1_seed in both astex_diverse.yaml copies at the same time.
+          # Pinned to 20260816. After C-3 receptor-size exclusion of 1of6 the
+          # same seed draws 1gpk 1mq6 1xm6 2cet (anchors unchanged; rotating
+          # slots shifted because random.sample sees 83 eligible instead of 84).
+          # 1xm6=5635 apo atoms, 2cet=7895 — both below the 15098 outer fence.
+          # Rotate deliberately via a direct commit — never per-PR — and only
+          # alongside a green run that establishes the new draw's expectations.
           FLEXAIDDS_TIER1_SEED: "20260816"
           # Per-entry FlexAID wall-time cap (WO-2). Library default is 3600 s;
           # CI gets 5400 s headroom: the docking step cap is 105 min and 4

--- a/benchmarks/datasets/astex_diverse.yaml
+++ b/benchmarks/datasets/astex_diverse.yaml
@@ -46,25 +46,47 @@ tier1_subset_size: 4
 # the first N, so coverage rotates instead of leaving 83 of the 85 codes untested.
 # The draw is seeded and logged: re-run with FLEXAIDDS_TIER1_SEED=<logged seed> to
 # reproduce a draw exactly. Seed precedence: FLEXAIDDS_TIER1_SEED > tier1_seed >
-# UTC date (YYYYMMDD), so the set rotates daily but is stable within a run.
+# UTC date (YYYYMMDD).
 #
 # CONSEQUENCE: metrics below are target-dependent, so two runs with DIFFERENT
 # seeds are not comparable to each other and a regression flag from a fresh draw
 # is not evidence on its own. Compare only runs reporting the same seed.
 tier1_selection: random
+# Pin the library-path seed so a local / workflow_dispatch reproduction without
+# FLEXAIDDS_TIER1_SEED still matches the CI gate. CI's env var overrides this.
+# Rotate this value and .github/workflows/benchmark-tier1.yml
+# FLEXAIDDS_TIER1_SEED together; never one without the other.
+tier1_seed: 20260816
 
-# WALL-TIME exclusions (NOT science exclusions). Targets measured over the
-# tier-1 per-entry timeout cap are removed from the eligible pool before
-# selection in BOTH fixed and random modes. This says "too slow for this job
-# budget", never "too hard": excluded targets remain fully eligible for tier-2
-# and campaign runs. Re-admission requires a clean run under the CURRENT cap.
-# The measured evidence travels with each entry:
+# WALL-TIME exclusions (NOT science exclusions). Targets are removed from the
+# eligible pool before selection in BOTH fixed and random modes. This says
+# "too slow for this job budget", never "too hard": excluded targets remain
+# fully eligible for tier-2 and campaign runs.
 #
-#   2bys  timed out at the 3600 s cap on 2026-08-16 (PR #439; timing per the
-#         external log audit recorded in workorders/HANDOFF_OpenCode_tier1_exit3.md
-#         — siblings that day: 1x8x 1219 s, 1gpk 1619 s, 1mq6 2455 s). Not yet
-#         measured against the 5400 s CI cap: re-admit after one clean 5400 s run.
+# Screened by RECEPTOR SIZE (apo ATOM+HETATM count), not by timeout incidents.
+# Timeout-only exclusion of 2bys left the next oversized target (1of6, larger
+# than 2bys) eligible. Counts measured 2026-08-16 from
+# $FLEXAIDDS_LOCAL_ROOT/cache_v2/astex_diverse/<PDB>/<PDB>_apo.pdb (85 targets).
+#
+#   n=85  min=1614  median=3729  Q3=5747  IQR=3117
+#   Tukey outer fence Q3+3·IQR = 15098  (4× median = 14916)
+#   Threshold: apo atoms > 15098 (extreme outliers).
+#
+#   1of6  21501  (5.77× median)  excluded
+#   2bys  18241  (4.89× median)  excluded; also timed out at 3600 s on 2026-08-16
+#   1n1m  12843  (3.44×)  KEPT — inner fence only; unmeasured wall time
+#   1u1c  11775  (3.16×)  KEPT
+#   1q1g  11523  (3.09×)  KEPT
+#   1sq5  10535  (2.83×)  KEPT
+#   1t9b  10458  (2.80×)  KEPT
+#   1gpk   4782           KEPT — anchor; ran 1619 s
+#   1x8x   2762           KEPT — ran 1219 s
+#   2c3i   2403           KEPT — newly pinned; unmeasured wall; ~1mq6 size
+#   1mq6   2385           KEPT — anchor; ran 2455 s (ligand DoF, not size)
+#
+# Re-admission requires a clean run under the CURRENT 5400 s CI cap.
 tier1_wall_time_exclusions:
+  - 1of6
   - 2bys
 
 # Anchor targets: pinned into EVERY draw, so a fixed core of each run stays

--- a/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
+++ b/python/flexaidds/dataset_runner/datasets/astex_diverse.yaml
@@ -46,25 +46,47 @@ tier1_subset_size: 4
 # the first N, so coverage rotates instead of leaving 83 of the 85 codes untested.
 # The draw is seeded and logged: re-run with FLEXAIDDS_TIER1_SEED=<logged seed> to
 # reproduce a draw exactly. Seed precedence: FLEXAIDDS_TIER1_SEED > tier1_seed >
-# UTC date (YYYYMMDD), so the set rotates daily but is stable within a run.
+# UTC date (YYYYMMDD).
 #
 # CONSEQUENCE: metrics below are target-dependent, so two runs with DIFFERENT
 # seeds are not comparable to each other and a regression flag from a fresh draw
 # is not evidence on its own. Compare only runs reporting the same seed.
 tier1_selection: random
+# Pin the library-path seed so a local / workflow_dispatch reproduction without
+# FLEXAIDDS_TIER1_SEED still matches the CI gate. CI's env var overrides this.
+# Rotate this value and .github/workflows/benchmark-tier1.yml
+# FLEXAIDDS_TIER1_SEED together; never one without the other.
+tier1_seed: 20260816
 
-# WALL-TIME exclusions (NOT science exclusions). Targets measured over the
-# tier-1 per-entry timeout cap are removed from the eligible pool before
-# selection in BOTH fixed and random modes. This says "too slow for this job
-# budget", never "too hard": excluded targets remain fully eligible for tier-2
-# and campaign runs. Re-admission requires a clean run under the CURRENT cap.
-# The measured evidence travels with each entry:
+# WALL-TIME exclusions (NOT science exclusions). Targets are removed from the
+# eligible pool before selection in BOTH fixed and random modes. This says
+# "too slow for this job budget", never "too hard": excluded targets remain
+# fully eligible for tier-2 and campaign runs.
 #
-#   2bys  timed out at the 3600 s cap on 2026-08-16 (PR #439; timing per the
-#         external log audit recorded in workorders/HANDOFF_OpenCode_tier1_exit3.md
-#         — siblings that day: 1x8x 1219 s, 1gpk 1619 s, 1mq6 2455 s). Not yet
-#         measured against the 5400 s CI cap: re-admit after one clean 5400 s run.
+# Screened by RECEPTOR SIZE (apo ATOM+HETATM count), not by timeout incidents.
+# Timeout-only exclusion of 2bys left the next oversized target (1of6, larger
+# than 2bys) eligible. Counts measured 2026-08-16 from
+# $FLEXAIDDS_LOCAL_ROOT/cache_v2/astex_diverse/<PDB>/<PDB>_apo.pdb (85 targets).
+#
+#   n=85  min=1614  median=3729  Q3=5747  IQR=3117
+#   Tukey outer fence Q3+3·IQR = 15098  (4× median = 14916)
+#   Threshold: apo atoms > 15098 (extreme outliers).
+#
+#   1of6  21501  (5.77× median)  excluded
+#   2bys  18241  (4.89× median)  excluded; also timed out at 3600 s on 2026-08-16
+#   1n1m  12843  (3.44×)  KEPT — inner fence only; unmeasured wall time
+#   1u1c  11775  (3.16×)  KEPT
+#   1q1g  11523  (3.09×)  KEPT
+#   1sq5  10535  (2.83×)  KEPT
+#   1t9b  10458  (2.80×)  KEPT
+#   1gpk   4782           KEPT — anchor; ran 1619 s
+#   1x8x   2762           KEPT — ran 1219 s
+#   2c3i   2403           KEPT — newly pinned; unmeasured wall; ~1mq6 size
+#   1mq6   2385           KEPT — anchor; ran 2455 s (ligand DoF, not size)
+#
+# Re-admission requires a clean run under the CURRENT 5400 s CI cap.
 tier1_wall_time_exclusions:
+  - 1of6
   - 2bys
 
 # Anchor targets: pinned into EVERY draw, so a fixed core of each run stays

--- a/python/tests/test_tier1_random_subset.py
+++ b/python/tests/test_tier1_random_subset.py
@@ -110,12 +110,16 @@ def test_astex_diverse_yaml_uses_random_selection():
         seen.append((
             d.get("tier1_selection"),
             d.get("tier1_subset_size"),
-            # Wall-time exclusions change the eligible pool, so a drift here
-            # silently changes every CI draw on one copy but not the other.
+            d.get("tier1_seed"),
+            # Wall-time / receptor-size exclusions change the eligible pool, so
+            # a drift here silently changes every CI draw on one copy but not
+            # the other.
             tuple(d.get("tier1_wall_time_exclusions") or ()),
         ))
     # 4 = the free-coverage point: one batch of 4 workers, same wall as 2.
-    assert seen[0] == ("random", 4, ("2bys",))
+    # 20260816 = CI FLEXAIDDS_TIER1_SEED; yaml pin matches so local repro
+    # without the env var still draws the same subset.
+    assert seen[0] == ("random", 4, 20260816, ("1of6", "2bys"))
     assert seen[0] == seen[1], f"astex_diverse copies disagree: {seen}"
 
 
@@ -186,10 +190,10 @@ def test_pinned_seed_draw_ignores_utc_date(monkeypatch):
 
 def test_ci_pinned_seed_draw_is_the_documented_one(monkeypatch):
     """Guard the workflow pin: FLEXAIDDS_TIER1_SEED=20260816 in
-    benchmark-tier1.yml must keep drawing 1gpk 1mq6 1x8x 2c3i from the real
-    astex_diverse config. If a YAML edit silently changes this draw, the CI
-    gate's expectations change with no one noticing — this test makes that
-    loud instead."""
+    benchmark-tier1.yml must keep drawing 1gpk 1mq6 1xm6 2cet from the real
+    astex_diverse config (anchors + rotating slots after C-3 excluded 1of6).
+    If a YAML edit silently changes this draw, the CI gate's expectations
+    change with no one noticing — this test makes that loud instead."""
     import pathlib
 
     monkeypatch.setenv("FLEXAIDDS_TIER1_SEED", "20260816")
@@ -200,7 +204,62 @@ def test_ci_pinned_seed_draw_is_the_documented_one(monkeypatch):
     if not cfg_path.exists():
         pytest.skip(f"{cfg_path} not present")
     cfg = DatasetConfig.from_yaml(cfg_path)
-    assert cfg.tier1_targets() == ["1gpk", "1mq6", "1x8x", "2c3i"]
+    assert cfg.tier1_targets() == ["1gpk", "1mq6", "1xm6", "2cet"]
+
+
+def test_yaml_tier1_seed_is_stable_across_utc_dates(monkeypatch):
+    """C-5: with no FLEXAIDDS_TIER1_SEED, two different UTC dates draw the same
+    subset because yaml ``tier1_seed: 20260816`` wins over the date fallback.
+    """
+    import datetime
+    import pathlib
+
+    monkeypatch.delenv("FLEXAIDDS_TIER1_SEED", raising=False)
+    cfg_path = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "python/flexaidds/dataset_runner/datasets/astex_diverse.yaml"
+    )
+    if not cfg_path.exists():
+        pytest.skip(f"{cfg_path} not present")
+
+    draws = []
+    for ymd in ("20260816", "20260817", "20260901"):
+        class _DT(datetime.datetime):
+            _ymd = ymd
+
+            @classmethod
+            def now(cls, tz=None):
+                return datetime.datetime.strptime(cls._ymd, "%Y%m%d").replace(
+                    tzinfo=datetime.timezone.utc
+                )
+
+        monkeypatch.setattr(
+            "flexaidds.dataset_runner.runner.datetime.datetime", _DT
+        )
+        cfg = DatasetConfig.from_yaml(cfg_path)
+        assert cfg.tier1_seed == 20260816
+        draws.append(tuple(cfg.tier1_targets()))
+    assert draws[0] == draws[1] == draws[2]
+    assert list(draws[0]) == ["1gpk", "1mq6", "1xm6", "2cet"]
+
+
+def test_receptor_size_exclusions_never_enter_a_draw(monkeypatch):
+    """1of6/2bys sit above the Tukey outer fence; no seed may draw them."""
+    import pathlib
+
+    cfg_path = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "python/flexaidds/dataset_runner/datasets/astex_diverse.yaml"
+    )
+    if not cfg_path.exists():
+        pytest.skip(f"{cfg_path} not present")
+    cfg = DatasetConfig.from_yaml(cfg_path)
+    assert "1of6" in cfg.tier1_wall_time_exclusions
+    assert "2bys" in cfg.tier1_wall_time_exclusions
+    for s in range(40):
+        monkeypatch.setenv("FLEXAIDDS_TIER1_SEED", str(s))
+        got = cfg.tier1_targets()
+        assert "1of6" not in got and "2bys" not in got
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Screen the Tier-1 eligible pool by apo ATOM+HETATM count (Tukey outer fence 15098), not by timeout incidents. Exclude `1of6` (21501) and `2bys` (18241). Inner-fence targets stay eligible.
- Pin `tier1_seed: 20260816` in both `astex_diverse.yaml` copies so a local run without `FLEXAIDDS_TIER1_SEED` matches CI. Workflow env value is **unchanged**.

Because `1of6` left the pool, seed 20260816 now draws `1gpk, 1mq6, 1xm6, 2cet` (anchors unchanged; rotating slots were `1x8x, 2c3i`). Tests lock the new draw and assert `1of6`/`2bys` never enter a draw.

## Change class (pick **one** primary)
- [x] **Benchmark harness / frozen referee**

`python3 scripts/classify_diff.py origin/main HEAD` → `VERDICT: benchmark harness`

## Science-Impact
- [x] none (cannot move docked coordinates or CF ranking)

Changes which four targets CI docks, not how they are scored.

## Scope
- [x] Benchmark / reproducibility
- [x] CI / release engineering

## Release impact
- [x] affects configuration schema or defaults
- [x] affects benchmark or metric reporting

## Validation
- `python3 -m pytest python/tests/test_tier1_random_subset.py` → **31 passed**
- [x] unit tests

## Security and safety
- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility
- [x] no benchmark claim involved

## Notes
C-3 + C-5 (addendum). `FLEXAIDDS_TIER1_SEED` in the workflow was not re-pinned. First clean Tier-1 run on `1gpk,1mq6,1xm6,2cet` is still required before calling the gate fixed. Independent of the Tier-2 workflow and native_score PRs.

Made with [Cursor](https://cursor.com)