### PR TITLE
Fix: sum every CF channel in native_score

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -6777,7 +6777,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
 
         // ── Parse [NATIVE_CF] from stderr.log ────────────────────────────────
         // Line format (emitted by native_score.cpp):
-        //   [NATIVE_CF] cf=<total> breakdown=com:<v>,wal:<v>,sas:<v>,con:<v>
+        //   [NATIVE_CF] cf=<total> breakdown=com:<v>,wal:<v>,sas:<v>,con:<v>,...
+        //   (ten get_cf_evalue channels; parser reads only cf=)
         {
             std::string stderr_path = out_dir + "/stderr.log";
             std::ifstream nf(stderr_path);

--- a/LIB/native_score.cpp
+++ b/LIB/native_score.cpp
@@ -320,7 +320,11 @@ void score_native_pose(FA_Global* FA, VC_Global* VC, atom* atoms,
             cf.wal += FA->optres[i].cf.wal;
             cf.sas += FA->optres[i].cf.sas;
             cf.con += FA->optres[i].cf.con;
+            cf.elec += FA->optres[i].cf.elec;
+            cf.gist_desolv += FA->optres[i].cf.gist_desolv;
+            cf.metal_coord += FA->optres[i].cf.metal_coord;
             cf.hbond += FA->optres[i].cf.hbond;
+            cf.entropy += FA->optres[i].cf.entropy;
             cf.pb_clash += FA->optres[i].cf.pb_clash;
         }
     }
@@ -339,13 +343,19 @@ void score_native_pose(FA_Global* FA, VC_Global* VC, atom* atoms,
     // ── 5. Emit [NATIVE_CF] line for DatasetRunner parsing ───────────────────
     const double cf_total = get_cf_evalue(&cf, FA);
     fprintf(stderr,
-        "[NATIVE_CF] cf=%.6f breakdown=com:%.4f,wal:%.4f,sas:%.4f,con:%.4f,hbond:%.4f,pb_clash:%.4f\n",
+        "[NATIVE_CF] cf=%.6f breakdown=com:%.4f,wal:%.4f,sas:%.4f,con:%.4f,"
+        "elec:%.4f,hbond:%.4f,gist_desolv:%.4f,metal_coord:%.4f,entropy:%.4f,"
+        "pb_clash:%.4f\n",
         cf_total,
         static_cast<double>(cf.com),
         static_cast<double>(cf.wal),
         static_cast<double>(cf.sas),
         static_cast<double>(cf.con),
+        static_cast<double>(cf.elec),
         static_cast<double>(cf.hbond),
+        static_cast<double>(cf.gist_desolv),
+        static_cast<double>(cf.metal_coord),
+        static_cast<double>(cf.entropy),
         static_cast<double>(cf.pb_clash));
 }
 

--- a/LIB/native_score.h
+++ b/LIB/native_score.h
@@ -15,7 +15,11 @@
 //   steric-clash explosions.
 //
 // Output:  one line on stderr  (DatasetRunner parses the cf= field):
-//   [NATIVE_CF] cf=<total> breakdown=com:<v>,wal:<v>,sas:<v>,con:<v>
+//   [NATIVE_CF] cf=<total> breakdown=com:<v>,wal:<v>,sas:<v>,con:<v>,
+//               elec:<v>,hbond:<v>,gist_desolv:<v>,metal_coord:<v>,
+//               entropy:<v>,pb_clash:<v>
+//   Total matches get_cf_evalue() (ten channels). elec/gist are structurally
+//   zero today; metal_coord is the term this diagnostic previously omitted.
 //
 // The GA continues normally after this diagnostic — no extra subprocess needed.
 //

--- a/tests/test_dump_pop_refstructure_wiring.py
+++ b/tests/test_dump_pop_refstructure_wiring.py
@@ -59,3 +59,22 @@ def test_cluster_dump_still_gated_on_refstructure_and_env():
     assert ".pop.tsv" in cl
     # Gate remains dual: refstructure AND env
     assert "FA->refstructure == 1" in cl
+
+
+def test_native_score_sums_all_get_cf_evalue_channels():
+    """cf_native must accumulate the same ten terms as ic2cf / get_cf_evalue.
+
+    Hygiene only: metal_coord (and elec, gist_desolv, entropy) were omitted
+    from native_score while pose CF_total already included them.
+    """
+    cpp = (ROOT / "LIB" / "native_score.cpp").read_text(encoding="utf-8")
+    loop = cpp.split("for (int i = 0; i < FA->num_optres; ++i)")[1].split("}")[0]
+    for term in (
+        "com", "wal", "sas", "con", "elec", "hbond",
+        "gist_desolv", "metal_coord", "entropy", "pb_clash",
+    ):
+        needle = f"cf.{term} += FA->optres[i].cf.{term}"
+        assert needle in loop, f"native_score optres loop missing {needle}"
+    ic2cf = (ROOT / "LIB" / "ic2cf.cpp").read_text(encoding="utf-8")
+    for term in ("elec", "gist_desolv", "metal_coord", "entropy"):
+        assert f"cf.{term} += FA->optres[i].cf.{term}" in ic2cf

--- a/tools/probe_cf.cpp
+++ b/tools/probe_cf.cpp
@@ -19,7 +19,7 @@
 //   which overrides the ligand atoms[].coor[] with the pose read from
 //   FLEXAIDDS_RMSDST and calls vcfunction() DIRECTLY — no GA — then std::exit()s
 //   before the search.  It prints:
-//       [NATIVE_CF] cf=<total> breakdown=com:..,wal:..,sas:..,con:..,hbond:..,pb_clash:..
+//       [NATIVE_CF] cf=<total> breakdown=com:..,wal:..,sas:..,con:..,elec:..,hbond:..,gist_desolv:..,metal_coord:..,entropy:..,pb_clash:..
 //   probe_cf captures that line and reformats it as JSON.
 //
 // This wraps the existing score_native_pose() diagnostic (per the task's
@@ -347,8 +347,9 @@ int main(int argc, char** argv) {
         return 4;
     }
 
-    // Parse: [NATIVE_CF] cf=<t> breakdown=com:<>,wal:<>,sas:<>,con:<>,hbond:<>,pb_clash:<>
-    double cf_total = 0, com = 0, wal = 0, sas = 0, con = 0, hbond = 0, pb_clash = 0;
+    // Parse: [NATIVE_CF] cf=<t> breakdown=com:<>,wal:<>,sas:<>,con:<>,elec:<>,hbond:<>,gist_desolv:<>,metal_coord:<>,entropy:<>,pb_clash:<>
+    double cf_total = 0, com = 0, wal = 0, sas = 0, con = 0, elec = 0, hbond = 0;
+    double gist_desolv = 0, metal_coord = 0, entropy = 0, pb_clash = 0;
     {
         size_t p = native_line.find("cf=");
         if (p != std::string::npos) cf_total = std::atof(native_line.c_str() + p + 3);
@@ -358,7 +359,9 @@ int main(int argc, char** argv) {
             if (q != std::string::npos) dst = std::atof(native_line.c_str() + q + k.size());
         };
         grab("com", com); grab("wal", wal); grab("sas", sas);
-        grab("con", con); grab("hbond", hbond); grab("pb_clash", pb_clash);
+        grab("con", con); grab("elec", elec); grab("hbond", hbond);
+        grab("gist_desolv", gist_desolv); grab("metal_coord", metal_coord);
+        grab("entropy", entropy); grab("pb_clash", pb_clash);
     }
 
     double roundtrip_rmsd = -1.0;
@@ -378,6 +381,10 @@ int main(int argc, char** argv) {
     std::printf("\"cf_hbond\": %.6f, ", hbond);
     std::printf("\"cf_sas\": %.6f, ", sas);
     std::printf("\"cf_wal\": %.6f, ", wal);
+    std::printf("\"cf_elec\": %.6f, ", elec);
+    std::printf("\"cf_gist_desolv\": %.6f, ", gist_desolv);
+    std::printf("\"cf_metal_coord\": %.6f, ", metal_coord);
+    std::printf("\"cf_entropy\": %.6f, ", entropy);
     std::printf("\"cf_clash\": %.6f, ", pb_clash);
     if (a.mode == "roundtrip")
         std::printf("\"roundtrip_rmsd\": %.4f, ", roundtrip_rmsd);


### PR DESCRIPTION
## Summary
- `native_score` now accumulates the same ten `get_cf_evalue` channels as `ic2cf` (adds `elec`, `gist_desolv`, `metal_coord`, `entropy`). `cf=` follows the full total.
- `probe_cf` parses the extra breakdown keys. `DatasetRunner` comment updated; it still reads only `cf=`.

Hygiene only. Leave-one-out on 35,873 poses: metal is already inside CF_total (bias 0.09–3.57% of |CF| on 13/84 targets). This will not move seed-echo or dG conclusions.

## Change class (pick **one** primary)
- [x] **Fix** — bug; default path unchanged, or fail-closed

`python3 scripts/classify_diff.py origin/main HEAD` → `VERDICT: engine-critical` because `LIB/DatasetRunner.cpp` is in that bucket. The DatasetRunner hunk is a **comment only**. Pose ranking and GA search are unchanged.

## Science-Impact
- [x] none (cannot move docked coordinates or CF ranking)

Native-pose diagnostic total only. GA ranking still uses pose CF_total, which already included these terms.

## Scope
- [x] Core 1.0 supported surface

## Release impact
- [x] affects benchmark or metric reporting

`[NATIVE_CF]` breakdown string gains four keys; `cf=` may change on metal-bearing natives.

## Validation
- `python3 -m pytest tests/test_dump_pop_refstructure_wiring.py` → **5 passed** (source-level channel list vs `ic2cf`)
- [x] unit tests

No FlexAID rebuild in this slice (no local `build/` tree).

## Security and safety
- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility
- [x] no benchmark claim involved

## Notes
C-4 from WORKORDER_Cursor_tier2_and_corrections, last on purpose. Independent of the two CI/YAML PRs.

Made with [Cursor](https://cursor.com)