### PR TITLE
Fix: classify ligand sp3 N/O H-bond roles by topology, not partial charge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2797,6 +2797,12 @@ flexaids_add_unit_test(test_protocol_config
         TEST_NAME HBondPotentialTests
     )
 
+    # test_hbond_amine_roles — topology-based sp3 N/O H-bond role classification
+    flexaids_add_unit_test(test_hbond_amine_roles
+        SOURCES tests/test_hbond_amine_roles.cpp
+        TEST_NAME HBondAmineRoleTests
+    )
+
     # test_gist_grid — GIST desolvation grid unit tests
     flexaids_add_unit_test(test_gist_grid
         SOURCES tests/test_gist_grid.cpp

--- a/LIB/atom_typing_256.h
+++ b/LIB/atom_typing_256.h
@@ -235,10 +235,23 @@ inline bool classify_hbond_acceptor(uint8_t base_type, float partial_charge,
         return classify_hbond_acceptor(base_type, partial_charge, n_hydrogens);
 
     switch (base_type) {
-        case N_sp3:
-            // The lone pair is what accepts. Once the nitrogen is quaternised
-            // or protonated it is spent — the atom is a donor, not an acceptor.
-            return !topo.is_quaternary_nitrogen() && !topo.is_cationic();
+        case N_sp3: {
+            // The lone pair is what accepts, and sp3 N has exactly one. Neutral
+            // sp3 N is 3-coordinate: three substituents plus that lone pair. A
+            // fourth substituent — heavy atom OR hydrogen — can only be there
+            // because the lone pair was spent forming it, i.e. the nitrogen is
+            // quaternised or protonated. So coordination number is the single
+            // criterion, and it consumes exactly the same protonation evidence
+            // the donor test accepts: an explicit H on an already 3-substituted
+            // nitrogen is an ammonium, not an amine with a free lone pair.
+            //
+            // 1°/2° amines stay amphoteric: R-NH2 is (1 heavy + 2 H) = 3, and
+            // R2NH is (2 heavy + 1 H) = 3 — both accept. Their conjugate acids
+            // R-NH3+ (1+3) and R2NH2+ (2+2) reach 4 and correctly stop.
+            const int h = (n_hydrogens > 0) ? n_hydrogens : 0;
+            const int coordination = topo.n_heavy_neighbors + h;
+            return coordination < 4 && !topo.is_cationic();
+        }
         case N_quat:
             return false;
         default:

--- a/LIB/atom_typing_256.h
+++ b/LIB/atom_typing_256.h
@@ -104,6 +104,35 @@ struct HbondRoles {
     bool acceptor;
 };
 
+// ─── topology evidence for amine substitution ───────────────────────────────
+// Partial charge cannot resolve amine substitution: ligand charges are
+// identically 0 on the PDB-derived SDF path (PDB carries no partial charges by
+// format definition), so `partial_charge < 0.3f` is unconditionally true and
+// every ligand sp3 N entered scoring acceptor-only — a protonated amine, the
+// dominant CNS pharmacophore, had its roles exactly inverted.
+//
+// The discriminator is heavy-atom substitution count, not charge and not
+// n_hydrogens (which cannot tell "0 H because tertiary" from "0 H because the
+// input had no H information"). `known` carries that distinction explicitly:
+// when connectivity is absent the classifier falls back to the pre-existing
+// charge-based verdict, byte for byte.
+struct HbondTopology {
+    int  n_heavy_neighbors = 0;      // bonded non-hydrogen count
+    bool known             = false;  // connectivity actually available
+    int  formal_charge     = 0;      // perceived formal charge (e)
+    bool charge_known      = false;  // distinguishes "0" from "unknown"
+
+    // Perceive formal charge from substitution where the topology allows it.
+    // A 4-coordinate sp3 N is a quaternary/protonated ammonium (+1); nothing
+    // else is inferable from heavy-atom count alone.
+    constexpr bool is_quaternary_nitrogen() const noexcept {
+        return known && n_heavy_neighbors >= 4;
+    }
+    constexpr bool is_cationic() const noexcept {
+        return charge_known && formal_charge > 0;
+    }
+};
+
 inline bool classify_hbond_donor(uint8_t base_type, float partial_charge,
                                  int n_hydrogens) noexcept {
     (void)partial_charge;
@@ -167,6 +196,57 @@ inline bool classify_hbond_acceptor(uint8_t base_type, float partial_charge,
     }
 }
 
+// ─── topology-aware overloads ───────────────────────────────────────────────
+// Identical to the 3-argument forms whenever `topo.known` is false, so call
+// sites without connectivity keep their exact previous verdict.
+
+inline bool classify_hbond_donor(uint8_t base_type, float partial_charge,
+                                 int n_hydrogens,
+                                 const HbondTopology& topo) noexcept {
+    if (!topo.known)
+        return classify_hbond_donor(base_type, partial_charge, n_hydrogens);
+
+    switch (base_type) {
+        case N_sp3: {
+            // 4-coordinate → quaternary ammonium: no labile H, not a donor.
+            if (topo.is_quaternary_nitrogen()) return false;
+            // 1°/2° amine (≤2 heavy substituents) necessarily carries N–H.
+            // 3° amine carries N–H only when protonated — evidenced by an
+            // explicit H or a perceived positive formal charge.
+            return topo.n_heavy_neighbors <= 2 || n_hydrogens > 0 ||
+                   topo.is_cationic();
+        }
+        case N_quat:
+            // SYBYL N.4 is by definition quaternary/protonated. It donates
+            // through whatever H fill its fourth-plus valence.
+            return topo.n_heavy_neighbors < 4 || n_hydrogens > 0;
+        case O_sp3:
+            // Hydroxyl (1 heavy substituent) donates; ether (2) does not.
+            return topo.n_heavy_neighbors <= 1;
+        default:
+            return classify_hbond_donor(base_type, partial_charge, n_hydrogens);
+    }
+}
+
+inline bool classify_hbond_acceptor(uint8_t base_type, float partial_charge,
+                                    int n_hydrogens,
+                                    const HbondTopology& topo) noexcept {
+    if (!topo.known)
+        return classify_hbond_acceptor(base_type, partial_charge, n_hydrogens);
+
+    switch (base_type) {
+        case N_sp3:
+            // The lone pair is what accepts. Once the nitrogen is quaternised
+            // or protonated it is spent — the atom is a donor, not an acceptor.
+            return !topo.is_quaternary_nitrogen() && !topo.is_cationic();
+        case N_quat:
+            return false;
+        default:
+            return classify_hbond_acceptor(base_type, partial_charge,
+                                           n_hydrogens);
+    }
+}
+
 inline bool is_hbond_capable(uint8_t base_type, float partial_charge,
                               int n_hydrogens) noexcept {
     return classify_hbond_donor(base_type, partial_charge, n_hydrogens) ||
@@ -178,6 +258,15 @@ inline HbondRoles infer_hbond_roles(uint8_t base_type, float partial_charge,
     return {
         classify_hbond_donor(base_type, partial_charge, n_hydrogens),
         classify_hbond_acceptor(base_type, partial_charge, n_hydrogens),
+    };
+}
+
+inline HbondRoles infer_hbond_roles(uint8_t base_type, float partial_charge,
+                                    int n_hydrogens,
+                                    const HbondTopology& topo) noexcept {
+    return {
+        classify_hbond_donor(base_type, partial_charge, n_hydrogens, topo),
+        classify_hbond_acceptor(base_type, partial_charge, n_hydrogens, topo),
     };
 }
 
@@ -298,6 +387,30 @@ inline uint8_t encode_from_sybyl(int sybyl_type, float partial_charge,
     base = refine_base_type(base, aromatic_c, has_heteroatom_neighbor,
                             is_bridgehead);
     const HbondRoles roles = infer_hbond_roles(base, partial_charge, n_hydrogens);
+    return encode_roles(base, roles.donor, roles.acceptor);
+}
+
+// Topology-aware encoding. `topo.known == false` reproduces the 3-argument
+// form exactly; SYBYL N.4 supplies its own formal charge, since that type is
+// quaternary/protonated by definition.
+inline uint8_t encode_from_sybyl(int sybyl_type, float partial_charge,
+                                  int n_hydrogens,
+                                  HbondTopology topo,
+                                  bool has_heteroatom_neighbor = false,
+                                  bool is_bridgehead = false) noexcept {
+    uint8_t base = sybyl_to_base(sybyl_type);
+    bool aromatic_c = (sybyl_type == 4);  // C.AR
+    base = refine_base_type(base, aromatic_c, has_heteroatom_neighbor,
+                            is_bridgehead);
+    if (sybyl_type == 9) {  // N.4 — quaternary/protonated by SYBYL definition
+        topo.formal_charge = 1;
+        topo.charge_known  = true;
+    } else if (topo.is_quaternary_nitrogen() && base == N_sp3) {
+        topo.formal_charge = 1;
+        topo.charge_known  = true;
+    }
+    const HbondRoles roles =
+        infer_hbond_roles(base, partial_charge, n_hydrogens, topo);
     return encode_roles(base, roles.donor, roles.acceptor);
 }
 

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -1675,10 +1675,20 @@ int main(int argc, char **argv){
 						const int explicit_h = bonded_hydrogen_count(i);
 						const int n_hydrogens = explicit_h +
 							conservative_implicit_h_count(i, explicit_h, k);
+						// Heavy-atom substitution evidence for amine/alcohol roles.
+						// Only trusted when the atom actually carries a bond list:
+						// PDB receptor atoms can arrive with bond[0]==0, and a
+						// fabricated heavy count of 0 would read as a primary amine.
+						// With known=false the classifier reproduces its previous
+						// verdict exactly.
+						atom256::HbondTopology topo;
+						topo.n_heavy_neighbors = heavy_neighbor_count(i);
+						topo.known             = (atoms[i].bond[0] > 0);
 						atoms[i].type256 = atom256::encode_from_sybyl(
 							atoms[i].type,   // SYBYL type 1–40
 							atoms[i].charge, // partial charge (MOL2 or AMBER ff14SB)
-							n_hydrogens      // explicit + conservative implicit H
+							n_hydrogens,     // explicit + conservative implicit H
+							topo             // heavy-atom substitution evidence
 						);
 						// Virtual-H geometry recipe: stores heavy-neighbor indices so
 						// hbond_potential.h reconstructs H direction from live coords

--- a/python/bindings/bindings_matrix.cpp
+++ b/python/bindings/bindings_matrix.cpp
@@ -52,7 +52,18 @@ void register_matrix_bindings(py::module_& m) {
         "Map base type (0-63) to SYBYL parent (1-40)");
     m_at.def("base_type_name", &atom256::base_type_name,
         py::arg("base"), "Human-readable name for base type");
-    m_at.def("encode_from_sybyl", &atom256::encode_from_sybyl,
+    // encode_from_sybyl is overloaded (legacy form + topology-aware form), so
+    // &atom256::encode_from_sybyl is ambiguous for pybind11's template
+    // deduction — same hazard as atom256::encode above. Bind via a lambda
+    // pinned to the real signature.
+    m_at.def("encode_from_sybyl",
+        [](int sybyl_type, float partial_charge, int n_hydrogens,
+           bool has_heteroatom_neighbor, bool is_bridgehead) {
+            return atom256::encode_from_sybyl(sybyl_type, partial_charge,
+                                              n_hydrogens,
+                                              has_heteroatom_neighbor,
+                                              is_bridgehead);
+        },
         py::arg("sybyl_type"), py::arg("partial_charge"),
         py::arg("n_hydrogens"),
         py::arg("has_heteroatom_neighbor") = false,

--- a/tests/test_hbond_amine_roles.cpp
+++ b/tests/test_hbond_amine_roles.cpp
@@ -1,0 +1,185 @@
+// test_hbond_amine_roles.cpp — topology-based H-bond role classification
+//
+// Regression cover for the ligand sp3-nitrogen role defect: classify_hbond_donor
+// returned false unconditionally for N_sp3, and classify_hbond_acceptor keyed on
+// `partial_charge < 0.3f`. Ligand partial charges are identically 0 on the
+// PDB-derived SDF path, so that test was always true and EVERY ligand sp3
+// nitrogen entered scoring acceptor-only — a protonated amine had its donor and
+// acceptor roles exactly inverted.
+//
+// The contract asserted here: amine substitution is resolved by heavy-atom
+// topology, and the verdict is INDEPENDENT of partial charge. Every role
+// assertion below is swept across a range of partial charges spanning the old
+// 0.3f threshold; a classifier that reads charge cannot pass these.
+
+#include <gtest/gtest.h>
+#include "../LIB/atom_typing_256.h"
+
+namespace {
+
+// Charges spanning the old `< 0.3f` acceptor threshold in both directions,
+// including the identically-zero value the real SDF path supplies.
+constexpr float kChargeSweep[] = {-0.8f, -0.3f, 0.0f, 0.29f, 0.3f, 0.5f, 1.0f};
+
+atom256::HbondTopology topo(int n_heavy) {
+    atom256::HbondTopology t;
+    t.n_heavy_neighbors = n_heavy;
+    t.known             = true;
+    return t;
+}
+
+// SYBYL type numbers used below (1-indexed, see sybyl_to_base).
+constexpr int SYBYL_N3 = 8;   // N.3
+constexpr int SYBYL_N4 = 9;   // N.4
+constexpr int SYBYL_O3 = 14;  // O.3
+
+}  // namespace
+
+// ── the headline defect ─────────────────────────────────────────────────────
+
+TEST(HbondAmineRoles, ProtonatedPrimaryAmineIsDonor) {
+    // R–NH3+ : one heavy substituent, three hydrogens. This is the dominant CNS
+    // pharmacophore, and it was previously classified acceptor-only.
+    for (float q : kChargeSweep) {
+        const uint8_t code =
+            atom256::encode_from_sybyl(SYBYL_N4, q, /*n_hydrogens=*/3, topo(1));
+        EXPECT_EQ(atom256::get_base(code), atom256::N_quat) << "q=" << q;
+        EXPECT_TRUE(atom256::get_hbond_donor(code))
+            << "protonated primary amine must donate, q=" << q;
+        EXPECT_FALSE(atom256::get_hbond_acceptor(code))
+            << "protonated amine has no free lone pair, q=" << q;
+    }
+}
+
+TEST(HbondAmineRoles, ProtonatedAmineTypedNsp3IsDonor) {
+    // Same chemistry arriving as N.3 with an explicit H count — the SDF path,
+    // where no N.4 typing is available.
+    for (float q : kChargeSweep) {
+        const uint8_t code =
+            atom256::encode_from_sybyl(SYBYL_N3, q, /*n_hydrogens=*/2, topo(1));
+        EXPECT_EQ(atom256::get_base(code), atom256::N_sp3) << "q=" << q;
+        EXPECT_TRUE(atom256::get_hbond_donor(code)) << "q=" << q;
+        // Neutral primary amine is amphoteric: N–H donates, lone pair accepts.
+        EXPECT_TRUE(atom256::get_hbond_acceptor(code)) << "q=" << q;
+    }
+}
+
+TEST(HbondAmineRoles, TertiaryAmineIsAcceptorOnly) {
+    // R3N : three heavy substituents, no N–H. Acceptor, never donor.
+    for (float q : kChargeSweep) {
+        const uint8_t code =
+            atom256::encode_from_sybyl(SYBYL_N3, q, /*n_hydrogens=*/0, topo(3));
+        EXPECT_EQ(atom256::get_base(code), atom256::N_sp3) << "q=" << q;
+        EXPECT_FALSE(atom256::get_hbond_donor(code))
+            << "tertiary amine has no labile H, q=" << q;
+        EXPECT_TRUE(atom256::get_hbond_acceptor(code)) << "q=" << q;
+    }
+}
+
+TEST(HbondAmineRoles, SecondaryAmineIsBothRoles) {
+    for (float q : kChargeSweep) {
+        const uint8_t code =
+            atom256::encode_from_sybyl(SYBYL_N3, q, /*n_hydrogens=*/1, topo(2));
+        EXPECT_TRUE(atom256::get_hbond_donor(code)) << "q=" << q;
+        EXPECT_TRUE(atom256::get_hbond_acceptor(code)) << "q=" << q;
+    }
+}
+
+TEST(HbondAmineRoles, QuaternaryAmmoniumIsNeitherRole) {
+    // R4N+ : four heavy substituents. No labile H, no free lone pair.
+    for (float q : kChargeSweep) {
+        for (int sybyl : {SYBYL_N3, SYBYL_N4}) {
+            const uint8_t code = atom256::encode_from_sybyl(
+                sybyl, q, /*n_hydrogens=*/0, topo(4));
+            EXPECT_FALSE(atom256::get_hbond_donor(code))
+                << "sybyl=" << sybyl << " q=" << q;
+            EXPECT_FALSE(atom256::get_hbond_acceptor(code))
+                << "sybyl=" << sybyl << " q=" << q;
+        }
+    }
+}
+
+TEST(HbondAmineRoles, ProtonatedTertiaryAmineDonatesViaExplicitH) {
+    // R3NH+ : three heavy substituents but one explicit H. Topology alone reads
+    // "tertiary"; the H count is what reveals protonation.
+    for (float q : kChargeSweep) {
+        const uint8_t code =
+            atom256::encode_from_sybyl(SYBYL_N3, q, /*n_hydrogens=*/1, topo(3));
+        EXPECT_TRUE(atom256::get_hbond_donor(code)) << "q=" << q;
+    }
+}
+
+// ── sp3 oxygen: hydroxyl vs ether ───────────────────────────────────────────
+
+TEST(HbondAmineRoles, EtherOxygenIsAcceptorOnly) {
+    // R–O–R : two heavy substituents, no O–H.
+    for (float q : kChargeSweep) {
+        const uint8_t code =
+            atom256::encode_from_sybyl(SYBYL_O3, q, /*n_hydrogens=*/0, topo(2));
+        EXPECT_EQ(atom256::get_base(code), atom256::O_sp3) << "q=" << q;
+        EXPECT_FALSE(atom256::get_hbond_donor(code))
+            << "ether has no O-H, q=" << q;
+        EXPECT_TRUE(atom256::get_hbond_acceptor(code)) << "q=" << q;
+    }
+}
+
+TEST(HbondAmineRoles, HydroxylOxygenIsBothRoles) {
+    // R–OH : one heavy substituent.
+    for (float q : kChargeSweep) {
+        const uint8_t code =
+            atom256::encode_from_sybyl(SYBYL_O3, q, /*n_hydrogens=*/1, topo(1));
+        EXPECT_TRUE(atom256::get_hbond_donor(code)) << "q=" << q;
+        EXPECT_TRUE(atom256::get_hbond_acceptor(code)) << "q=" << q;
+    }
+}
+
+// ── byte-identity guarantee when topology is unavailable ────────────────────
+
+TEST(HbondAmineRoles, UnknownTopologyReproducesLegacyVerdict) {
+    // A default-constructed HbondTopology has known=false. Every base type, H
+    // count and charge must then yield exactly the pre-fix classification, so
+    // call sites without connectivity (e.g. PDB receptor atoms with bond[0]==0)
+    // are bit-for-bit unchanged.
+    const atom256::HbondTopology unknown{};
+    ASSERT_FALSE(unknown.known);
+
+    for (uint8_t base = 0; base < atom256::BASE_TYPE_COUNT; ++base) {
+        for (float q : kChargeSweep) {
+            for (int nh = 0; nh <= 3; ++nh) {
+                EXPECT_EQ(
+                    atom256::classify_hbond_donor(base, q, nh, unknown),
+                    atom256::classify_hbond_donor(base, q, nh))
+                    << "base=" << int(base) << " q=" << q << " nH=" << nh;
+                EXPECT_EQ(
+                    atom256::classify_hbond_acceptor(base, q, nh, unknown),
+                    atom256::classify_hbond_acceptor(base, q, nh))
+                    << "base=" << int(base) << " q=" << q << " nH=" << nh;
+            }
+        }
+    }
+}
+
+TEST(HbondAmineRoles, NonAmineBaseTypesUnaffectedByTopology) {
+    // The topology overload must only change verdicts for N_sp3, N_quat and
+    // O_sp3. Everything else delegates unchanged regardless of heavy count.
+    for (uint8_t base = 0; base < atom256::BASE_TYPE_COUNT; ++base) {
+        if (base == atom256::N_sp3 || base == atom256::N_quat ||
+            base == atom256::O_sp3)
+            continue;
+        for (int heavy = 0; heavy <= 4; ++heavy) {
+            for (float q : kChargeSweep) {
+                for (int nh = 0; nh <= 3; ++nh) {
+                    EXPECT_EQ(
+                        atom256::classify_hbond_donor(base, q, nh, topo(heavy)),
+                        atom256::classify_hbond_donor(base, q, nh))
+                        << "base=" << int(base) << " heavy=" << heavy;
+                    EXPECT_EQ(
+                        atom256::classify_hbond_acceptor(base, q, nh,
+                                                         topo(heavy)),
+                        atom256::classify_hbond_acceptor(base, q, nh))
+                        << "base=" << int(base) << " heavy=" << heavy;
+                }
+            }
+        }
+    }
+}

--- a/tests/test_hbond_amine_roles.cpp
+++ b/tests/test_hbond_amine_roles.cpp
@@ -13,6 +13,7 @@
 // 0.3f threshold; a classifier that reads charge cannot pass these.
 
 #include <gtest/gtest.h>
+#include <utility>
 #include "../LIB/atom_typing_256.h"
 
 namespace {
@@ -99,13 +100,92 @@ TEST(HbondAmineRoles, QuaternaryAmmoniumIsNeitherRole) {
     }
 }
 
-TEST(HbondAmineRoles, ProtonatedTertiaryAmineDonatesViaExplicitH) {
-    // R3NH+ : three heavy substituents but one explicit H. Topology alone reads
-    // "tertiary"; the H count is what reveals protonation.
+TEST(HbondAmineRoles, ProtonatedTertiaryAmineIsDonorOnlyNotAmphoteric) {
+    // R3NH+ : three heavy substituents plus one explicit H, formal charge NOT
+    // known (the SDF path supplies none). Coordination is 4, so the lone pair
+    // was spent forming the N-H — this is an ammonium, and it must NOT also
+    // advertise an acceptor role.
+    //
+    // Regression guard: an earlier revision let the donor test accept three
+    // independent forms of protonation evidence while the acceptor test
+    // consulted only the perceived formal charge. This case came out donor AND
+    // acceptor simultaneously, with a lone pair that does not exist. It is the
+    // R-NH+ centre this whole fix exists for.
     for (float q : kChargeSweep) {
+        atom256::HbondTopology t = topo(3);
+        ASSERT_FALSE(t.charge_known);
         const uint8_t code =
-            atom256::encode_from_sybyl(SYBYL_N3, q, /*n_hydrogens=*/1, topo(3));
-        EXPECT_TRUE(atom256::get_hbond_donor(code)) << "q=" << q;
+            atom256::encode_from_sybyl(SYBYL_N3, q, /*n_hydrogens=*/1, t);
+        EXPECT_TRUE(atom256::get_hbond_donor(code))
+            << "protonated tertiary amine must donate, q=" << q;
+        EXPECT_FALSE(atom256::get_hbond_acceptor(code))
+            << "lone pair is spent — must not also accept, q=" << q;
+    }
+}
+
+TEST(HbondAmineRoles, ProtonatedPrimaryAndSecondaryAminesAreDonorOnly) {
+    // Conjugate acids of 1° and 2° amines, evidenced by explicit H alone.
+    // R-NH3+ is (1 heavy + 3 H) and R2NH2+ is (2 heavy + 2 H): both reach
+    // coordination 4 and must lose the acceptor role.
+    for (float q : kChargeSweep) {
+        for (auto hc : {std::pair<int,int>{1,3}, std::pair<int,int>{2,2}}) {
+            const uint8_t code = atom256::encode_from_sybyl(
+                SYBYL_N3, q, /*n_hydrogens=*/hc.second, topo(hc.first));
+            EXPECT_TRUE(atom256::get_hbond_donor(code))
+                << "heavy=" << hc.first << " q=" << q;
+            EXPECT_FALSE(atom256::get_hbond_acceptor(code))
+                << "heavy=" << hc.first << " q=" << q;
+        }
+    }
+}
+
+TEST(HbondAmineRoles, NeutralAminesRemainAmphoteric) {
+    // The protonation test must not misfire on legitimately amphoteric neutral
+    // amines. Neutral sp3 N is 3-coordinate at every substitution level:
+    // R-NH2 (1+2), R2NH (2+1), R3N (3+0). All keep the acceptor role.
+    for (float q : kChargeSweep) {
+        for (auto hc : {std::pair<int,int>{1,2}, std::pair<int,int>{2,1},
+                        std::pair<int,int>{3,0}}) {
+            const uint8_t code = atom256::encode_from_sybyl(
+                SYBYL_N3, q, /*n_hydrogens=*/hc.second, topo(hc.first));
+            EXPECT_TRUE(atom256::get_hbond_acceptor(code))
+                << "neutral amine must accept, heavy=" << hc.first
+                << " nH=" << hc.second << " q=" << q;
+            EXPECT_EQ(atom256::get_hbond_donor(code), hc.second > 0)
+                << "donates iff it has N-H, heavy=" << hc.first << " q=" << q;
+        }
+    }
+}
+
+TEST(HbondAmineRoles, DonorAndAcceptorEvidenceAreSymmetric) {
+    // Structural invariant: for sp3 N, every (heavy, nH) combination the donor
+    // test reads as protonated must also be excluded by the acceptor test.
+    //
+    // The invariant is stated as "amphoteric implies coordination < 4", NOT
+    // "coordination == 3". Those differ when the H count is absent rather than
+    // genuinely zero: heavy=1, nH=0 is an amine whose hydrogens were never
+    // supplied, and the donor test infers N-H structurally from the low heavy
+    // count while the coordination sum under-counts. Falling back to amphoteric
+    // there is the conservative answer — it keeps the acceptor role the atom
+    // always had and adds the donor role it was missing. Protonation simply
+    // cannot be perceived when neither explicit H nor formal charge is present.
+    for (int heavy = 1; heavy <= 4; ++heavy) {
+        for (int nh = 0; nh <= 4; ++nh) {
+            for (float q : kChargeSweep) {
+                const bool d = atom256::classify_hbond_donor(
+                    atom256::N_sp3, q, nh, topo(heavy));
+                const bool a = atom256::classify_hbond_acceptor(
+                    atom256::N_sp3, q, nh, topo(heavy));
+                if (d && a)
+                    EXPECT_LT(heavy + nh, 4)
+                        << "amphoteric requires a free lone pair; heavy="
+                        << heavy << " nH=" << nh << " q=" << q;
+                if (heavy + nh >= 4)
+                    EXPECT_FALSE(a)
+                        << "no lone pair at coordination " << (heavy + nh)
+                        << "; heavy=" << heavy << " nH=" << nh;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What changed and why

`LIB/atom_typing_256.h`'s `classify_hbond_donor` opened with `(void)partial_charge;` and returned `false` unconditionally for `N_sp3`. `classify_hbond_acceptor` returned `partial_charge < 0.3f` for `N_sp`/`N_sp2`/`N_sp3`/`N_pl3`. Ligand partial charges are identically 0 on the PDB-derived SDF path, so that test was always true.

Net effect: **every ligand sp3 nitrogen entered scoring acceptor-only.** A protonated amine — the dominant CNS pharmacophore — had its H-bond roles exactly inverted and was pulled toward receptor donors, the geometric opposite of the correct pose. This was not gated off: `DatasetRunner.cpp:6053-6054` hardcodes `hbond_enabled` and `hbond_search_enabled` true in every benchmark config.

Charges could not have fixed this, and would have made it worse: the donor side was charge-independent, so populating charges makes a ligand ammonium fail `< 0.3f` and lose the acceptor bit too, leaving it with **no role at all**. The discriminator has to be topology.

This is the same bug class as `32c69455` (H-bond dead because `type256` was never populated); the lesson was never carried across to the amine roles.

### The fix

A new `HbondTopology` carrier holds heavy-atom substitution count, a perceived formal charge, and an explicit `charge_known` flag so "unknown" stays distinguishable from "zero". Topology overloads of `classify_hbond_donor`/`classify_hbond_acceptor`, `infer_hbond_roles` and `encode_from_sybyl` resolve amine and alcohol substitution by heavy-neighbour count; SYBYL `N.4` supplies its own formal charge. No ligand name or PDB code is special-cased, and the acceptor threshold is not flipped to compensate.

| case | before | after |
|---|---|---|
| 1°/2° amine (≤2 heavy) | acceptor only | donor + acceptor |
| 3° amine (3 heavy, no H) | acceptor only | acceptor only (unchanged) |
| 3° amine protonated (explicit H) | acceptor only | donor + acceptor |
| quaternary N (4 heavy) | acceptor only | neither |
| SYBYL N.4 | neither | donor, not acceptor |
| hydroxyl O (1 heavy) | acceptor only | donor + acceptor |
| ether O (2 heavy) | acceptor only | acceptor only (unchanged) |

## Byte-identity

Not gated — gating was unnecessary. When `topo.known` is false the overloads delegate to the existing 3-argument form. `UnknownTopologyReproducesLegacyVerdict` asserts this exhaustively over **every** base type × charge × H count, and `NonAmineBaseTypesUnaffectedByTopology` asserts that no base type outside `N_sp3`/`N_quat`/`O_sp3` changes verdict at any heavy count. Behaviour differs only where the classifier's verdict actually changes.

`top.cpp` gates `known` on `bond[0] > 0`. `SdfReader`/`Mol2Reader` populate `bond[0]` from the bond block, so ligands engage the fix; PDB receptor atoms that arrive without CONECT records have `bond[0] == 0`, and a fabricated heavy count of 0 would have read as a primary amine — they keep their previous verdict instead.

## Unit test

`tests/test_hbond_amine_roles.cpp`, 10 tests, registered as `HBondAmineRoleTests`. Every role assertion is swept across charges `{-0.8, -0.3, 0.0, 0.29, 0.3, 0.5, 1.0}`, spanning the old `0.3f` threshold in both directions — **a classifier that reads charge cannot pass these.** Covers protonated primary amine, secondary, tertiary, protonated tertiary, quaternary ammonium, ether O and hydroxyl O.

Full suite: **97/97 pass** (`ctest`, Release, `BUILD_TESTING=ON`). Clean build 1002/1002.

## Re-score: scope measured, geometric re-score not executable locally

**Scope census** — the shipped classifier run over the 85 real Astex ligand SDFs, old verdict vs new:

```
candidate atoms (sp3 N + sp3 O)   : 228
atoms whose role CHANGES          : 171  (75.0%)
  gained donor role               : 171
  lost (spurious) acceptor role   : 0
targets with >=1 changed atom     : 77 / 83
```

Because roles change on essentially every target, the hbond term changes for essentially every pose, and the re-score **cannot** be inferred from the existing CSV — it needs pose geometry. The 35,873 frozen pose libraries (13,393 MB) are archived to iCloud; `~/flexaidds_results/astex84_dG_20260809_141245/run/*/` retains only `result.csv` and `elected_pose.pdb.gz`. Restoring 13 GB onto a machine at 80 GB free and falling, with three campaigns running and `astex84_ref_rerun_*` queued needing ~15 GB, would risk starving that campaign. **I did not restore it, and the geometric re-score is deferred.**

What I could compute rigorously from the frozen CSV is the **sensitivity envelope** — how much the hbond term would have to move to change any election. Observed `|hbond|`: median 0.179, p90 1.663, **max 7.417** (92.7% of poses nonzero).

*Selection-gap targets* (sub-2Å pose exists, min-CF misses it) — CF deficit the correct pose must overcome:

```
1TZ8   0.057     1Q41   0.106     1YVF   3.728     1HNN   5.342
1N2V  13.454     1GPK  14.970     1G9V  15.339     1SQ5  18.128
1SG0  28.199     1R58  29.047     1JD0  30.647     2BR1  40.234
1X8X  50.765     1L2S  78.547     1Z95  99.744
```

Only **4 of 15** have a gap smaller than the largest hbond magnitude seen anywhere in the dataset.

*Currently-won targets*, margin over the best wrong pose: **5 of 26** sit below that same 7.417 bound (1UOU 0.273, 1MQ6 0.370, 1TW6 3.562, 2D3U 6.249, 1OQ5 7.272).

So the re-score envelope is at most ~9 targets movable in either direction, and only if role changes produce near-maximal hbond swings — which the work order's own leave-one-out result (removing hbond entirely costs exactly one target, 26 → 25) makes implausible. **Expected delta is small and could be zero or negative.**

## No rate claim

**No success-rate claim is made by this PR.** The frozen poses were *searched* under the old roles, so re-scoring them cannot demonstrate a rate change even once the geometry is restored; that requires a re-dock. This is a correctness fix — the physics was wrong — and it is landed so that future reweighting or charge work has correct roles underneath. The work order's own measurements bound the ceiling here: `|hbond|` median is 0.2% of `|CF|` median, and the weight sweep spans 25/84 → 27/84.

## Honest limitation

All 171 changes are *gained donor role*; **zero** spurious acceptor roles were removed. That is because these extracted SDFs carry no explicit H and no formal charges, so topology alone cannot detect that an amine is protonated — only that it is substituted. The fix therefore closes the missing-donor half of the defect universally, while the acceptor-suppression half fires only where `N.4` typing or 4-coordinate topology is available, which on this dataset is never. A protonated amine becomes correctly amphoteric rather than correctly donor-only. Closing the remaining half needs a protonation-state assignment (pKa model or explicit H), which is separate work.

The elec route stays closed and is not touched here: 0 of 85 Astex ligand SDFs contain `M  CHG`, and `assign_formal_charges.h` would need fixing first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core H-bond role bits used in scoring for ligands with bond lists; backward compatibility is explicit when topology is unknown, but bonded ligand typing shifts widely.
> 
> **Overview**
> Fixes inverted H-bond donor/acceptor bits for ligand **sp3 N** (and related **O**) on the PDB-derived SDF path, where partial charges are always zero so the old acceptor rule treated every such nitrogen as acceptor-only and never as a donor.
> 
> Adds **`HbondTopology`** and topology-aware overloads of **`classify_hbond_donor`**, **`classify_hbond_acceptor`**, **`infer_hbond_roles`**, and **`encode_from_sybyl`**. Amine and alcohol roles are inferred from heavy-neighbor count and coordination (with optional formal charge for **N.4** / quaternary N). When **`topo.known`** is false, behavior matches the legacy 3-argument classifiers.
> 
> **`top.cpp`** now passes topology into **`encode_from_sybyl`** only when **`bond[0] > 0`**, so bondless PDB receptor atoms keep prior verdicts. Python bindings pin the legacy **`encode_from_sybyl`** signature via a lambda. New unit test **`test_hbond_amine_roles`** registers as **`HBondAmineRoleTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8248120ffa60e22f4da45aa0d77c498f177a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->