### PR TITLE
Add: FLEXAIDDS_FITNESS_MODEL env gate (default SMFREE)

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -6161,7 +6161,15 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                    // Shannon-ON vs default A/B is a single-flag toggle on the same
                    // binary — no source fork. The flag is echoed into the per-case
                    // dock_config.json so the experiment arm is greppable on disk.
-                   <<    "    \"fitness_model\": \"SMFREE\"";  // v121: SMFREE e^(-CF/kT) overflows at docking CF~-80,kT=0.596 -> fitness=1000 for all -> GA=random sampler. v50b 81.2% relied on this: crystal-seed+exploration+5r-consensus finds native. PSHARE (ee9db7f9) optimizes correctly but converges to CF false-min -> 41.2%.
+                   // FLEXAIDDS_FITNESS_MODEL: default SMFREE (unset/empty) so every
+                   // existing number stays bit-identical. PSHARE is the 2016
+                   // production model. Unknown values fail-closed in ProtocolConfig.
+                   // v121: SMFREE e^(-CF/kT) overflows at docking CF~-80,kT=0.596 ->
+                   // fitness=1000 for all -> GA=random sampler. v50b 81.2% relied on
+                   // this: crystal-seed+exploration+5r-consensus finds native.
+                   // PSHARE (ee9db7f9) optimizes correctly but converges to CF
+                   // false-min -> 41.2%.
+                   <<    "    \"fitness_model\": \"" << protocol_cfg_.fitness_model << "\"";
                 if (protocol_cfg_.use_shannon) {
                     jf << ",\n    \"use_shannon\": true";
                 }

--- a/LIB/ProtocolConfig.cpp
+++ b/LIB/ProtocolConfig.cpp
@@ -75,6 +75,17 @@ void json_bool(std::ostringstream& o, const char* key, bool v, bool trailing_com
     if (trailing_comma) o << ',';
 }
 
+// DatasetRunner historically hardcoded ga.fitness_model = SMFREE. The env gate
+// keeps that default; PSHARE is the 2016 production model. Unknown values
+// fail-closed so a typo cannot silently run a third, unimplemented arm.
+std::string parse_fitness_model(const char* e) {
+    if (!e || e[0] == '\0') return "SMFREE";
+    if (std::strcmp(e, "SMFREE") == 0 || std::strcmp(e, "PSHARE") == 0) return e;
+    throw std::runtime_error(
+        std::string("FLEXAIDDS_FITNESS_MODEL: unknown value '") + e +
+        "' (accepted: SMFREE, PSHARE)");
+}
+
 }  // namespace
 
 ProtocolConfig ProtocolConfig::defaults() {
@@ -126,6 +137,7 @@ ProtocolConfig ProtocolConfig::from_env() {
     }
     // Historical DatasetRunner: presence of FLEXAIDDS_USE_SHANNON enables.
     cfg.use_shannon = env_present("FLEXAIDDS_USE_SHANNON");
+    cfg.fitness_model = parse_fitness_model(env_raw("FLEXAIDDS_FITNESS_MODEL"));
 
     // Ranking / emission + GA ablation (config_parser historical getenv sites).
     // Presence-only: unset keeps JSON/defaults; set applies override.
@@ -376,6 +388,7 @@ std::string ProtocolConfig::to_json() const {
         o << "\"diversity_monitoring\":null,";
     }
     json_bool(o, "use_shannon", use_shannon);
+    o << "\"fitness_model\":\"" << json_escape(fitness_model) << "\",";
     json_bool(o, "thermo_enabled", thermo_enabled);
     o << "\"t_eff\":" << t_eff << ',';
     o << "\"tencom_scale\":" << tencom_scale << ',';
@@ -470,6 +483,10 @@ ProtocolConfig ProtocolConfig::from_json(const std::string& json_text) {
         cfg.diversity_monitoring = root["diversity_monitoring"].as_bool(true);
     if (!root["use_shannon"].is_null())
         cfg.use_shannon = root["use_shannon"].as_bool(false);
+    if (!root["fitness_model"].is_null()) {
+        const std::string fm = root["fitness_model"].as_string("SMFREE");
+        cfg.fitness_model = parse_fitness_model(fm.c_str());
+    }
     if (!root["thermo_enabled"].is_null())
         cfg.thermo_enabled = root["thermo_enabled"].as_bool(false);
     if (!root["t_eff"].is_null())

--- a/LIB/ProtocolConfig.h
+++ b/LIB/ProtocolConfig.h
@@ -46,6 +46,12 @@ struct ProtocolConfig {
     /// True when FLEXAIDDS_VCT_ENTROPY_WEIGHT was present (apply_config gate).
     bool vct_entropy_weight_set{false};
     bool use_shannon{false};          ///< FLEXAIDDS_USE_SHANNON (presence)
+    /// GA fitness model emitted into dock_config.json `ga.fitness_model`.
+    /// Default SMFREE — bit-identical to the historical DatasetRunner hardcode.
+    /// FLEXAIDDS_FITNESS_MODEL=PSHARE selects classic rank + niche sharing
+    /// (2016 production). Unset or empty → SMFREE. Unknown values throw
+    /// (fail-closed; do not silently run a typo arm).
+    std::string fitness_model{"SMFREE"};  ///< FLEXAIDDS_FITNESS_MODEL
 
     // ── Ranking / emission + GA ablation (config_parser / engine) ─────────
     /// nullopt = env unset (keep JSON/default). true/false = explicit override.

--- a/LIB/flexaidds_flags.cpp
+++ b/LIB/flexaidds_flags.cpp
@@ -179,6 +179,7 @@ void seed_runtime_gates() {
     };
     static const char* kEnum[] = {
         "FLEXAIDDS_CLUSTER_REP",
+        "FLEXAIDDS_FITNESS_MODEL",
         "FLEXAIDDS_SEARCH",
         "FLEXAIDDS_POSEBUST_BACKEND",
         "FLEXAIDDS_NEW_SEARCH_ARCH",

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <stdexcept>
 #include <string>
 #include <unistd.h>
 
@@ -71,6 +72,7 @@ struct ClearProtocolEnv {
         , boom("FLEXAIDDS_BOOM_FRAC", nullptr)
         , n_elite("FLEXAIDDS_N_ELITE", nullptr)
         , shannon("FLEXAIDDS_USE_SHANNON", nullptr)
+        , fitness_model("FLEXAIDDS_FITNESS_MODEL", nullptr)
         , thermo("FLEXAIDDS_THERMO", nullptr)
         , t_eff("FLEXAIDDS_T_EFF", nullptr)
         , tencom("FLEXAIDDS_TENCOM_SCALE", nullptr)
@@ -123,7 +125,7 @@ struct ClearProtocolEnv {
         , elect_sing("FLEXAIDDS_ELECTION_INCLUDE_SINGLETONS", nullptr) {}
 
     ScopedEnv seed_base, restarts, parallel, max_conc, vct_r0, vct_norm, vct_ew,
-              sharing, boom, n_elite, shannon, thermo, t_eff, tencom,
+              sharing, boom, n_elite, shannon, fitness_model, thermo, t_eff, tencom,
               data_dir, oracle_dir, oracle_site, cleft, cf_win, cluster,
               seed_elit, seed_delta, freqsel, freq_a, freq_r, consensus,
               cl_spread, cl_popfrac, cl_ctau, cl_ck, cl_prad,
@@ -151,6 +153,7 @@ TEST(ProtocolConfig, DefaultsMatchHistoricalFallbacks) {
     EXPECT_FALSE(e.boom_frac.has_value());
     EXPECT_EQ(e.n_elite, 1);
     EXPECT_FALSE(e.use_shannon);
+    EXPECT_EQ(e.fitness_model, "SMFREE");
     EXPECT_FALSE(e.thermo_enabled);
     EXPECT_FLOAT_EQ(e.t_eff, 0.596f);
     EXPECT_FLOAT_EQ(e.tencom_scale, 1.0f);
@@ -257,6 +260,44 @@ TEST(ProtocolConfig, PresenceFlagsAndParallelRestarts) {
     // Explicit parallel=1 but restarts==1 → parallel stays false.
     EXPECT_FALSE(cfg.parallel_restarts);
     EXPECT_TRUE(cfg.parallel_restarts_explicit);
+}
+
+TEST(ProtocolConfig, FitnessModelFromEnv) {
+    // Unset / empty → SMFREE (DatasetRunner historical hardcode; bit-identical default).
+    {
+        ClearProtocolEnv clear;
+        EXPECT_EQ(flexaids::ProtocolConfig::from_env().fitness_model, "SMFREE");
+        EXPECT_EQ(flexaids::ProtocolConfig::defaults().fitness_model, "SMFREE");
+    }
+    {
+        ClearProtocolEnv clear;
+        ScopedEnv empty("FLEXAIDDS_FITNESS_MODEL", "");
+        EXPECT_EQ(flexaids::ProtocolConfig::from_env().fitness_model, "SMFREE");
+    }
+    {
+        ClearProtocolEnv clear;
+        ScopedEnv pshare("FLEXAIDDS_FITNESS_MODEL", "PSHARE");
+        const auto cfg = flexaids::ProtocolConfig::from_env();
+        EXPECT_EQ(cfg.fitness_model, "PSHARE");
+        EXPECT_NE(cfg.to_json().find("\"fitness_model\":\"PSHARE\""), std::string::npos);
+        const auto round = flexaids::ProtocolConfig::from_json(cfg.to_json());
+        EXPECT_EQ(round.fitness_model, "PSHARE");
+    }
+    {
+        ClearProtocolEnv clear;
+        ScopedEnv smfree("FLEXAIDDS_FITNESS_MODEL", "SMFREE");
+        EXPECT_EQ(flexaids::ProtocolConfig::from_env().fitness_model, "SMFREE");
+    }
+    {
+        ClearProtocolEnv clear;
+        ScopedEnv typo("FLEXAIDDS_FITNESS_MODEL", "LINEAR");
+        EXPECT_THROW(flexaids::ProtocolConfig::from_env(), std::runtime_error);
+    }
+    {
+        ClearProtocolEnv clear;
+        ScopedEnv typo("FLEXAIDDS_FITNESS_MODEL", "pshare");
+        EXPECT_THROW(flexaids::ProtocolConfig::from_env(), std::runtime_error);
+    }
 }
 
 TEST(ProtocolConfig, MaxConcurrentRestartsFromEnvAndJsonRoundTrip) {


### PR DESCRIPTION
## Summary
- Add `FLEXAIDDS_FITNESS_MODEL` env override (SMFREE default, PSHARE accepted, unknown values fail-closed) so a 2016-style PSHARE arm can run without changing default scoring.
- Wire through ProtocolConfig → DatasetRunner JSON `fitness_model`; leave unset path bit-identical to SMFREE.
- Unit tests for empty/unset/PSHARE/reject paths.

## Test plan
- [ ] `ctest` / ProtocolConfigTests (or `test_protocol_config`) pass
- [ ] Unset env → emitted dock_config has `"fitness_model": "SMFREE"`
- [ ] `FLEXAIDDS_FITNESS_MODEL=PSHARE` → `"fitness_model": "PSHARE"`
- [ ] Invalid value (e.g. LINEAR) fails closed
- [ ] Do not launch WO-2 / 20-target PSHARE arm from this PR alone


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable fitness-model selection through runtime settings and JSON configuration.
  * Supports `SMFREE` (default) and `PSHARE` fitness models.
  * Selected fitness models are preserved in serialized configuration output.

* **Bug Fixes**
  * Invalid or incorrectly cased fitness-model values are now rejected instead of silently accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->