### PR TITLE
Fix: unred CMake Configure (orphan test_rescore_pool_loader)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1312,6 +1312,13 @@ if(BUILD_TESTING)
         TEST_NAME TencomLedgerTests
     )
 
+    # test_rescore_pool_loader — serial-mapped pose PDB → coordinate-slot loader
+    # (header-only flexaids::load_complex_coor_from_pdb; no engine state).
+    flexaids_add_unit_test(test_rescore_pool_loader
+        SOURCES tests/test_rescore_pool_loader.cpp
+        TEST_NAME RescorePoolLoaderTests
+    )
+
     # test_json_config — JSON parser & config defaults tests (zero dependencies)
     flexaids_add_unit_test(test_json_config
         SOURCES tests/test_json_config.cpp

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -814,6 +814,14 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 	safe_remark_cat(remark, tmpremark, &remark_len);
 	snprintf(tmpremark, MAX_REMARK, "REMARK CF.app=%8.5f\n", Rep->chrom->app_evalue);
 	safe_remark_cat(remark, tmpremark, &remark_len);
+	// Before per-residue CF blocks: those can fill the 5k REMARK cap and
+	// silently drop a trailing ledger line (safe_remark_cat is fail-closed).
+	if (this->Population && this->Population->FA) {
+		append_tencom_lambda_ledger_remark(
+			remark, &remark_len,
+			this->Population->atoms, this->Population->residue,
+			this->Population->FA->res_cnt);
+	}
 
 	for (int j = 0; j < this->Population->FA->num_optres; ++j)
 	{
@@ -891,12 +899,6 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 		safe_remark_cat(remark, tmpremark, &remark_len);
 		snprintf(tmpremark, MAX_REMARK, "REMARK pose_rank = 1\n");
 		safe_remark_cat(remark, tmpremark, &remark_len);
-		if (this->Population && this->Population->FA) {
-			append_tencom_lambda_ledger_remark(
-				remark, &remark_len,
-				this->Population->atoms, this->Population->residue,
-				this->Population->FA->res_cnt);
-		}
 	}
 	for (int j = 0; j < this->Population->FA->npar; ++j)
 	{
@@ -984,6 +986,12 @@ void BindingMode::output_dynamic_BindingMode(int num_result, char* end_strfile, 
 		safe_remark_cat(remark, tmpremark, &remark_len);
 		snprintf(tmpremark, MAX_REMARK, "REMARK CF.app=%8.5f\n", Pose->chrom->app_evalue);
 		safe_remark_cat(remark, tmpremark, &remark_len);
+		if (this->Population && this->Population->FA) {
+			append_tencom_lambda_ledger_remark(
+				remark, &remark_len,
+				this->Population->atoms, this->Population->residue,
+				this->Population->FA->res_cnt);
+		}
 
 		for (int j = 0; j < this->Population->FA->num_optres; ++j)
 		{
@@ -1059,12 +1067,6 @@ void BindingMode::output_dynamic_BindingMode(int num_result, char* end_strfile, 
 			safe_remark_cat(remark, tmpremark, &remark_len);
 			snprintf(tmpremark, MAX_REMARK, "REMARK pose_rank = %d\n", nModel);
 			safe_remark_cat(remark, tmpremark, &remark_len);
-			if (this->Population && this->Population->FA) {
-				append_tencom_lambda_ledger_remark(
-					remark, &remark_len,
-					this->Population->atoms, this->Population->residue,
-					this->Population->FA->res_cnt);
-			}
 		}
 
 		for (int j = 0; j < this->Population->FA->npar; ++j)

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -65,6 +65,23 @@ void format_vibrational_diagnostic_remark(char* buf, size_t buflen, double vib_c
 		vib_corr);
 }
 
+namespace {
+
+// Ledger-only tENCoM λ REMARK. Must not be called from compute_energy().
+void append_tencom_lambda_ledger_remark(
+    char* remark, size_t* remark_len,
+    atom* atoms, resid* residue, int res_cnt)
+{
+    if (!flexaids::ledger_tencom_lambda_enabled()) return;
+    const flexaids::TencomLambdaLedger rec =
+        flexaids::collect_tencom_lambda_from_atoms(atoms, residue, res_cnt);
+    const std::string line = flexaids::format_tencom_lambda_remark(rec);
+    if (!line.empty())
+        safe_remark_cat(remark, line.c_str(), remark_len);
+}
+
+}  // namespace
+
 static void append_gated_cf_term_remarks(char* remark, size_t* remark_len,
                                          char* tmpremark, const cfstr* pCF)
 {

--- a/LIB/rescore_pool.h
+++ b/LIB/rescore_pool.h
@@ -90,16 +90,21 @@ inline bool load_complex_coor_from_pdb(const char* pdb_path,
         if (!is_atom && !truncated) continue;
         if (!is_atom) { continue; }  // drained non-record tail counts as nothing
         if (std::strlen(buf) < 54) { ++skipped; continue; }
+        // PDB atom serial is columns 7–11. A digit in column 12 means the
+        // writer overflowed the field (e.g. HETATM4294967297); do not accept
+        // the truncated 5-byte prefix, which would otherwise collide with a
+        // legitimate serial (42949) and poison that slot.
+        if (buf[11] >= '0' && buf[11] <= '9') { ++skipped; continue; }
         char serial_buf[8];
         std::memcpy(serial_buf, buf + 6, 5);
         serial_buf[5] = '\0';
         char* endp = nullptr;
         const long serial = std::strtol(serial_buf, &endp, 10);
         if (endp == serial_buf) { ++skipped; continue; }
-        // Worst-case guard: out-of-int-range serials must NOT be truncated by
-        // the int cast (e.g. 4294967297 would wrap onto serial 1 and silently
-        // poison a mapped slot's coordinates).
-        if (serial < -2147483647L - 1 || serial > 2147483647L) { ++skipped; continue; }
+        // PDB serials are 1-based. Refuse 0/negative and values that would
+        // wrap on an int cast (the 5-column field cannot exceed INT_MAX, but
+        // keep the bound so a wider parse cannot poison slot 1).
+        if (serial < 1 || serial > 2147483647L) { ++skipped; continue; }
         auto it = serial_to_slot.find(static_cast<int>(serial));
         if (it == serial_to_slot.end()) {
             ++skipped;

--- a/LIB/rescore_pool.h
+++ b/LIB/rescore_pool.h
@@ -101,6 +101,14 @@ inline bool load_complex_coor_from_pdb(const char* pdb_path,
         char* endp = nullptr;
         const long serial = std::strtol(serial_buf, &endp, 10);
         if (endp == serial_buf) { ++skipped; continue; }
+        // strtol stops at the first non-digit. "   1A" would otherwise become
+        // serial 1 and pass ligand-completeness. Trailing field bytes must
+        // be spaces only (PDB right-justified serials).
+        bool rest_ok = true;
+        for (const char* p = endp; *p != '\0'; ++p) {
+            if (*p != ' ') { rest_ok = false; break; }
+        }
+        if (!rest_ok) { ++skipped; continue; }
         // PDB serials are 1-based. Refuse 0/negative and values that would
         // wrap on an int cast (the 5-column field cannot exceed INT_MAX, but
         // keep the bound so a wider parse cannot poison slot 1).
@@ -118,6 +126,7 @@ inline bool load_complex_coor_from_pdb(const char* pdb_path,
         float x, y, z;
         if (std::sscanf(buf + 30, "%f%f%f", &x, &y, &z) != 3) { ++skipped; continue; }
         const int slot = it->second;
+        if (slot < 0) { ++skipped; continue; }
         coor_out[slot * 3 + 0] = x;
         coor_out[slot * 3 + 1] = y;
         coor_out[slot * 3 + 2] = z;

--- a/tests/test_rescore_pool_loader.cpp
+++ b/tests/test_rescore_pool_loader.cpp
@@ -18,10 +18,11 @@
 
 #include "rescore_pool.h"
 
+#include <cstdio>
 #include <cstdlib>
-#include <sys/stat.h>
 #include <fstream>
 #include <string>
+#include <sys/stat.h>
 #include <unordered_map>
 
 namespace {
@@ -53,7 +54,7 @@ TEST(RescorePoolLoader, MapsSerialsToSlotsAndSkipsUnknowns)
     // Deliberately sparse map: serial 5 is unmapped and must be SKIPPED, not
     // silently compacted — a compaction bug would shift every later atom.
     std::unordered_map<int,int> m{{1, 7}, {100, 0}, {102, 3}};
-    float coor[4 * 3] = {};
+    float coor[8 * 3] = {};  // slot 7 is in-range; 4 slots would OOB under ASan
     int matched = -1, skipped = -1;
 
     const std::string path = write_temp("rescore_loader_ok.pdb", kPosePdb);
@@ -112,21 +113,22 @@ TEST(RescorePoolLoader, MalformedCoordinateLineIsSkippedNotFatal)
 
 TEST(RescorePoolLoader, OutOfIntRangeSerialDoesNotPoisonMappedSlot)
 {
-    // 4294967297 mod 2^32 == 1: a naive int cast would collide with serial 1
-    // and overwrite slot A's coordinates with garbage.
+    // 5-column parse of HETATM4294967297 is 42949. Put that key in the map so
+    // accepting the truncated prefix would write -9 into slot 2.
     const std::string pdb =
         "HETATM   1  N1  LIG B   1       1.000   2.000   3.000  1.00  0.00           N\n"
         "HETATM4294967297  XX  LIG B   1     -9.000  -9.000  -9.000  1.00  0.00           C\n";
     const std::string path = write_temp("rescore_overflow.pdb", pdb);
-    std::unordered_map<int,int> m{{1, 5}};
+    std::unordered_map<int,int> m{{1, 5}, {42949, 2}};
     float coor[6 * 3] = {};
     int matched = -1, skipped = -1;
     ASSERT_TRUE(flexaids::load_complex_coor_from_pdb(
         path.c_str(), m, coor, &matched, &skipped));
     EXPECT_EQ(matched, 1);
-    EXPECT_EQ(skipped, 1);  // the overflowing serial is refused, not wrapped
+    EXPECT_EQ(skipped, 1);  // overlong serial field is refused, not truncated
     EXPECT_FLOAT_EQ(coor[5 * 3 + 0], 1.0f);
     EXPECT_FLOAT_EQ(coor[5 * 3 + 1], 2.0f);
+    EXPECT_FLOAT_EQ(coor[2 * 3 + 0], 0.0f);  // collision slot stays empty
 }
 
 TEST(RescorePoolLoader, NegativeSerialIsSkipped)
@@ -135,14 +137,16 @@ TEST(RescorePoolLoader, NegativeSerialIsSkipped)
         "HETATM  -7  X1  LIG B   1       9.000   9.000   9.000  1.00  0.00           C\n"
         "HETATM   2  N1  LIG B   1       1.000   1.000   1.000  1.00  0.00           N\n";
     const std::string path = write_temp("rescore_neg.pdb", pdb);
-    std::unordered_map<int,int> m{{2, 0}};
-    float coor[3] = {};
+    // Include -7 so a loader that only skips unmapped keys would write slot 1.
+    std::unordered_map<int,int> m{{2, 0}, {-7, 1}};
+    float coor[2 * 3] = {};
     int matched = -1, skipped = -1;
     ASSERT_TRUE(flexaids::load_complex_coor_from_pdb(
         path.c_str(), m, coor, &matched, &skipped));
     EXPECT_EQ(matched, 1);
     EXPECT_EQ(skipped, 1);
     EXPECT_FLOAT_EQ(coor[0], 1.0f);
+    EXPECT_FLOAT_EQ(coor[1 * 3 + 0], 0.0f);
 }
 
 TEST(RescorePoolLoader, DuplicateSerialsLastWriteWinsAndCountsBoth)
@@ -252,6 +256,12 @@ TEST(RescorePoolLoader, UnreadableFileFailsClosed)
     const std::string path = write_temp("rescore_unreadable.pdb",
                                         "HETATM   1  C   LIG B   1       0.000   0.000   0.000\n");
     ::chmod(path.c_str(), 0000);
+    if (FILE* probe = std::fopen(path.c_str(), "r")) {
+        std::fclose(probe);
+        ::chmod(path.c_str(), 0644);
+        GTEST_SKIP() << "process can open chmod 000 files (privileged); "
+                        "EACCES path is not testable here";
+    }
     std::unordered_map<int,int> m{{1, 0}};
     float coor[3] = {};
     int matched = -1, skipped = -1;

--- a/tests/test_rescore_pool_loader.cpp
+++ b/tests/test_rescore_pool_loader.cpp
@@ -251,6 +251,25 @@ TEST(RescorePoolLoader, Utf8BomBeforeFirstRecordHandled)
     EXPECT_FLOAT_EQ(coor[4 * 3 + 0], 7.0f);
 }
 
+TEST(RescorePoolLoader, PartialSerialFieldIsRejected)
+{
+    // Columns 7–11 are "   1A". strtol would yield 1; map serial 1 so a
+    // prefix-accepting loader would write slot 0.
+    const std::string pdb =
+        "HETATM   1A C1  LIG B   1       9.000   9.000   9.000  1.00  0.00           C\n"
+        "HETATM   2  N1  LIG B   1       1.000   1.000   1.000  1.00  0.00           N\n";
+    const std::string path = write_temp("rescore_partial_serial.pdb", pdb);
+    std::unordered_map<int,int> m{{1, 0}, {2, 1}};
+    float coor[2 * 3] = {};
+    int matched = -1, skipped = -1;
+    ASSERT_TRUE(flexaids::load_complex_coor_from_pdb(
+        path.c_str(), m, coor, &matched, &skipped));
+    EXPECT_EQ(matched, 1);
+    EXPECT_EQ(skipped, 1);
+    EXPECT_FLOAT_EQ(coor[0], 0.0f);
+    EXPECT_FLOAT_EQ(coor[1 * 3 + 0], 1.0f);
+}
+
 TEST(RescorePoolLoader, UnreadableFileFailsClosed)
 {
     const std::string path = write_temp("rescore_unreadable.pdb",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

FlexAID CI on `main` dies at **CMake Configure** (~2 min, not compile/test) because STRICT source validation treats `tests/test_rescore_pool_loader.cpp` as an orphan. That file landed with the rescore-pool commits and was never listed in `CMakeLists.txt`.

This PR:

1. Registers `test_rescore_pool_loader` as a header-only gtest target so `FLEXAIDS_STRICT_SOURCE_VALIDATION=ON` configure succeeds.
2. Restores `append_tencom_lambda_ledger_remark` in `LIB/BindingMode.cpp` (call sites had survived; sanitizers/tsan/tier-2 then failed to compile).
3. Follow-up from Codex review: enlarge the MapsSerials coordinate buffer (ASan OOB on slot 7), fail-closed overlong/negative serial parse with collision-map tests, skip UnreadableFileFailsClosed when chmod 000 is still openable, and emit the opt-in tENCoM λ REMARK before per-residue CF blocks so it is not truncated by the 5k cap.
4. CodeRabbit: reject `std::strtol` prefix parses such as `"   1A"` → serial 1 before slot lookup/write, so a garbage serial cannot satisfy ligand-completeness. Skip negative mapped slots. Regression: `RescorePoolLoader.PartialSerialFieldIsRejected`.

GoogleTest stays pinned at FetchContent `v1.17.0`. Issue #458 is not this configure failure.

No docking-success claims and no baseline changes.

## Change class (pick **one** primary)

- [x] **Fix** — bug; default path unchanged, or fail-closed
- [ ] **Science enhancement** — opt-in; env-gated **OFF** (`flexaids::env_bool`)
- [ ] **Engine/code** — LIB/src behavior that is not a science gate
- [ ] **Docs / audit / swarm pack** — `docs/swarm/`, `docs/audit/` (own PR; do not mix with LIB)
- [ ] **Benchmark harness / frozen referee**
- [ ] **CI / hygiene**

`scripts/classify_diff.py` may print `engine-critical` from path buckets. Ranking and CF scoring are unchanged: the loader tests are offline rescore-path only, and the BindingMode helper emits a ledger REMARK behind `FLEXAIDDS_LEDGER_TENCOM_LAMBDA` (default off).

## Science-Impact

- [x] none (cannot move docked coordinates or CF ranking)
- [ ] gated OFF — flag name: `FLEXAIDDS_…`
- [ ] default-path (requires METHODOLOGY.md §1 parity)

## Scope

- [x] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [x] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [x] no user-facing release impact

## Validation

- [x] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [ ] documentation review
- [x] manual validation

Root cause from FlexAID CI run [32722516662](https://github.com/LeBonhommePharma/FlexAIDdS/actions/runs/32722516662): orphan `tests/test_rescore_pool_loader.cpp` under STRICT.

Local after CodeRabbit remainder-check (`5954579a`): `test_rescore_pool_loader` **12/12** Release and **12/12** with `-fsanitize=address,undefined` (g++-14), including `PartialSerialFieldIsRejected`.

GitHub on `5954579a`:

- **FlexAID CI** [33023130605](https://github.com/LeBonhommePharma/FlexAIDdS/actions/runs/33023130605): **success** (linux-gcc, linux-clang, linux-gcc-avx512, linux-gcc-asan, linux-gcc-mpi, macOS CPU, plus Python/hygiene/Metal smokes). Sanitizers and tsan also succeeded. Coverage 49.6% (≥ 45%).
- **Tier-1 Benchmark** [33023130543](https://github.com/LeBonhommePharma/FlexAIDdS/actions/runs/33023130543): the engine **ran** (4/4 subset targets, 10 poses each: 1gpk, 1mq6, 1xm6, 2cet; seed `20260816`). The job then failed the **aspirational** `expected_baselines.docking_power_top1: 0.70` gate (`astex_diverse.yaml`; YAML states these are not measured field state). Reported on this 4-target draw: docking_power_top1 **0.0000**, mean_rmsd **6.1199 Å**. That gate is unchanged; this PR does not lower it and does not treat 0.0 as a docking-success claim. Most recent engine PRs that actually dock hit the same class of fail; PoseBust-only PRs skip the dock via `scripts/tier1_pr_needs_dock.py`.

## Security and safety

- [x] no new third-party dependency
- [ ] third-party dependency added and documented
- [ ] no known security-sensitive parsing change
- [x] security-sensitive parsing change reviewed

Offline PDB serial parse is fail-closed (overlong field, serial < 1, and leftover non-space characters after `strtol` are skipped).

## Reproducibility

- [x] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Issue #458 (googletest v1.17.0 → v1.18.0) is left open on purpose.
Codex P1/P2 comments on the first SHA are addressed in later commits on this branch.
CodeRabbit discussion on partial serial fields (`1A`) is addressed in `5954579a`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8bfebab-a4b2-41f5-bce3-5735eae61c28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8bfebab-a4b2-41f5-bce3-5735eae61c28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of PDB atom serial numbers, rejecting invalid, zero, negative, and overflowed values instead of interpreting them incorrectly.
  - Ensured tENCoM λ ledger information is consistently retained in binding-mode and dynamic binding-mode output, even when output is large.

- **Tests**
  - Expanded coverage for coordinate loading, invalid serial numbers, negative mappings, and unreadable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->