### PR TITLE
[fix] Repair benchmark admission, pointer lifetimes and pose provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,11 +396,11 @@ jobs:
         env:
           FLEXAIDDS_REQUIRE_BUILD: '0'
         run: python3 .grok/skills/flexaidds/scripts/validate_skill.py
-      - name: Skill unit tests (figure handler + resolve_build + edge cases)
+      - name: Skill, claim admission and reproducibility gate tests
         env:
           FLEXAIDDS_REQUIRE_BUILD: '0'
           PYTHONPATH: ${{ github.workspace }}/python
-        run: python3 -m pytest tests/test_flexaid_skill.py tests/test_flexaidds_skill_figure.py tests/test_resolve_build.py tests/test_skill_edge_cases.py tests/test_aggregate_claim_metrics.py -q --tb=line
+        run: python3 -m pytest tests/test_flexaid_skill.py tests/test_flexaidds_skill_figure.py tests/test_resolve_build.py tests/test_skill_edge_cases.py tests/test_aggregate_claim_metrics.py tests/p0_claim_contract/test_fixed_denominator.py tests/test_engine_repro_gate.py -q --tb=line
 
   # New job: Validates the flexaidds skill's DatasetRunner features
   # (per-entry checkpointing, --resume + CostHistory, --package reproducibility)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1449,6 +1449,14 @@ if(BUILD_TESTING)
         TEST_NAME AtomPointerLifetimeTests
     )
 
+    flexaids_add_unit_test(test_ga_population_receipt
+        SOURCES tests/test_ga_population_receipt.cpp
+        TEST_NAME GaPopulationReceiptTests
+    )
+    if(TARGET OpenMP::OpenMP_CXX)
+        target_link_libraries(test_ga_population_receipt PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+
     # test_statmech — StatMechEngine unit tests
     flexaids_add_unit_test(test_statmech
         SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1444,6 +1444,11 @@ if(BUILD_TESTING)
     # flexaids_configure_msvc_test is provided by cmake/FlexAIDOptions.cmake
     # (single definition, available for all test targets below).
 
+    flexaids_add_unit_test(test_atom_pointer_lifetimes
+        SOURCES tests/test_atom_pointer_lifetimes.cpp
+        TEST_NAME AtomPointerLifetimeTests
+    )
+
     # test_statmech — StatMechEngine unit tests
     flexaids_add_unit_test(test_statmech
         SOURCES
@@ -2995,6 +3000,7 @@ flexaids_add_unit_test(test_protocol_config
             tests/test_hungarian_rmsd_bounds.cpp
             tests/hungarian_rmsd_stubs.cpp
             LIB/calc_rmsd.cpp
+            LIB/rot_gene_index.cpp
             LIB/geometry.cpp
         TEST_NAME HungarianRmsdBoundsTests
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1457,6 +1457,11 @@ if(BUILD_TESTING)
         target_link_libraries(test_ga_population_receipt PRIVATE OpenMP::OpenMP_CXX)
     endif()
 
+    flexaids_add_unit_test(test_pose_provenance
+        SOURCES tests/test_pose_provenance.cpp LIB/write_pdb.cpp LIB/fileio.cpp
+        TEST_NAME PoseProvenanceTests
+    )
+
     # test_statmech — StatMechEngine unit tests
     flexaids_add_unit_test(test_statmech
         SOURCES

--- a/LIB/AtomOptResBinding.h
+++ b/LIB/AtomOptResBinding.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "flexaid.h"
+
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace flexaids {
+
+// Capture ownership once from the master arrays. Selective atom refresh leaves
+// a mixture of master and workspace pointers, so rebinding must never infer an
+// index by subtracting a retained workspace pointer from the master allocation.
+class AtomOptResBinding {
+public:
+    AtomOptResBinding(std::span<const atom> master_atoms,
+                      std::span<const OptRes> master_optres)
+        : indices_(master_atoms.size(), no_optres), optres_count_(master_optres.size()) {
+        std::unordered_map<const OptRes*, std::size_t> owned_indices;
+        owned_indices.reserve(master_optres.size());
+        for (std::size_t i = 0; i < master_optres.size(); ++i)
+            owned_indices.emplace(&master_optres[i], i);
+
+        for (std::size_t i = 0; i < master_atoms.size(); ++i) {
+            if (master_atoms[i].optres == nullptr) continue;
+            const auto found = owned_indices.find(master_atoms[i].optres);
+            if (found == owned_indices.end())
+                throw FlexAIDException("Atom OptRes pointer is not owned by the master OptRes array");
+            indices_[i] = found->second;
+        }
+    }
+
+    // Read-only mapping shared by all evaluation threads. The arrays supplied
+    // here belong to one workspace; repeated calls are deliberately idempotent.
+    void bind(std::span<atom> workspace_atoms, std::span<OptRes> workspace_optres) const {
+        if (workspace_atoms.size() != indices_.size() ||
+            workspace_optres.size() != optres_count_)
+            throw FlexAIDException("Atom/OptRes workspace sizes changed after binding capture");
+        for (std::size_t i = 0; i < indices_.size(); ++i) {
+            const auto index = indices_[i];
+            workspace_atoms[i].optres = index == no_optres ? nullptr : &workspace_optres[index];
+        }
+    }
+
+private:
+    static constexpr std::size_t no_optres = static_cast<std::size_t>(-1);
+    std::vector<std::size_t> indices_;
+    std::size_t optres_count_;
+};
+
+}  // namespace flexaids

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -8,25 +8,8 @@
 #include "fast_optics.hpp"
 #include "SoftBetaFreeEnergy.h"
 #include "RngSeed.h"
+#include "PoseProvenance.h"
 #include "tencom_ledger.h"
-
-// Build provenance, normally injected by CMakeLists.txt via
-// add_compile_definitions().  Defaulted here so a build outside CMake (or one
-// where git was unavailable and the rev-parse produced nothing) still compiles
-// and still emits an honest, obviously-unknown value rather than failing.
-#ifndef FLEXAIDS_GIT_COMMIT
-#define FLEXAIDS_GIT_COMMIT "unknown"
-#endif
-// 0 = clean, 1 = dirty, 2 = unknown.  This default was 0, which made the
-// comment above ("still emits an honest, obviously-unknown value") true of
-// FLEXAIDS_GIT_COMMIT and false of this macro: a build that reached the
-// fallback stamped `FLEXAID.dirty=0` into every pose it wrote -- a positive
-// assertion that the tree was clean, produced by the very code path that
-// exists because nothing was known about the tree.  `unknown` and `clean` are
-// not the same claim, and 0 is not available to say the first one.
-#ifndef FLEXAIDS_GIT_DIRTY
-#define FLEXAIDS_GIT_DIRTY 2
-#endif
 
 #include <algorithm>
 #include <cfloat>
@@ -850,14 +833,7 @@ void BindingMode::output_BindingMode(int num_result, char* end_strfile, char* tm
 	// therefore in the only region truncation cannot reach first -- which is
 	// where the line identifying the whole file belongs.  Moving it down would
 	// make the provenance the first thing lost on a REMARK-heavy target.
-	snprintf(tmpremark, MAX_REMARK,
-		"REMARK FLEXAID.commit=%s FLEXAID.dirty=%d FLEXAID.seed=%llu\n",
-		FLEXAIDS_GIT_COMMIT,
-		FLEXAIDS_GIT_DIRTY,
-		flexaids_rng::has_master_seed()
-			? static_cast<unsigned long long>(flexaids_rng::master_seed())
-			: 0ULL);
-	safe_remark_cat(remark, tmpremark, &remark_len);
+	safe_remark_cat(remark, flexaids::pose_provenance::remark().c_str(), &remark_len);
 
 	if (pb_promotion) {
 		snprintf(tmpremark, MAX_REMARK,
@@ -1188,13 +1164,16 @@ void BindingMode::output_dynamic_BindingMode(int num_result, char* end_strfile, 
 
 		snprintf(sufix, sizeof(sufix), "_%d_MODEL_%d.pdb", minPoints, num_result);
 		snprintf(tmp_end_strfile, MAX_PATH__, "%s%s", end_strfile, sufix);
+		// Only the first MODEL writes this expanded header. Preserve the
+		// complete pre-existing scientific buffer when adding provenance.
+		std::string pose_remarks = flexaids::pose_provenance::add_to_remarks(remark);
 		if (Pose == this->Poses.begin() && Pose + 1 == this->Poses.end())
 		{
-			write_MODEL_pdb(true, true, nModel, this->Population->FA, this->Population->atoms, this->Population->residue, tmp_end_strfile, remark);
+			write_MODEL_pdb(true, true, nModel, this->Population->FA, this->Population->atoms, this->Population->residue, tmp_end_strfile, pose_remarks.data());
 		}
 		else if (Pose == this->Poses.begin())
 		{
-			write_MODEL_pdb(true, false, nModel, this->Population->FA, this->Population->atoms, this->Population->residue, tmp_end_strfile, remark);
+			write_MODEL_pdb(true, false, nModel, this->Population->FA, this->Population->atoms, this->Population->residue, tmp_end_strfile, pose_remarks.data());
 		}
 		else if (Pose + 1 == this->Poses.end())
 		{

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -5530,18 +5530,19 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset() << " BenchmarkMode:    " << mode_label << "\n";
     }
 
+    // Argv-only hash helpers — no shell (security harden from main).
+    auto md5_of = [](const std::string& path) -> std::string {
+        if (path.empty() || !fs::exists(path) || !is_safe_exec_path(path)) return "";
+        std::string t = run_argv_first_token({"md5", "-q", path});
+        if (t.empty()) t = run_argv_first_token({"md5sum", path});
+        return t;
+    };
+
     // ── RUN_RECEIPT.json + legacy provenance.json ─────────────────────────
     // Align with C0 iCloud launch scripts: matrix/binary hashes, GA knobs,
     // mode, seed flags, and a full ProtocolConfig JSON snapshot. Best-effort:
     // failure here must not block docking.
     {
-        // Argv-only hash helpers — no shell (security harden from main).
-        auto md5_of = [](const std::string& path) -> std::string {
-            if (path.empty() || !fs::exists(path) || !is_safe_exec_path(path)) return "";
-            std::string t = run_argv_first_token({"md5", "-q", path});
-            if (t.empty()) t = run_argv_first_token({"md5sum", path});
-            return t;
-        };
         auto sha256_of = [](const std::string& path) -> std::string {
             if (path.empty() || !fs::exists(path) || !is_safe_exec_path(path)) return "";
             std::string t = flexaids::posebust::sha256_file(path);
@@ -5912,6 +5913,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
         float cached_csv_best_score = 0.0f;
         float cached_csv_predicted_dg = 0.0f;
         int cached_csv_num_poses = 0;
+        int cached_docking_exit_code = -1;
+        bool cached_docking_completed = false;
         double cached_csv_wall_time_s = 0.0;
         if (!ignore_cache && config.skip_completed && fs::exists(out_dir)) {
             int cached_poses = 0;
@@ -5993,7 +5996,13 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         cached_csv_best_score = parse_float_cell("best_score", 0.0f);
                         cached_csv_predicted_dg = parse_float_cell("predicted_dG", 0.0f);
                         cached_csv_num_poses = parse_int_cell("num_poses", 0);
+                        result.matrix_md5 = cell_for("matrix_md5");
                         cached_csv_wall_time_s = parse_double_cell("wall_time_s", 0.0);
+                        // A pose or stale success flag does not witness a child
+                        // exit. Legacy cache rows remain explicitly unwitnessed.
+                        cached_docking_exit_code = docking_exit_code_or_unknown(cell_for("docking_exit_code"));
+                        const auto completed = cell_for("docking_completed");
+                        cached_docking_completed = completed == "1" || completed == "true" || completed == "True";
                     }
                 }
             } catch (...) {
@@ -6012,8 +6021,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             }
         }
 
-        // ret is initialised to 0; for cached runs we never call exec_cmd so
-        // the success condition (ret == 0 && n_poses > 0 && !stuck) still works.
+        // Cached execution status is read separately from its receipt; the
+        // initial value of ret must not manufacture a successful child exit.
         int ret = 0;
 
         if (!skip) {
@@ -6855,6 +6864,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             // Paths are shell_quote'd: dock still uses /bin/sh -c for env
             // prefixes + stdout/stderr redirection (fork_exec_argv cannot).
             std::string data_dir_arg;
+            std::string selected_matrix_path;
             {
                 // FLEXAIDDS_DATA_DIR remains the explicit matrix-swap hook for
                 // controlled A/B tests. Normal runs prefer data staged beside
@@ -6869,6 +6879,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                             "FLEXAIDDS_DATA_DIR/path is unsafe for shell (NUL/newline/control)");
                     }
                     data_dir_arg = " --data-dir " + shell_quote(canon) + " ";
+                    selected_matrix_path = canon + "/MC_st0r5.2_6.dat";
                 } else {
                     std::string bin_dir = flexaidds_bin;
                     auto slash = bin_dir.rfind('/');
@@ -6878,12 +6889,15 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     if (fs::exists(staged_candidate + "/MC_st0r5.2_6.dat")) {
                         data_dir_arg = " --data-dir " +
                                        shell_quote(fs::canonical(staged_candidate).string()) + " ";
+                        selected_matrix_path = staged_candidate + "/MC_st0r5.2_6.dat";
                     } else if (fs::exists(wrk_candidate + "/MC_st0r5.2_6.dat")) {
                         data_dir_arg = " --data-dir " +
                                        shell_quote(fs::canonical(wrk_candidate).string()) + " ";
+                        selected_matrix_path = wrk_candidate + "/MC_st0r5.2_6.dat";
                     }
                 }
             }
+            result.matrix_md5 = md5_of(selected_matrix_path);
             // ── Per-worker OMP thread budget ──────────────────────────
             // Each FlexAIDdS subprocess inherits the parent environment, so
             // OMP_NUM_THREADS must be set explicitly in the command string.
@@ -7580,7 +7594,12 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
 
         // Runtime completion is tracked separately from benchmark success.
         // The latter is only true once we have a valid pose RMSD under 2 Å.
-        const bool docking_completed = (ret == 0 && n_poses > 0 && !result.stuck);
+        result.docking_exit_code = skip ? cached_docking_exit_code : ret;
+        const bool docking_completed = (result.docking_exit_code == 0 && n_poses > 0 &&
+                                        !result.stuck && (!skip || cached_docking_completed));
+        result.docking_completed = docking_completed;
+        if (!docking_completed && result.rmsd_fail_reason == "none")
+            result.rmsd_fail_reason = "docking_incomplete";
 
         // If the dock produced no output, surface stderr for clues.
         //
@@ -7598,7 +7617,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 std::string err_line;
                 int err_lines = 0;
                 std::cerr << "  [WARN] " << entry.pdb_id
-                          << " produced no output poses (exit " << ret
+                          << " produced no output poses (exit " << result.docking_exit_code
                           << "). stderr:\n";
                 while (std::getline(stderr_file, err_line) && err_lines < 5) {
                     std::cerr << "    " << err_line << "\n";
@@ -8681,7 +8700,7 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                            "compensation_ratio,TdS_shannon_gen500,TdS_shannon_gen1000,"
                            "cf_best_cluster,"
                            "report_T,I_ES,CF_r2s,binding_regime,ensemble_log_Z,"
-                           "rmsd_fail_reason\n";
+                           "rmsd_fail_reason,docking_exit_code,docking_completed,matrix_md5\n";
                     ofs << std::fixed << std::setprecision(4)
                         << result.pdb_id << ","
                         << result.best_score << ","
@@ -8766,7 +8785,8 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         << result.thermo_CF_r2s << ","
                         << "\"" << result.thermo_binding_regime << "\","
                         << result.ensemble_log_Z << ","
-                        << result.rmsd_fail_reason << "\n";
+                        << result.rmsd_fail_reason << "," << result.docking_exit_code
+                        << "," << (result.docking_completed ? 1 : 0) << "," << result.matrix_md5 << "\n";
                 }
             } catch (...) {
                 // Per-complex CSV is best-effort; failures are non-fatal.
@@ -8942,22 +8962,13 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
             static_cast<double>(claim_ready_count) / report.total_systems;
     }
 
-    // Mean RMSD
-    if (!rmsds.empty()) {
-        report.mean_rmsd = std::accumulate(rmsds.begin(), rmsds.end(), 0.0) / rmsds.size();
-    }
-
-    // Median RMSD
-    if (!rmsds.empty()) {
-        auto sorted = rmsds;
-        std::sort(sorted.begin(), sorted.end());
-        size_t mid = sorted.size() / 2;
-        if (sorted.size() % 2 == 0) {
-            report.median_rmsd = (sorted[mid - 1] + sorted[mid]) / 2.0;
-        } else {
-            report.median_rmsd = sorted[mid];
-        }
-    }
+    const auto rmsd_summary = summarize_rmsds(rmsds);
+    report.valid_rmsd_count = static_cast<int>(rmsd_summary.count);
+    report.mean_rmsd = rmsd_summary.mean;
+    report.median_rmsd = rmsd_summary.median;
+    report.completed_systems = static_cast<int>(std::count_if(
+        report.results.begin(), report.results.end(),
+        [](const DockingResult& r) { return r.docking_completed; }));
 
     // Correlation metrics
     if (pred_affinities.size() >= 3) {
@@ -9021,8 +9032,15 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
         ofs << "| Success rate (legacy == RMSD-only) | "
             << (report.success_rate * 100.0) << "% |\n";
         ofs << std::setprecision(2);
-        ofs << "| Mean elected ordered RMSD (Å) | " << report.mean_rmsd << " |\n";
-        ofs << "| Median elected ordered RMSD (Å) | " << report.median_rmsd << " |\n";
+        ofs << "| Runtime-completed systems | " << report.completed_systems << " |\n";
+        ofs << "| Valid elected ordered RMSDs | " << report.valid_rmsd_count << " |\n";
+        ofs << "| Mean elected ordered RMSD (Å) | ";
+        if (report.valid_rmsd_count > 0 && std::isfinite(report.mean_rmsd)) ofs << report.mean_rmsd;
+        else ofs << "NA";
+        ofs << " |\n| Median elected ordered RMSD (Å) | ";
+        if (report.valid_rmsd_count > 0 && std::isfinite(report.median_rmsd)) ofs << report.median_rmsd;
+        else ofs << "NA";
+        ofs << " |\n";
         ofs << "| Affinity pairs | " << report.affinity_pairs << " |\n";
         ofs << "\n**Notes:** Headline claim success is **claim_ready** only "
                "(ordered RMSD ≤2 Å + official PoseBusters + tENCoM/Eigen + hash "
@@ -9169,7 +9187,7 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
         }
         // Appended at END (not mid-header): column names are position-stable
         // for live campaigns; new diagnostics go last.
-        ofs << ",rmsd_fail_reason\n";
+        ofs << ",rmsd_fail_reason,docking_exit_code,docking_completed,matrix_md5,pb_ran,pb_n_checks,pb_n_pass,pb_n_fail\n";
 
         for (const auto& r : report.results) {
             ofs << std::fixed << std::setprecision(4)
@@ -9237,7 +9255,10 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
                     << "," << r.thermo_CF_r2s
                     << ",\"" << r.thermo_binding_regime << "\"";
             }
-            ofs << "," << r.rmsd_fail_reason << "\n";
+            ofs << "," << r.rmsd_fail_reason << "," << r.docking_exit_code
+                << "," << (r.docking_completed ? 1 : 0) << "," << r.matrix_md5
+                << "," << (r.pb_ran ? 1 : 0) << "," << r.pb_n_checks
+                << "," << r.pb_n_pass << "," << r.pb_n_fail << "\n";
         }
 
         ofs.close();
@@ -9251,7 +9272,7 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
         std::ofstream ofs(summary_csv);
 
         // Headline: claim_ready. RMSD-only and pool ceiling stay diagnostic.
-        // suspect_zero_success is appended at END (position-stable header):
+        // Runtime and valid-count fields are appended; existing positions stay stable:
         // 1 when the zero-success plausibility gate fired (bug 2026-08-22).
         ofs << "dataset,total_systems,"
                "claim_ready_count,claim_ready_rate,"
@@ -9259,7 +9280,7 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
                "successful_rmsd,success_rate_rmsd,"
                "successful,success_rate,"
                "mean_rmsd,median_rmsd,pearson_r,spearman_rho,kendall_tau,"
-               "suspect_zero_success\n";
+               "suspect_zero_success,valid_rmsd_count,completed_systems\n";
         ofs << std::fixed << std::setprecision(4)
             << report.dataset_name << ","
             << report.total_systems << ","
@@ -9270,13 +9291,15 @@ void DatasetRunner::write_report(const BenchmarkReport& report,
             << report.successful_rmsd << ","
             << report.success_rate_rmsd << ","
             << report.successful << ","
-            << report.success_rate << ","
-            << report.mean_rmsd << ","
-            << report.median_rmsd << ","
-            << report.pearson_r << ","
+            << report.success_rate << ",";
+        if (report.valid_rmsd_count > 0 && std::isfinite(report.mean_rmsd)) ofs << report.mean_rmsd;
+        ofs << ",";
+        if (report.valid_rmsd_count > 0 && std::isfinite(report.median_rmsd)) ofs << report.median_rmsd;
+        ofs << "," << report.pearson_r << ","
             << report.spearman_rho << ","
             << report.kendall_tau << ","
-            << (report.suspect_zero_success ? 1 : 0) << "\n";
+            << (report.suspect_zero_success ? 1 : 0) << ","
+            << report.valid_rmsd_count << "," << report.completed_systems << "\n";
 
         ofs.close();
         std::cout << "  Summary CSV: " << summary_csv << "\n";

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -167,6 +167,11 @@ struct DockingResult {
     float shannon_entropy{0.0f};      // conformational Shannon entropy -Σ p_i ln p_i (nats)
     float search_entropy_proxy{0.0f}; // legacy H_final collapse proxy from GA energy histogram (nats)
     int   num_poses{0};               // number of binding modes found
+    // Runtime completion is independent of RMSD/PB success. -1 includes not
+    // started or a timeout; the retained child log distinguishes those causes.
+    int   docking_exit_code{-1};
+    bool  docking_completed{false};
+    std::string matrix_md5;          // actual selected matrix input, not an expected default
     double wall_time_s{0.0};          // docking wall time
     // ── Success gates (fixed semantics; never remapped by env) ────────────
     // success_rmsd : ordered direct rmsd_to_crystal <= 2 Å && !seed_echo
@@ -330,8 +335,10 @@ struct BenchmarkReport {
     double success_rate_rmsd{0.0};
     double success_rate_pb{0.0};
     double claim_ready_rate{0.0};
-    double mean_rmsd{0.0};
-    double median_rmsd{0.0};
+    int completed_systems{0};
+    int valid_rmsd_count{0};
+    double mean_rmsd{std::numeric_limits<double>::quiet_NaN()};
+    double median_rmsd{std::numeric_limits<double>::quiet_NaN()};
     // Zero-success plausibility gate (DatasetRunnerStats.h): true when the
     // summary would certify 0% while poses exist and negative RMSDs are
     // dominated by wholesale measurement-side reasons (bug 2026-08-22,
@@ -357,6 +364,20 @@ struct BenchmarkReport {
 };
 
 // =============================================================================
+// Runtime exit status for the CLI; a completed inaccurate pose is not a
+// process failure. Preparation/listing intentionally has no docking results.
+inline int benchmark_runtime_exit_code(const BenchmarkReport& report,
+                                       bool no_docking = false) {
+    if (no_docking) return 0;
+    if (report.total_systems <= 0 ||
+        report.results.size() != static_cast<size_t>(report.total_systems)) return 2;
+    for (const auto& result : report.results) {
+        if (!result.docking_completed || result.docking_exit_code != 0 ||
+            result.num_poses <= 0 || result.stuck) return 2;
+    }
+    return 0;
+}
+
 // Lightweight docking config for benchmarks
 // =============================================================================
 

--- a/LIB/DatasetRunnerStats.h
+++ b/LIB/DatasetRunnerStats.h
@@ -10,11 +10,46 @@
 #pragma once
 
 #include <array>
+#include <charconv>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace dataset {
+
+// Cache restoration must preserve a recorded failure code, not collapse it to
+// the -1 sentinel used for unknown/not-started/timeout outcomes.
+inline int docking_exit_code_or_unknown(const std::string& value) {
+    int code = -1;
+    const auto parsed = std::from_chars(value.data(), value.data() + value.size(), code);
+    return parsed.ec == std::errc{} && parsed.ptr == value.data() + value.size() ? code : -1;
+}
+
+struct RmsdSummary {
+    size_t count{0};
+    double mean{std::numeric_limits<double>::quiet_NaN()};
+    double median{std::numeric_limits<double>::quiet_NaN()};
+};
+
+// Reject missing/invalid measurements; a real zero RMSD remains a measurement.
+inline RmsdSummary summarize_rmsds(std::vector<double> values) {
+    values.erase(std::remove_if(values.begin(), values.end(), [](double v) {
+        return !std::isfinite(v) || v < 0;
+    }), values.end());
+    RmsdSummary out;
+    out.count = values.size();
+    if (values.empty()) return out;
+    out.mean = std::accumulate(values.begin(), values.end(), 0.0) / values.size();
+    std::sort(values.begin(), values.end());
+    const auto mid = values.size() / 2;
+    out.median = values.size() % 2 ? values[mid] : (values[mid-1] + values[mid]) / 2;
+    return out;
+}
+
 
 /// Pearson correlation coefficient (computed from scratch).
 /// Returns 0.0 if sizes differ, n < 2, or either series is constant.

--- a/LIB/DensityPeak_Cluster.cpp
+++ b/LIB/DensityPeak_Cluster.cpp
@@ -2,6 +2,7 @@
 #include "fileio.h"
 #include "MinibatchSampler.h"
 #include "ClusterRepMode.h"
+#include "PoseProvenance.h"
 #include "TargetServer.h"
 #include <cmath>
 #include <limits>
@@ -669,7 +670,8 @@ void DensityPeak_cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome
 		snprintf(tmp_end_strfile,MAX_PATH__,"%s%s",end_strfile,sufix);
 
 		// (*) write pdb file
-		write_pdb(FA,atoms,residue,tmp_end_strfile,remark);
+		std::string pose_remarks = flexaids::pose_provenance::add_to_remarks(remark);
+		write_pdb(FA,atoms,residue,tmp_end_strfile,pose_remarks.data());
 	}
     
     for(i = 0, k = 0; i < num_chrom; ++i)

--- a/LIB/FleetRunner.cpp
+++ b/LIB/FleetRunner.cpp
@@ -86,7 +86,8 @@ std::string utc_now() {
 }
 
 bool execution_completed(const dataset::DockingResult& result) {
-    return result.num_poses > 0 && !result.elected_pose_path.empty();
+    return result.docking_completed && result.docking_exit_code == 0 &&
+           result.num_poses > 0 && !result.stuck;
 }
 
 bool validators_complete(const dataset::DockingResult& result) {
@@ -170,6 +171,8 @@ std::string FleetRunner::serialize_chunk_result(
         out << "    {\n";
         out << "      \"pdb_id\": "; json_string(out, result.pdb_id); out << ",\n";
         out << "      \"execution_completed\": " << json_bool(execution_completed(result)) << ",\n";
+        out << "      \"docking_exit_code\": " << result.docking_exit_code << ",\n";
+        out << "      \"matrix_md5\": "; json_string(out, result.matrix_md5); out << ",\n";
         out << "      \"num_poses\": " << result.num_poses << ",\n";
         out << "      \"wall_time_s\": "; json_number(out, result.wall_time_s); out << ",\n";
         out << "      \"rmsd_hungarian_a\": "; json_number(out, result.rmsd_hungarian); out << ",\n";

--- a/LIB/GaPopulationReceipt.h
+++ b/LIB/GaPopulationReceipt.h
@@ -1,0 +1,288 @@
+#ifndef FLEXAIDS_GA_POPULATION_RECEIPT_H
+#define FLEXAIDS_GA_POPULATION_RECEIPT_H
+
+#include "gaboom.h"
+#include "flexaid_exception.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <locale>
+#include <span>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace flexaids {
+
+struct GaPopulationWorkerReceipt {
+    int team_size = 0;
+    std::uint64_t evaluated_chromosomes = 0;
+};
+
+struct GaPopulationEvaluationBatch {
+    std::string region;
+    int population_count;
+    int popoffset;
+    std::vector<GaPopulationWorkerReceipt> workers;
+};
+
+inline bool ga_population_receipt_requested() {
+    const char* path = std::getenv("FLEXAIDDS_GEN0_RECEIPT");
+    return path && *path;
+}
+
+// One collector per calling GA thread, scoped around initial population creation
+// only. Recursive IPFILE completion uses the same collector; later adaptive
+// repopulation/offspring evaluation runs after the scope has ended.
+class GaPopulationObservation {
+public:
+    GaPopulationObservation() : enabled_(ga_population_receipt_requested()) {
+        if (enabled_) {
+            if (current)
+                throw FlexAIDException("Generation-zero receipt: nested GA observation");
+            current = this;
+        }
+    }
+    ~GaPopulationObservation() { if (enabled_) current = nullptr; }
+    GaPopulationObservation(const GaPopulationObservation&) = delete;
+    GaPopulationObservation& operator=(const GaPopulationObservation&) = delete;
+
+    std::vector<GaPopulationEvaluationBatch> batches;
+    inline static thread_local GaPopulationObservation* current = nullptr;
+private:
+    bool enabled_;
+};
+
+inline bool ga_population_observation_active() {
+    return GaPopulationObservation::current != nullptr;
+}
+
+// Called only by the OpenMP worker owning this slot, after a completed evaluation.
+// The caller must wait for the parallel region before reading the slots.
+inline void record_ga_population_worker(GaPopulationWorkerReceipt& slot, int team_size) {
+    slot.team_size = team_size;
+    ++slot.evaluated_chromosomes;
+}
+
+inline void observe_ga_population_workers(
+        const char* region, int population_count, int popoffset,
+        std::span<const GaPopulationWorkerReceipt> workers) {
+    auto* observation = GaPopulationObservation::current;
+    if (!observation) return;
+    if (!region || (std::strcmp(region, "populate_chromosomes") != 0 &&
+                    std::strcmp(region, "calculate_fitness") != 0))
+        throw FlexAIDException("Generation-zero receipt: unknown evaluation region");
+    if (population_count <= 0 || popoffset < 0 || popoffset > population_count)
+        throw FlexAIDException("Generation-zero receipt: invalid evaluation range");
+    std::uint64_t total = 0;
+    for (std::size_t tid = 0; tid < workers.size(); ++tid) {
+        const auto& worker = workers[tid];
+        if (!worker.evaluated_chromosomes) continue;
+        if (worker.team_size <= 0 || tid >= static_cast<std::size_t>(worker.team_size) ||
+            static_cast<std::size_t>(worker.team_size) > workers.size() ||
+            worker.evaluated_chromosomes > static_cast<std::uint64_t>(population_count - popoffset))
+            throw FlexAIDException("Generation-zero receipt: invalid observed worker participation");
+        if (worker.evaluated_chromosomes >
+                static_cast<std::uint64_t>(population_count - popoffset) - total)
+            throw FlexAIDException("Generation-zero receipt: evaluation count exceeds observed range");
+        total += worker.evaluated_chromosomes;
+    }
+    if (total > static_cast<std::uint64_t>(population_count - popoffset))
+        throw FlexAIDException("Generation-zero receipt: evaluation count exceeds observed range");
+    if (total)
+        observation->batches.push_back({region, population_count, popoffset,
+                                       {workers.begin(), workers.end()}});
+}
+
+namespace population_receipt_detail {
+
+// Read object representations, never convert or perform arithmetic on a score.
+// This preserves signed zero, subnormals, and even NaN payloads for diagnosis.
+inline std::string hex_integer(std::uint64_t bits, int digits) {
+    constexpr char hex[] = "0123456789abcdef";
+    std::string result(static_cast<std::size_t>(digits) + 2, '0');
+    result[1] = 'x';
+    for (int i = digits + 1; i >= 2; --i) {
+        result[static_cast<std::size_t>(i)] = hex[bits & 15];
+        bits >>= 4;
+    }
+    return result;
+}
+
+inline std::string bits(const double& value) {
+    static_assert(sizeof(double) == sizeof(std::uint64_t) &&
+                  std::numeric_limits<double>::is_iec559);
+    std::uint64_t representation;
+    std::memcpy(&representation, &value, sizeof(representation));
+    return hex_integer(representation, 16);
+}
+
+inline std::string bits(const float& value) {
+    static_assert(sizeof(float) == sizeof(std::uint32_t) &&
+                  std::numeric_limits<float>::is_iec559);
+    std::uint32_t representation;
+    std::memcpy(&representation, &value, sizeof(representation));
+    return hex_integer(representation, 8);
+}
+
+inline void field(std::ostream& out, const char* name, const double& value) {
+    out << ",\"" << name << "_bits\":\"" << bits(value) << '\"';
+}
+
+inline FlexAIDException io_error(const char* operation, const char* path, int code) {
+    return FlexAIDException(std::string("Generation-zero receipt: ") + operation +
+                           " '" + path + "': " +
+                           std::error_code(code, std::generic_category()).message());
+}
+
+// Always close the owned stream, even after a short write or flush error. A
+// failed write may leave a partial receipt; successful process completion is
+// mandatory in addition to the JSON completion marker when admitting a run.
+inline void finish_output(FILE* output, const std::string& payload, const char* path) {
+    int error = 0;
+    if (std::fwrite(payload.data(), 1, payload.size(), output) != payload.size())
+        error = errno ? errno : EIO;
+    if (std::fflush(output) != 0 && !error) error = errno ? errno : EIO;
+    if (std::fclose(output) != 0 && !error) error = errno ? errno : EIO;
+    if (error) throw io_error("cannot finish", path, error);
+}
+
+}  // namespace population_receipt_detail
+
+// Called only after initial populate_chromosomes() has returned, including its
+// existing fitness calculation and sort, and before any generation/reproduction.
+// Array order is retained; consumers may compare multisets while keeping duplicate
+// multiplicities. Sums belong in the external comparator, not the docking engine.
+inline std::string serialize_ga_population_receipt(
+        std::span<const chromosome> population, int n_genes, std::uint64_t seed) {
+    using namespace population_receipt_detail;
+    if (population.empty() || n_genes <= 0)
+        throw FlexAIDException("Generation-zero receipt: empty population or invalid gene count");
+    for (const auto& chrom : population) {
+        if (!chrom.genes)
+            throw FlexAIDException("Generation-zero receipt: null chromosome genes");
+    }
+
+    std::ostringstream out;
+    out.imbue(std::locale::classic());
+    out << "{\"schema\":\"flexaidds.ga_population_receipt.v1\","
+           "\"boundary\":\"initial_population_complete_before_reproduction\","
+           "\"generation\":0,\"population_count\":" << population.size()
+        << ",\"n_genes\":" << n_genes << ",\"seed\":\"" << seed
+        << "\",\"execution\":{\"openmp_compiled\":"
+#ifdef _OPENMP
+        << "true"
+#else
+        << "false"
+#endif
+        << ",\"deterministic_compile\":"
+#ifdef FLEXAID_DETERMINISTIC
+        << "true"
+#else
+        << "false"
+#endif
+        << ",\"evaluation_batches\":[";
+    if (const auto* observation = GaPopulationObservation::current) {
+        for (std::size_t b = 0; b < observation->batches.size(); ++b) {
+            const auto& batch = observation->batches[b];
+            if (b) out << ',';
+            out << "{\"region\":\"" << batch.region << "\",\"population_count\":"
+                << batch.population_count << ",\"popoffset\":" << batch.popoffset
+                << ",\"workspace_slots\":" << batch.workers.size() << ",\"workers\":[";
+            bool first = true;
+            for (std::size_t tid = 0; tid < batch.workers.size(); ++tid) {
+                const auto& worker = batch.workers[tid];
+                if (!worker.evaluated_chromosomes) continue;
+                if (!first) out << ',';
+                first = false;
+                out << "{\"worker_id\":" << tid << ",\"team_size\":" << worker.team_size
+                    << ",\"evaluated_chromosomes\":" << worker.evaluated_chromosomes << '}';
+            }
+            out << "]}";
+        }
+    }
+    out << "]},\"records\":[\n";
+    for (std::size_t i = 0; i < population.size(); ++i) {
+        const auto& chrom = population[i];
+        if (i) out << ",\n";
+        out << "{\"index\":" << i << ",\"status\":"
+            << static_cast<unsigned int>(static_cast<unsigned char>(chrom.status))
+            << ",\"genes\":[";
+        for (int g = 0; g < n_genes; ++g) {
+            if (g) out << ',';
+            out << "{\"to_int32\":" << chrom.genes[g].to_int32
+                << ",\"to_ic_bits\":\"" << bits(chrom.genes[g].to_ic) << "\"}";
+        }
+        out << "],\"cf\":{\"rclash\":" << chrom.cf.rclash;
+        field(out, "com", chrom.cf.com);
+        field(out, "con", chrom.cf.con);
+        field(out, "wal", chrom.cf.wal);
+        field(out, "sas", chrom.cf.sas);
+        field(out, "elec", chrom.cf.elec);
+        field(out, "gist", chrom.cf.gist);
+        field(out, "hbond", chrom.cf.hbond);
+        field(out, "gist_desolv", chrom.cf.gist_desolv);
+        field(out, "metal_coord", chrom.cf.metal_coord);
+        field(out, "h_rep", chrom.cf.h_rep);
+        field(out, "entropy", chrom.cf.entropy);
+        field(out, "pb_clash", chrom.cf.pb_clash);
+        field(out, "totsas", chrom.cf.totsas);
+        field(out, "nor", chrom.cf.nor);
+        out << '}';
+        field(out, "evalue", chrom.evalue);
+        field(out, "app_evalue", chrom.app_evalue);
+        field(out, "fitnes", chrom.fitnes);
+        field(out, "boltzmann_weight", chrom.boltzmann_weight);
+        field(out, "free_energy", chrom.free_energy);
+        out << ",\"ring_phases_bits\":[";
+        for (int r = 0; r < MAX_RING_FLEX; ++r) {
+            if (r) out << ',';
+            out << '\"' << bits(chrom.ring_phases[r]) << '\"';
+        }
+        out << "],\"ring_six\":[";
+        for (int r = 0; r < MAX_RING_FLEX; ++r) {
+            if (r) out << ',';
+            out << static_cast<unsigned int>(chrom.ring_six[r]);
+        }
+        out << "],\"ring_five\":[";
+        for (int r = 0; r < MAX_RING_FLEX; ++r) {
+            if (r) out << ',';
+            out << static_cast<unsigned int>(chrom.ring_five[r]);
+        }
+        out << "]}";
+    }
+    out << "\n],\"complete\":true}\n";
+    if (!out) throw FlexAIDException("Generation-zero receipt: serialization failed");
+    return out.str();
+}
+
+// Exclusive creation deliberately rejects an existing receipt, including another
+// GA invocation/restart using this path. Adaptive repopulations do not call this
+// observer. Each independently launched GA needs a distinct receipt path.
+inline void write_ga_population_receipt(
+        const char* path, std::span<const chromosome> population,
+        int n_genes, std::uint64_t seed) {
+    using namespace population_receipt_detail;
+    if (!path || !*path)
+        throw FlexAIDException("Generation-zero receipt: empty output path");
+    const std::string payload = serialize_ga_population_receipt(population, n_genes, seed);
+    FILE* output = std::fopen(path, "wbx");
+    if (!output) throw io_error("cannot create", path, errno);
+    finish_output(output, payload, path);
+}
+
+// OFF unless a nonempty path is explicitly supplied. No serialization, scoring,
+// RNG calls, or input inspection occurs when disabled.
+inline void write_ga_population_receipt_if_requested(
+        std::span<const chromosome> population, int n_genes, std::uint64_t seed) {
+    const char* path = std::getenv("FLEXAIDDS_GEN0_RECEIPT");
+    if (path && *path) write_ga_population_receipt(path, population, n_genes, seed);
+}
+
+}  // namespace flexaids
+
+#endif  // FLEXAIDS_GA_POPULATION_RECEIPT_H

--- a/LIB/PoseProvenance.h
+++ b/LIB/PoseProvenance.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "RngSeed.h"
+
+#include <cstdint>
+#include <string>
+
+// CMake supplies these values. A build without that information must not
+// claim a known revision or a clean tree (0=clean, 1=dirty, 2=unknown).
+#ifndef FLEXAIDS_GIT_COMMIT
+#define FLEXAIDS_GIT_COMMIT "unknown"
+#endif
+#ifndef FLEXAIDS_GIT_DIRTY
+#define FLEXAIDS_GIT_DIRTY 2
+#endif
+
+namespace flexaids::pose_provenance {
+
+inline std::string format_remark(const char* commit, int dirty,
+                                 std::uint64_t seed)
+{
+    return std::string("REMARK FLEXAID.commit=") + commit +
+           " FLEXAID.dirty=" + std::to_string(dirty) +
+           " FLEXAID.seed=" + std::to_string(seed) + "\n";
+}
+
+// Read the effective GA seed; do not initialize or draw from any RNG here.
+// Keep the existing BindingMode fallback of zero when no master seed is set.
+inline std::string remark()
+{
+    return format_remark(FLEXAIDS_GIT_COMMIT, FLEXAIDS_GIT_DIRTY,
+                         flexaids_rng::has_master_seed()
+                             ? flexaids_rng::master_seed() : 0);
+}
+
+// Classic and density-peak writers already fill a bounded scientific REMARK
+// buffer. Insert metadata only after that buffer is complete: adding it to
+// the bounded buffer would displace/truncate scientific lines at its tail.
+// The expanded string preserves every input byte, including an incomplete
+// final line, and keeps provenance near the head of the output.
+inline std::string add_to_remarks(std::string scientific_remarks)
+{
+    const auto newline = scientific_remarks.find('\n');
+    scientific_remarks.insert(newline == std::string::npos ? 0 : newline + 1,
+                              remark());
+    return scientific_remarks;
+}
+
+} // namespace flexaids::pose_provenance

--- a/LIB/benchmark_datasets.cpp
+++ b/LIB/benchmark_datasets.cpp
@@ -112,8 +112,14 @@ static void print_publication_table(const dataset::BenchmarkReport& report) {
     printf("  │ Total systems               │ %18d │\n", report.total_systems);
     printf("  │ Successful (RMSD <= 2.0 A)  │ %18d │\n", report.successful);
     printf("  │ Success rate                │ %17.1f%% │\n", report.success_rate * 100.0);
-    printf("  │ Mean RMSD (Å)               │ %18.2f │\n", report.mean_rmsd);
-    printf("  │ Median RMSD (Å)             │ %18.2f │\n", report.median_rmsd);
+    printf("  │ Valid RMSDs                 │ %18d │\n", report.valid_rmsd_count);
+    if (report.valid_rmsd_count > 0 && std::isfinite(report.mean_rmsd) && std::isfinite(report.median_rmsd)) {
+        printf("  │ Mean RMSD (Å)               │ %18.2f │\n", report.mean_rmsd);
+        printf("  │ Median RMSD (Å)             │ %18.2f │\n", report.median_rmsd);
+    } else {
+        printf("  │ Mean RMSD (Å)               │ %18s │\n", "NA");
+        printf("  │ Median RMSD (Å)             │ %18s │\n", "NA");
+    }
     printf("  │ Affinity pairs              │ %18d │\n", report.affinity_pairs);
     if (report.affinity_pairs >= 3 &&
         std::isfinite(report.pearson_r) &&
@@ -748,6 +754,7 @@ int main(int argc, char** argv) {
     }
     std::cout << "\n";
 
+    int runtime_exit_code = 0;
     // Handle "all" benchmark
     if (benchmark_name == "all") {
         std::vector<std::string> all_benchmarks = {
@@ -761,17 +768,21 @@ int main(int argc, char** argv) {
             std::cout << "  Running: " << name << "\n";
             std::cout << "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
 
-            run_single_benchmark(name, runner, config, prepare_only, list_codes_only, only_codes);
+            auto report = run_single_benchmark(name, runner, config, prepare_only, list_codes_only, only_codes);
+            runtime_exit_code = std::max(runtime_exit_code,
+                dataset::benchmark_runtime_exit_code(report, prepare_only || list_codes_only));
         }
 
         // Print combined summary
         std::cout << "\n\n═══════════════════════════════════════════════════════════════\n";
-        std::cout << "  All benchmarks completed. Results in: " << output_dir << "\n";
+        std::cout << "  All benchmark attempts finished. Results in: " << output_dir << "\n";
         std::cout << "═══════════════════════════════════════════════════════════════\n";
     } else {
         const auto fleet_started = std::chrono::steady_clock::now();
         auto report = run_single_benchmark(benchmark_name, runner, config, prepare_only, list_codes_only, only_codes);
 
+        runtime_exit_code = dataset::benchmark_runtime_exit_code(
+            report, prepare_only || list_codes_only);
         if (fleet_mode) {
             const double duration_s = std::chrono::duration<double>(
                 std::chrono::steady_clock::now() - fleet_started).count();
@@ -813,5 +824,7 @@ int main(int argc, char** argv) {
         }
     }
 
-    return 0;
+    if (runtime_exit_code != 0)
+        std::cerr << "ERROR: Incomplete docking; inspect per-target runtime fields and child logs\n";
+    return runtime_exit_code;
 }

--- a/LIB/build_rotamers.cpp
+++ b/LIB/build_rotamers.cpp
@@ -1,5 +1,6 @@
 #include "flexaid.h"
 #include "fileio.h"
+#include "rotamer_output.h"
 // Receptor side-chain conformational strain (FLEXAIDDS_RECEPTOR_STRAIN,
 // default OFF). Header-only; every entry point below is a no-op when the
 // gate is unset, so this build stays bit-identical without it.
@@ -104,7 +105,7 @@ void build_rotamers(FA_Global* FA,atom** atoms,resid* residue,rot* rotamer){
 
 				if(strcmp(rotamer[l].res,residue[kres].name) == 0){
 
-					atom* at_cb = NULL;
+					int cb_index = 0;
 
 					/*
 					printf("---------------------\n");
@@ -171,7 +172,7 @@ void build_rotamers(FA_Global* FA,atom** atoms,resid* residue,rot* rotamer){
 							if((*atoms)[j].rec[3] != 0){
 								(*atoms)[j].shift = (*atoms)[(*atoms)[j].rec[3]].dih - (*atoms)[j].dih;
 							}
-						}else if(!strcmp((*atoms)[j].name," CB ")){ at_cb = &(*atoms)[j]; }
+						}else if(!strcmp((*atoms)[j].name," CB ")){ cb_index = j; }
 
 						(*atoms)[j+delta_atm] = (*atoms)[j];
 						//(*atoms)[j+delta_atm].number += delta_atm;
@@ -259,20 +260,10 @@ void build_rotamers(FA_Global* FA,atom** atoms,resid* residue,rot* rotamer){
 								}
 							}
 
-							fprintf(outrot, "MODEL       %2d\n", residue[kres].trot);
-							resid* res = &residue[at_cb->ofres];
-							fprintf(outrot, "ATOM  %5d %4s %3s %c%4d    %8.3f%8.3f%8.3f\n",
-								at_cb->number, at_cb->name,
-								res->name, res->chn, res->number,
-								at_cb->coor[0], at_cb->coor[1], at_cb->coor[2] );
-							for(int m=0; m<total_build; m++){
-								atom* at = &(*atoms)[buildcc_list[m]];
-								fprintf(outrot, "ATOM  %5d %4s %3s %c%4d    %8.3f%8.3f%8.3f\n",
-									at->number, at->name,
-									res->name, res->chn, res->number,
-									at->coor[0], at->coor[1], at->coor[2] );
-							}
-							fprintf(outrot, "ENDMDL\n");
+							flexaids::write_rotamer_model(outrot,
+							    std::span<const atom>(*atoms, FA->atm_cnt + 1),
+							    std::span<const resid>(residue, FA->res_cnt + 1), cb_index,
+							    std::span<const int>(buildcc_list, total_build), residue[kres].trot);
 						}
 
 						if(FA->nrg_suite){

--- a/LIB/cluster.cpp
+++ b/LIB/cluster.cpp
@@ -4,6 +4,7 @@
 #include "statmech.h"
 #include "SoftBetaFreeEnergy.h"
 #include "EnvFlags.h"
+#include "PoseProvenance.h"
 #include "ClusterRepMode.h"
 #include "TargetServer.h"
 #include "tencom_ledger.h"
@@ -844,7 +845,8 @@ void cluster(FA_Global* FA, GB_Global* GB, VC_Global* VC, chromosome* chrom, gen
 		snprintf(tmp_end_strfile, MAX_PATH__, "%s%s", end_strfile, sufix);
 		//printf("filename=<%s>\n",tmp_end_strfile);
 		//PAUSE;
-		write_pdb(FA,atoms,residue,tmp_end_strfile,remark);
+		std::string pose_remarks = flexaids::pose_provenance::add_to_remarks(remark);
+		write_pdb(FA,atoms,residue,tmp_end_strfile,pose_remarks.data());
 
 		// ── Write the receptor AS SCORED (FLEXAIDDS_WRITE_FLEXED_RECEPTOR) ──
 		// DEFAULT OFF. Nothing above this point is touched: the pose PDB has

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -13,6 +13,7 @@
 #include "niche_distance.h"
 #include "niche_hash.h"
 #include "new_search_arch.h"
+#include "AtomOptResBinding.h"
 
 #include <random>
 #include <functional>
@@ -4024,6 +4025,9 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 		const int nopt  = FA->num_optres;
 		const int nctb  = FA->ntypes * FA->ntypes;
 		const int range = GB->num_chrom - popoffset;
+		const flexaids::AtomOptResBinding p_optres_binding(
+		    std::span<const atom>(atoms + 1, natm),
+		    std::span<const OptRes>(FA->optres, nopt));
 
 		std::vector<std::vector<atom>>   p_atoms(n_thr, std::vector<atom>(atoms, atoms + natm + 1));
 		std::vector<std::vector<resid>>  p_res(n_thr, std::vector<resid>(residue, residue + nres + 1));
@@ -4123,7 +4127,7 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 	shared(chrom, FA, GB, VC, gene_lim, atoms, residue, cleftgrid, target, \
 	       popoffset, p_atoms, p_res, p_fa, p_optres, p_vc, natm, nres, nopt, \
 	       n_receptor_chains, p_use_selective, p_dirty_atm, p_dirty_res_idx, \
-	       p_n_dirty_atm, p_n_dirty_res)
+	       p_n_dirty_atm, p_n_dirty_res, p_optres_binding)
 #endif
 		for(i=popoffset;i<GB->num_chrom;i++){
 #ifdef _OPENMP
@@ -4144,14 +4148,10 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 				std::copy(atoms,   atoms + natm + 1,   p_atoms[tid].begin());
 				std::copy(residue, residue + nres + 1, p_res[tid].begin());
 			}
-			// Redirect per-thread atom optres pointers to per-thread optres array.
-			for (int ai = 1; ai <= natm; ++ai) {
-				atom& a = p_atoms[tid][ai];
-				if (a.optres) {
-					ptrdiff_t oidx = a.optres - FA->optres;
-					a.optres = &p_optres[tid][oidx];
-				}
-			}
+			// Non-dirty atoms already point into this workspace on its second
+			// chromosome. Rebind from immutable master indices, not those pointers.
+			p_optres_binding.bind(
+			    std::span<atom>(p_atoms[tid].data() + 1, natm), p_optres[tid]);
 			for (int o = 0; o < nopt; ++o) {
 				p_optres[tid][o].cf.com    = 0.0;
 				p_optres[tid][o].cf.wal    = 0.0;

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -1,4 +1,5 @@
 #include "gaboom.h"
+#include "GaPopulationReceipt.h"
 #include "Vcontacts.h"
 #include "fileio.h"
 #include "coarse_init.h"
@@ -528,8 +529,16 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 
 	std::unordered_map<size_t, int> duplicates;
 
+	{
+	flexaids::GaPopulationObservation initial_population_observation;
 	populate_chromosomes(FA,GB,VC,(*chrom),(*gene_lim),atoms,residue,(*cleftgrid),
 			     GB->pop_init_method,target,GB->pop_init_file,at,0,print,dice,duplicates);
+	// Observe only the completed initial population, before any reproduction.
+	// Repopulations below never overwrite this optional generation-zero receipt.
+	flexaids::write_ga_population_receipt_if_requested(
+	    std::span<const chromosome>(*chrom, GB->num_chrom), GB->num_genes,
+	    static_cast<std::uint64_t>(tt));
+	}
 	//}
 
 	//print_pop((*chrom),(*gene_lim),GB->num_chrom,GB->num_genes);
@@ -3278,9 +3287,13 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 #ifdef _OPENMP
 		const int eval_threads = deterministic_eval ? 1 : n_thr;
 #endif
+		const bool record_initial_workers = flexaids::ga_population_observation_active();
+		std::vector<flexaids::GaPopulationWorkerReceipt> initial_workers(
+		    record_initial_workers ? n_thr : 0);
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(eval_threads) default(none) \
+	shared(record_initial_workers, initial_workers) \
 	shared(chrom, pop_size, GB, gene_lim, cleftgrid, target, \
 	       atoms, residue, FA, VC, eval_threads, \
 	       tl_atoms, tl_res, tl_fa, tl_optres, tl_vc, \
@@ -3346,7 +3359,17 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			chrom[ii].app_evalue = get_apparent_cf_evalue(&chrom[ii].cf) / n_receptor_chains;
 			ccbm_inject_strain(FA, chrom[ii], gene_lim);  // CCBM strain
 			chrom[ii].status     = 'n';
+			if (record_initial_workers) {
+#ifdef _OPENMP
+				const int actual_team_size = omp_get_num_threads();
+#else
+				const int actual_team_size = 1;
+#endif
+				flexaids::record_ga_population_worker(initial_workers[tid], actual_team_size);
+			}
 		}
+		if (record_initial_workers)
+			flexaids::observe_ga_population_workers("calculate_fitness", pop_size, 0, initial_workers);
 	}
 	}  // !gpu_handled
 
@@ -4025,6 +4048,9 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 		const int nopt  = FA->num_optres;
 		const int nctb  = FA->ntypes * FA->ntypes;
 		const int range = GB->num_chrom - popoffset;
+		const bool p_record_initial_workers = flexaids::ga_population_observation_active();
+		std::vector<flexaids::GaPopulationWorkerReceipt> p_initial_workers(
+		    p_record_initial_workers ? n_thr : 0);
 		const flexaids::AtomOptResBinding p_optres_binding(
 		    std::span<const atom>(atoms + 1, natm),
 		    std::span<const OptRes>(FA->optres, nopt));
@@ -4124,6 +4150,7 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic) default(none) \
+	shared(p_record_initial_workers, p_initial_workers) \
 	shared(chrom, FA, GB, VC, gene_lim, atoms, residue, cleftgrid, target, \
 	       popoffset, p_atoms, p_res, p_fa, p_optres, p_vc, natm, nres, nopt, \
 	       n_receptor_chains, p_use_selective, p_dirty_atm, p_dirty_res_idx, \
@@ -4177,7 +4204,18 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 			chrom[i].app_evalue = get_apparent_cf_evalue(&chrom[i].cf) / n_receptor_chains;
 			chrom[i].status     = 'n';
 			ccbm_inject_strain(FA, chrom[i], gene_lim);  // CCBM strain
+			if (p_record_initial_workers) {
+#ifdef _OPENMP
+				const int actual_team_size = omp_get_num_threads();
+#else
+				const int actual_team_size = 1;
+#endif
+				flexaids::record_ga_population_worker(p_initial_workers[tid], actual_team_size);
+			}
 		}
+		if (p_record_initial_workers)
+			flexaids::observe_ga_population_workers(
+			    "populate_chromosomes", GB->num_chrom, popoffset, p_initial_workers);
 	}
 
 	// sort and calculate fitness (use a local GAContext for initial population)

--- a/LIB/rotamer_output.h
+++ b/LIB/rotamer_output.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "flexaid.h"
+
+#include <span>
+
+namespace flexaids {
+
+// Atom indices survive growth of the atom allocation. Resolve them here only
+// after the rotamer has been built and accepted, never before a possible realloc.
+inline void write_rotamer_model(FILE* output, std::span<const atom> atoms,
+                                std::span<const resid> residues, int cb_index,
+                                std::span<const int> built_indices, int model) {
+    if (cb_index <= 0 || static_cast<std::size_t>(cb_index) >= atoms.size())
+        throw FlexAIDException("Cannot write rotamer without a valid CB atom index");
+    const atom& cb = atoms[cb_index];
+    if (cb.ofres <= 0 || static_cast<std::size_t>(cb.ofres) >= residues.size())
+        throw FlexAIDException("Rotamer CB atom has an invalid residue index");
+    for (const int index : built_indices) {
+        if (index <= 0 || static_cast<std::size_t>(index) >= atoms.size())
+            throw FlexAIDException("Rotamer output contains an invalid built atom index");
+    }
+    const resid& res = residues[cb.ofres];
+    fprintf(output, "MODEL       %2d\n", model);
+    fprintf(output, "ATOM  %5d %4s %3s %c%4d    %8.3f%8.3f%8.3f\n",
+            cb.number, cb.name, res.name, res.chn, res.number,
+            cb.coor[0], cb.coor[1], cb.coor[2]);
+    for (const int index : built_indices) {
+        const atom& at = atoms[index];
+        fprintf(output, "ATOM  %5d %4s %3s %c%4d    %8.3f%8.3f%8.3f\n",
+                at.number, at.name, res.name, res.chn, res.number,
+                at.coor[0], at.coor[1], at.coor[2]);
+    }
+    fprintf(output, "ENDMDL\n");
+}
+
+}  // namespace flexaids

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -27,7 +27,8 @@ numbers into other files — reference `METHODOLOGY.md §N`.
 - **Deterministic seed:** `FLEXAID_SEED=12345`. This is the ONLY determinism seed. Do **not** use
   `FLEXAIDDS_SEED_BASE` for determinism (it offsets per-restart seeds).
 - **Benchmark GA budget:** **2000 generations, population 1000** (the FlexAID/FlexAIDdS norm =
-  2,000,000 evals/restart). Do not change for accuracy runs.
+  a nominal population-generation product of 2,000,000 per restart). Do not change for accuracy runs.
+  This product is not an observed evaluation count; throughput requires a witnessed evaluator-boundary counter.
 - **Restarts:** `FLEXAIDDS_RESTARTS=<n>`. Published Astex protocol = 10 restarts; a fast A/B may
   use 1–3 but MUST state it.
 - **Security channel off for benchmarks:** `FLEXAIDDS_NO_SEC=1`.
@@ -189,6 +190,43 @@ receipt, so a completed run cannot be told apart from one at different weights.
 
 ---
 
+## 0.3 Admission identity, missingness, and repair evidence
+
+The CSV aggregator validates receipt fields; it does not independently witness engine or
+validator execution. Its report must identify that evidence level and must not describe
+string equality as verification of raw artifacts. STRICT requires complete, consistent
+protocol, matrix, finite serial RMSD, PoseBusters, score-pose consistency, tENCoM/Eigen,
+and syntactically valid pose-linked hash fields. A stored `claim_ready` or success flag
+cannot override contradictory or missing measurements. This hardening does not change
+the RMSD instrument or pose election described in §0.0.
+
+The frozen manifest is mandatory for a primary rate: validate its schema, unique codes,
+declared count, and sorted-code digest. Never silently substitute admitted row count.
+Each target contributes at most once. Existing one-row-per-target producer output is
+explicitly a **single-observation** analysis. Repeated seeds require an explicit expected
+seed list; a target passes only on a strict majority of that list, with absent/failed
+seeds counting as failures. Reject duplicate observation identities and implicit mixing
+of arms or endpoints; any explicit arm selection must be recorded. Do not infer a union
+or majority across unrelated experiments. A diagnostic mode may expose legacy data but
+must not emit a primary STRICT rate without this contract.
+
+Reject duplicate CSV headers, inconsistent widths, ambiguous source layouts, and sidecar
+joins lacking matching pose identity. Report S1/S2 diagnostics over their declared eligible
+population independently of filtering on STRICT success. Empty measurement populations
+have unavailable statistics and an explicit valid count, never an invented zero RMSD.
+Process completion and scientific success are separate: a wrapper must retain runtime
+failure state and signal incomplete docking without calling a completed inaccurate pose
+a process failure.
+
+Memory-ownership repairs are checked against allocation and workspace invariants. Correct
+paths must retain their outputs; paths that use invalid pointers are not a scientifically
+valid parity baseline. Document those intentional invalid-path corrections and test the
+production ownership transitions, including repeated and parallel workspace use. Do not
+hide an invalid-pointer repair behind an option that leaves undefined behavior as default.
+Changes to valid scoring, ranking, clustering, or thermodynamic models still require the
+feature flags and science gates below. No claim of historical crash attribution follows
+from a source fix alone.
+
 ## 1. Reproducibility / parity gate (run before ANY merge)
 
 Purpose: prove a change is bit-identical to the baseline under default flags.
@@ -260,8 +298,9 @@ mirror (`docs/ICLOUD_BENCHMARK_STORAGE.md`).
 
 ## 4. ctest
 
-`cd build && /opt/homebrew/bin/ctest --output-on-failure` — expect **11/11**. A stale binary can
-cause a false PoseBustTests failure; rebuild before trusting a red.
+`cd build && /opt/homebrew/bin/ctest --output-on-failure`. All configured tests must pass;
+record the actual test count from this build instead of relying on a historical count. A
+stale binary can cause a false PoseBustTests failure; rebuild before trusting a red.
 
 ---
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -229,34 +229,74 @@ from a source fix alone.
 
 ## 1. Reproducibility / parity gate (run before ANY merge)
 
-Purpose: prove a change is bit-identical to the baseline under default flags.
+Purpose: compare the baseline and candidate's emitted scientific results under default
+flags, with exact input and executable provenance. Publication acceptance is separate.
 
-1. Build the candidate engine and the baseline engine (main) separately; record both md5s.
-2. Dock 1G9V, `FLEXAID_SEED=12345`, `OMP_NUM_THREADS=1`, config `/tmp/parity.json`
-   (2000 gen / pop 1000, no crystal-pose seed: `pose_seed_enabled=false, seed_fraction=0`).
-3. Assert: elected CF equal AND all 10 elected poses byte-identical between candidate and main.
-4. PASS = default-flag behavior unchanged. Any intended behavior change must be opt-in behind an
-   env flag that defaults OFF, and parity must hold with the flag OFF.
+1. Build main and candidate in separate pinned checkouts using the same compiler/options.
+   Preserve source commits and any diagnostic-only patch, compiler commands, binary MD5
+   and SHA-256, runtime-data hashes, input hashes and exact argv/environment.
+2. Dock 1G9V, `FLEXAID_SEED=12345`, `OMP_NUM_THREADS=1`, population 1000 and generations
+   2000, without crystal/native pose seeding (`pose_seed_enabled=false, seed_fraction=0`).
+   Use fresh output directories keyed by run ID and source identity, never engine basename.
+3. Require child exit zero, completed fresh artifacts, all ten emitted ranks and a valid
+   fresh `.rrg` grid. Missing or stale output is a failed gate. A printed FAIL must return
+   nonzero. Never compare a file overwritten by the second run with itself.
+4. Compare all ten scientific PDB payloads and elected CF fields at their emitted precision.
+   Preserve raw files/hashes. Across builds, normalize **only** the commit and dirty values
+   in the exact `REMARK FLEXAID.commit=... FLEXAID.dirty=... FLEXAID.seed=...` provenance line.
+   Keep seed, every other REMARK, coordinates, atom identities, scores, ranking and grid
+   order unchanged. Report this as provenance-normalized byte equality, not raw hash identity
+   or proof of equality below the instrument's serialized precision.
+5. Exact initial-population gene/score receipts (§2) complement the emitted-output comparison.
+   PASS means the declared observations agree. Invalid-pointer baseline execution is handled
+   by §0.3; it cannot establish a valid scientific reference. Changes to valid scoring,
+   ranking, clustering or thermodynamic models still require their own gated validation.
 
-Reference baseline engine md5 (main @ 7f1f10a0…): `7f1f10a0f10b682b33a76622a40f1a60`.
+`ops/gate_parity.sh` and `ops/engine_repro_gate.py` implement the fail-closed invocation
+and comparison interface. The obsolete hard-coded baseline MD5 is not a current engine pin.
 
 ---
 
 ## 2. Determinism check (multi-thread)
 
-For changes touching parallel regions (GA eval, cleft detection):
+For changes touching parallel regions (GA eval, cleft detection), repeat candidate runs
+at `OMP_NUM_THREADS=1` and `=4` twice each with `FLEXAIDDS_PARALLEL_REPRODUCE=1`.
+Default-flag parity runs are separate and cannot silently substitute for flag-ON runs.
 
-- **Cleft grid:** dock a fixed seed at `OMP_NUM_THREADS=1` and `=4`, twice each; assert the emitted
-  `.rrg` grid-cache file is byte-identical across thread counts AND run-to-run.
-- **GA population:** with the parallel-reproduce flag ON, assert the gen-0 order-independent CF
-  checksum (Σ cf.com, Σ cf.wal over the population) is identical run-to-run at 1 AND 4 threads, and
-  that all 10 elected poses are byte-identical across two 4-thread runs.
+- Use an OpenMP-enabled build; record actual compiler flags and actual worker/team
+  participation. Disable dynamic team sizing, reject thread-limit overrides and leave
+  `FLEXAID_DETERMINISTIC` unset so the tested path is not silently serialized.
+- **Cleft grid:** generate a fresh grid for each run; compare valid `.rrg` files in their
+  original record order across runs/thread counts. A shared cached grid is not evidence
+  of independently reproduced grid construction.
+- **Initial population:** enable the opt-in `FLEXAIDDS_GEN0_RECEIPT` observer at a unique
+  path. It snapshots stored values immediately after the initial population is evaluated
+  and sorted, before reproduction, without rescoring, RNG calls or population mutation.
+  Require successful engine completion as well as a complete receipt. Record actual seed,
+  population count, exact gene/ring identity and exact stored score bits. Check complete
+  order-independent gene/score record multisets; derive CF.com/CF.wal checksum summaries
+  from those records. Equality of two sums alone cannot exclude compensating differences.
+  Later generation traces or re-scored terminal populations are not this observation.
+- Compare the two four-thread elected outputs as in §1. Keep the one-thread repeats and
+  cross-thread comparisons explicit; never hide a failure by sorting grid or pose ranks.
+- A matching diagnostic-only observer may be applied to baseline and candidate with its
+  exact patch recorded. The observer is off by default and is tested for nonmutation and
+  I/O failure. Failed writes, duplicate output paths, missing rows or wrong population
+  counts fail the gate. The enabled observer does not make a run a publication campaign.
 
 ---
 
 ## 3. Astex-85 accuracy A/B (the science gate)
 
-Purpose: prove a determinism/perf change does not regress docking accuracy.
+Purpose: prove a change to valid scoring, search, cleft selection, ranking or thermodynamic
+models does not regress docking accuracy.
+
+**Applicability to correctness repairs:** ownership, receipt, reporting and diagnostic-observer
+repairs that preserve valid scientific operations use §§0.3, 1, 2, 4 and 6 for merge acceptance.
+They do not require a new 85×10 publication campaign merely because the repaired code is in a
+GA source file. Any unexplained valid-path scoring/output difference must be investigated;
+if resolution changes the valid scientific model or search behavior, this full accuracy A/B
+applies. This exception does not turn merge-validation runs into docking-success evidence.
 
 - **Protocol:** autonomous (blind) mode — `--mode autonomous` — which exercises SURFNET cleft
   detection (top.cpp "Always run SURFNET"). Seed 12345, `FLEXAIDDS_NO_SEC=1`, 2000 gen / pop 1000.
@@ -315,7 +355,7 @@ stale binary can cause a false PoseBustTests failure; rebuild before trusting a 
 ## 6. Commit review & audit (OPS/CI)
 
 Every commit by any agent is reviewed against: (a) §1 parity, (b) §2 determinism if it touches
-parallel code, (c) §3 accuracy if it touches scoring/cleft/GA, (d) §4 ctest, (e) code-conduct in
+parallel code, (c) §3 accuracy when its scientific applicability above is met, (d) §4 ctest, (e) code-conduct in
 `AGENTS.md`, (f) no leaked instrumentation / debug prints / commented-out dead code introduced.
 The review is run through the strongest reviewer model available in the runtime and its verdict is
 recorded. NOTE: model availability is runtime-dependent — if a specifically requested reviewer model

--- a/benchmarks/protocols/admission_metrics_contract.md
+++ b/benchmarks/protocols/admission_metrics_contract.md
@@ -1,286 +1,184 @@
-# Admission + Metrics Contract (Normative)
+# Admission and metrics contract
 
-**Comparative science hub:** `docs/implementation/COMPARATIVE_SCIENCE_README.md`  
-**Status:** Normative for claim-table aggregation and abstract / headline rates.  
-**Aligned with:** `benchmarks/protocols/three_engine_entropy_comparison.md` §1.4–§5, `AGENTS.md`, audit 2026-07-17.  
-**Enforcement:** `scripts/aggregate_claim_metrics.py` (fail-closed).
+**Canonical methodology:** [METHODOLOGY.md §0.3](../../METHODOLOGY.md#03-admission-identity-missingness-and-repair-evidence).
+`AGENTS.md` governs coding conduct. This document maps that methodology to the
+CSV interface enforced by `scripts/aggregate_claim_metrics.py`.
 
----
+## 1. What this report establishes
 
-## 1. Success metrics (report all; headline is claim_ready)
+The aggregator checks **receipt-field completeness and internal consistency**.
+Every report carries `evidence_level=validated_receipt_fields` and
+`artifacts_verified=false`. Matching SHA-256 strings do not establish that a
+validator ran, that the described files still exist, or that those files hash
+to the supplied values. Publication still requires the underlying run,
+configuration, elected pose, receptor condition, reference, raw validator
+outputs, and provenance review.
 
-| ID | Definition | Role |
-|----|------------|------|
-| **S1** | Elected pose **ordered direct** `rmsd_to_crystal` ≤ 2.0 Å and `seed_echo==0` | RMSD-only diagnostic of election |
-| **S2** | S1 ∧ `pb_pass` on the **same** elected pose (`success_pb`) | Intermediate (RMSD∧PB) |
-| **STRICT** / **claim_ready** | Engine `claim_ready==1`: S2 ∧ official PoseBusters ∧ tENCoM/Eigen complete on exact pose SHA-256 ∧ protocol eligibility ∧ score–pose consistency | **Primary / claim KPI** |
-| **S3** | `conditional_scanned_pool_ceiling` / `best_cluster_rmsd` ≤ 2.0 Å | **Diagnostic only** (scanned heads/members, **not** any-pose) |
+A stored `claim_ready=1` is a required producer attestation. It is never a
+substitute for the measurements and receipts below. Existing historical CSVs
+that lack required evidence cannot supply STRICT successes through this tool.
+They may still supply explicitly labelled diagnostics when their protocol
+eligibility fields are complete.
 
-### Field mapping (DatasetRunner `result.csv`)
+## 2. Separate metrics and populations
 
-| Metric | Required / preferred fields |
-|--------|------------------------------|
-| Elected RMSD (S1) | **`rmsd_to_crystal` only** (ordered direct, whole-ligand). **Never** `rmsd_hungarian` for S1/admission |
-| Hungarian | `rmsd_hungarian` — diagnostic symmetry metric only |
-| PoseBusters | `pb_pass`, `success_pb`, `pb_backend==bust_cli` for claims |
-| Strict claim | **`claim_ready==1`** (and receipts: pose hashes, `tencom_status==ok`, `eigen_status==ok`) |
-| Pool ceiling (S3) | `conditional_scanned_pool_ceiling` → else `best_cluster_rmsd` (scanned emission pool only) |
+| Metric | Per-observation test | Role |
+|---|---|---|
+| S1 | Finite nonnegative elected in-place graph-symmetry RMSD at the §0 cutoff; otherwise labelled serial/legacy ordered fallback | RMSD-only diagnostic |
+| S2 | S1 and `pb_pass=1`, with a valid elected pose SHA-256 matching `posebusters_pose_sha256` | RMSD/PB receipt diagnostic |
+| STRICT | Recomputed serial RMSD, PB, score, validator and protocol receipt conjunction below | Primary **receipt-level** headline |
+| S3 | Finite nonnegative `conditional_scanned_pool_ceiling`, else `best_cluster_rmsd` / `rmsd_bcr`, at the §0 cutoff | Conditional scanned-pool diagnostic; never any-pose success |
 
-### Hard rules
+`rmsd_hungarian` cannot substitute for an elected S1 or STRICT measurement.
+`rmsd_to_crystal` retains its serial identity-mapping meaning. Symmetry-corrected
+S1 does not change the producer's serial STRICT gate. The ordering arguments in
+§0.0 require the same atoms, graph, coordinates, and valid identity mapping;
+they do not authenticate a foreign sidecar or an incompatible topology.
 
-1. **Headline claim rate = claim_ready only** (not S1, not S3).
-2. **S1 uses ordered direct RMSD only** — never Hungarian for claim S1.
-3. **Never report S3 as abstract / headline success.** Label as diagnostic conditional scanned-pool ceiling.
-4. **Always report S1, S2, STRICT (claim_ready), and S3 separately.**
-5. **Election gap** = S3=1 and S1=0 (scanned pool had ≤2 Å; elector missed). Diagnostic only.
-6. Generator **CF top-1** and **entropy/consensus reranked top-1** are separate estimands (paths, scores, hashes, RMSDs) when both are present.
+All metric numerators count **unique frozen-roster targets** using the declared
+observation rule. Off-manifest rows never inflate diagnostic or STRICT rates.
+S1/S2/S3 are evaluated on protocol-eligible rows independently of whether STRICT
+passes. A tENCoM failure or false `claim_ready` therefore cannot erase a valid
+RMSD diagnostic. `N_protocol_eligible` counts those observations; `N_claim` counts
+individual STRICT receipt successes, while each metric's `n` counts targets.
+Neither count should be confused with the other in multi-seed analyses.
 
----
+No `success`, `success_s1`, `success_rmsd` or `success_s3` flag can replace a
+missing/nonfinite RMSD. For S2, `success_pb` does not override `pb_pass`: it also
+contains the producer's serial RMSD gate and is a different predicate from
+symmetry-corrected S1 plus PB. Present contradictory PB run/count/failure fields
+also defeat S2; independence from STRICT does not permit a diagnostic to ignore
+contradictions in its own measurements.
 
-## 2. Claim admission (row must pass all)
+## 3. Required receipt fields
 
-A row is **claim-eligible** only if:
+Protocol eligibility requires every one of these:
 
-| Check | Required value |
-|-------|----------------|
-| `seed_echo` | **0** (explicit; missing fails closed) |
-| `native_pose_seeded` | **0** (explicit; missing fails closed) |
-| `matrix_md5` | equals campaign matrix pin when present |
-| `protocol_claim_eligible` | true when column present |
-| **`claim_ready`** | **1** when column present (strict admission) |
-| Hash receipts (when present) | `rmsd_pose_sha256` / `posebusters_pose_sha256` / `tencom_pose_sha256` match `pose_sha256` |
-| Validator status (when present) | `tencom_status==ok`, `eigen_status==ok`, `pb_backend==bust_cli` |
+- Explicit `seed_echo=0` and `native_pose_seeded=0`.
+- Explicit `protocol_claim_eligible=1`.
+- A syntactically valid row `matrix_md5` equal to the selected expected pin.
+  A campaign/default pin alone is not evidence of which matrix a row used.
+- If `native_pose_seed_fraction` is supplied, it must be finite zero; a blank fails.
 
-Rows missing `claim_ready` but satisfying seed gates are admitted only for **legacy diagnostic** tables; they **must not** contribute to STRICT headline. The aggregator reports them under `N_legacy_no_claim_ready` and excludes them from STRICT rates.
+STRICT additionally requires every one of these:
 
-### Default matrix pin
+- `claim_ready=1`, `success_rmsd=1`, `success_pb=1`, `pb_pass=1`, and
+  `score_pose_consistent=1`.
+- Finite nonnegative serial `rmsd_to_crystal` within the §0 cutoff.
+- Finite `score_pose_delta` within the producer's absolute tolerance, `1e-4`.
+- `pb_backend=bust_cli`, `tencom_status=ok`, and `eigen_status=ok`.
+- Syntactically valid 64-hex-character `pose_sha256`, `rmsd_pose_sha256`,
+  `posebusters_pose_sha256`, and `tencom_pose_sha256`; the latter three must
+  equal the elected pose anchor. Hexadecimal comparison is case insensitive.
+- A valid `posebusters_input_sha256`. The PB input may be a converted SDF, so
+  its hash is not required to equal the elected PDB hash.
+- If `docking_completed` or `docking_exit_code` is present, it must explicitly
+  assert completion or zero exit respectively. Missing runtime fields remain
+  an identified limitation of older producer schemas; a present blank or
+  unknown value cannot be treated as success.
 
-| Field | Value |
-|-------|--------|
-| Canonical matrix | campaign-dependent (see RUN_RECEIPT) |
+STRICT requires `pb_ran=1`, `pb_n_checks=27`, `pb_n_pass=27`, `pb_n_fail=0`,
+positive integer `eigen_n_modes`, and finite `elected_H_vib`. The count 27 is
+pinned to the current mandatory `BustCli` check schema; a schema revision must
+update the producer, aggregator, and regression controls together. Historical
+summaries missing these fields are diagnostics, not full STRICT evidence.
 
----
+When supplied, `num_poses` must be a positive integer, `pb_failed_keys` empty,
+and `rmsd_fail_reason` exactly the success sentinel `none`. Present contradictory
+or blank numeric/failure state cannot be overridden by status flags.
 
-## 2b. Solvent condition (NORMATIVE — added 2026-09-04)
+Every missing or contradictory STRICT field produces an explicit failure reason.
+CLI, `RUN_RECEIPT.json`, and `provenance.json` matrix pins must agree when supplied;
+malformed receipts and conflicting pins are errors.
 
-**Every PoseBusters-derived rate in this contract is conditional on which waters the
-validator saw, and until now that was not the set the engine scored against.**
+## 4. Identity, denominator, and repeated seeds
 
-### The engine's shipped policy
+A primary rate requires a frozen manifest with schema
+`flexaidds.astex.target_manifest/v1`, containing unique uppercase target
+codes, matching `N`, and a valid `sha256_of_sorted_codes`. The digest is SHA-256
+of the UTF-8/ASCII **comma-joined sorted codes, without a terminal newline**.
+The default is `astex85_target_manifest.json`; a different preregistered roster
+must be selected explicitly using `--manifest`. An intact digest establishes
+internal integrity, not the historical date or independence of preregistration.
+Missing/corrupt manifests are errors, never an implicit smaller denominator.
 
-`config_parser.cpp:362-369` defaults to `remove_water=true`,
-`keep_structural_waters=true`, `structural_water_bfactor_max=20.0`.
-`modify_pdb.cpp:158-166` implements that combination as **B-factor-thresholded
-conserved-water retention**: an `HOH` is dropped only when its B-factor exceeds
-the threshold. It is *not* full stripping. The banner at `modify_pdb.cpp:59`
-prints whenever `exclude_het || remove_water` and is **not** a count.
+One row per target is labelled `single_observation`. It is not evidence of
+majority-of-seeds behavior. More than one observation per target requires
+`--expected-seeds` with the prespecified seed list. Per METHODOLOGY §0.3,
+strictly more than half of **all expected seeds** must pass; missing seeds do
+not pass, and even-seed ties fail. The report lists absent expected target/seed
+observations. Every target still contributes at most one numerator unit.
 
-Measured with `FLEXAIDDS_WRITE_FLEXED_RECEPTOR=1` on 1JD0: the receptor as scored
-holds 4325 atoms including 156 `HOH`, every one at B ≤ 20 and none above; 504
-waters in, 156 retained. The loader's 4338 reconciles exactly as
-4169 non-water + 156 conserved + 13 ligand. Across the 84-target roster,
-**2822 of 28608 crystallographic waters (9.9%) reach the search**; 18 targets have
-waters and retain none; 1 target (1IGJ) has none at all.
+Seed identities are unsigned 64-bit decimal integers, canonicalized before
+comparison: `1` and `01` are the same seed. Arbitrary labels and out-of-range
+values are rejected. Legacy single-observation rows may omit a seed; repeated
+observations may not.
 
-### Hard rules
+Duplicate target/seed identities are errors, including byte-identical copies.
+The tool never clips rates, silently deduplicates, or chooses the best replicate.
+Mixed arm or endpoint values, including a mixture of missing and supplied values,
+are rejected. `--arm` may explicitly select an arm, and the number of filtered
+observations is reported. Separate endpoints must be supplied as separate sources.
+Rows lacking all arm/endpoint labels can be analyzed as legacy single-observation
+inputs with `unspecified` labels; those labels disclose incomplete protocol
+identity and must be resolved against source receipts before publication.
 
-7. **Every PB-derived rate MUST name its receptor condition.** A bare
-   `pb_pass`/`success_pb`/`claim_ready` rate is incomplete without it.
-8. **The claim-bearing condition is ENGINE-MATCHED**: the conditioning receptor
-   passed to `bust -p` must contain exactly the waters the engine retained
-   (`<T>_apo.pdb` minus `HOH` with B > `structural_water_bfactor_max`).
-9. **Full-receptor PB rates are SUPERSEDED, not merely noisier.** They judge the
-   pose against waters the search never saw — 348 per target on 1JD0, ~25,786
-   across the set. Measured on 77 paired rigid cells (seed 12345), STRICT rule
-   (§2b rule 14): all-waters 41.6%, engine-matched **68.8%**, no-waters 72.7%.
-   The full-receptor tier is biased downward by ~27 points and must not be
-   reported as a headline.
-10. **Water removal can only remove failures**, so an engine-matched rate that
-    exceeds a full-receptor rate is expected, not suspicious. Zero losses across
-    the correction is the internal check; a loss indicates a defect.
+Do not conflate unassessable measurements with physical invalidity. Missing PB
+assessments remain named missing observations and cannot enter a STRICT numerator;
+they do not shrink its frozen denominator. A separately reported PB-only assessed
+subset must state its own assessability rule and count and is a distinct estimand.
 
-### The PB pass rule (NORMATIVE)
+## 5. CSV, source, and sidecar contracts
 
-14. **A pose passes only if EVERY check column in `bust_raw.csv` is literally
-    `True`**, excluding the three non-check columns (`file`, `molecule`,
-    `position`) and the `rmsd_≤_2å` column (`BustCli.h:42` records but excludes
-    it). **A blank is a FAILURE, not a pass** — a blank means the check did not
-    run. This is 27 check columns.
+- CSV headers must be unique and nonblank. Every record must have the exact
+  header width, with an unambiguous target identity. Malformed input is rejected.
+- Per-target `*/result.csv` must contain exactly one observation. No hidden
+  second row is silently discarded.
+- A directory containing both per-target files and recognized summaries, or
+  multiple recognized summaries, is ambiguous. Select a source with `--csv`.
+  The tool does not infer source authority from filenames, ordering, or mtimes.
+- A usable symmetry sidecar row must have `status=ok`, finite nonnegative RMSD,
+  and a valid pose SHA-256. Joins require both target and pose hash. Duplicate
+  sidecar target/pose identities and absent/mismatching pose hashes are errors.
+  Multiple poses of one target can coexist only under distinct hashes.
+- Live files are local-first. CloudDocs must be staged through
+  `scripts/icloud_safe_io.py`; this aggregator refuses direct CloudDocs reads.
 
-15. **Do NOT derive the check set by testing which columns are boolean-valued
-    across the corpus.** A predicate that admits `''` into the boolean set
-    silently drops every sometimes-blank column. Measured consequence on the
-    154-cell NO_SEC corpus: such a predicate kept 16 columns and dropped 11 —
-    `internal_steric_clash`, `bond_lengths`, `bond_angles`,
-    `aromatic_ring_flatness`, `non-aromatic_ring_non-flatness`,
-    `double_bond_flatness`, `double_bond_stereochemistry`,
-    `tetrahedral_chirality`, `molecular_formula`, `molecular_bonds`,
-    `internal_energy`. **`internal_steric_clash` is `False` on 3 of 154 cells**,
-    so dropping it makes the rule LOOSER: poses with intramolecular clashes pass.
-    Ten of the eleven are vacuous in practice (always `True`, blank on the same
-    2 cells, both of which fail other checks); the strict rule changes the rigid
-    engine-matched count by exactly 1 cell (54 → 53). The looseness is small but
-    it is in the direction that flatters the engine.
+## 6. Interpretation of validators and election
 
-### PB denominator: 8 targets are NOT ASSESSABLE under the current invocation
+PoseBusters-derived results are conditional on the receptor and solvent condition
+actually supplied to the validator. Claim review must establish the engine-matched
+condition from artifacts; the aggregator cannot infer it from `pb_pass`.
+The canonical raw PB check set belongs to the versioned `BustCli` schema, not to
+a predicate learned from whichever columns happened to be boolean in a corpus.
+Blank, missing, or nonboolean check values cannot count as a pass.
 
-16. **A PB rate MUST state its own denominator, and a target PoseBusters could
-    not score is NOT ASSESSED — never a failure.** Measured on the 84-target
-    roster: 7 targets wrote a **0-byte** `bust_raw.csv` with `pb_pass=false`, and
-    an 8th (`1TW6`) produced a row whose chemistry columns are blank. So a rate
-    quoted `x/84` counts 7–8 unmeasurable cells as failures, and the honest
-    denominator is **76–77**.
+Retain raw PB CSV and execution receipts before returning a schema failure.
+Keep RMSD reference and PB input provenance separate if their instruments differ.
+Historical solvent or aromaticity analyses are observations about their exact
+files and invocation; their rates and denominators are not universal admission
+constants.
 
-    | Target | Symptom |
-    |--------|---------|
-    | `1K3U` `1N2V` `1U1C` `1U4D` `1XOZ` `1Y6R` `2BSM` | 0-byte `bust_raw.csv`, `pb_pass=false` |
-    | `1TW6` | row present, chemistry columns blank |
+The elected entropy/consensus top-1 and generator CF top-1 are separate estimands.
+Preserve separate paths, scores, hashes, and RMSDs. Do not join restarts by rounded
+CF value. S3 is the minimum over actually enumerated emitted heads/members; it
+must never clear `seed_echo`, rewrite `pose_source`, or become an any-pose claim.
 
-    **Cause, established by re-invocation.** The ligand SDF for these targets
-    carries an aromatic bond block RDKit cannot kekulize
-    (`KekulizeException: Can't kekulize mol`), so `MolFromMolFile` returns
-    `None` and `SDMolSupplier` yields 0 non-`None` molecules. This is **in the
-    cache input, not written by the engine** — the native `<T>_ligand.sdf` and
-    the written pose SDF have the *identical* bond-order histogram
-    (1K3U: 9×single, 3×double, 10×aromatic) and both fail identically, while
-    control targets parse in both. It is therefore **not** the pose→SDF writer
-    defect reported elsewhere.
-
-    **Why it is fatal only in the harness.** The harness passes
-    `-l <crystal_sdf>` (`BustCli.cpp:243-244`), which puts PoseBusters on the
-    RMSD path and that path requires a sanitized reference. Measured:
-    `bust <pose> -p <apo>` returns **1 row** for all 8 targets, while
-    `bust <pose> -l <crystal> -p <apo>` returns **0 rows** on 1K3U and 1 row on
-    1JD0. Scored without `-l`, three of the eight (`1K3U`, `1XOZ`, `1Y6R`) pass
-    **every physical check**; all eight report `sanitization=False` and
-    `inchi_convertible=False`. So the exclusion is **not neutral** — it removes
-    targets that would have passed the chemistry.
-
-17. **Do not "fix" this by dropping `-l`.** Without a reference, PoseBusters
-    cannot compute RMSD and the result cannot satisfy S2 (§1). The two admissible
-    repairs are: (a) repair the cache SDF aromaticity so the reference sanitizes,
-    or (b) take RMSD from the engine's own `rmsd_to_crystal` and run PoseBusters
-    without `-l`, declaring the split provenance. Either way the 8 targets must
-    be reported as a named, counted exclusion until repaired.
-
-### Scope limit on the numbers above
-
-These figures are an **S2-grade PB tier, NOT `claim_ready`** — `claim_ready`
-additionally requires tENCoM/Eigen completion, protocol eligibility and
-score–pose consistency per §1. `claim_ready` *inherits* the solvent condition
-through its PB component and must be recomputed under rules 8 and 14 before it
-is quoted. The 16-column rule reproduces the harness's stored `pb_pass` on
-154/154 cells, so the harness's own `pb_pass` carries the same looseness.
-
-### Ablation status
-
-The retention policy is **the shipped default and has never been ablated.** It
-was never chosen: the `protein` config block was not emitted until commit
-`70dd2ed4`, so every key took its parser fallback on every cell this project has
-ever run. All three conditions are now reachable
-(`FLEXAIDDS_REMOVE_WATER`, `FLEXAIDDS_KEEP_STRUCTURAL_WATERS`,
-`FLEXAIDDS_STRUCTURAL_WATER_BFACTOR_MAX`) and default-off is proven byte-identical
-at production settings. **Methods text must state the policy** rather than imply
-a dry receptor.
-
----
-
-## 2c. Scored endpoint (NORMATIVE — added 2026-09-04)
-
-**The two candidate endpoints disagree on a majority of cells, so a rate without a
-declared endpoint is unreadable.**
-
-| Endpoint | Definition | Status |
-|----------|------------|--------|
-| `argmin(ACF)` | Cluster free energy over members; what the engine **ships** | Primary — declare explicitly |
-| `argmin(CF)` | Lowest contact-function pose in the emitted pool | Secondary / sensitivity |
-
-Measured on 83 rigid NO_SEC cells (seed 12345, ordered-direct RMSD): ACF 40/83 =
-48.2%, CF 44/83 = 53.0%. Per-cell endpoint agreement is 34.9% rigid and 39.8%
-flexible.
-
-### Hard rules
-
-11. **Every claim table MUST carry an endpoint column**, and every reported rate
-    MUST name its endpoint. The two are separate estimands (§1 rule 6).
-12. **Banner-to-pose joins key on the restart directory path**, never on the CF
-    value — two restarts share a rank-0 CF to 3 d.p. on 22% of cells, making a
-    value-join non-deterministic.
-13. **Multi-seed aggregation is majority-of-seeds, never union.** A union
-    systematically flatters the noisier arm.
-
-    **WHY, so this is not "simplified" back into a union.** A p-value is a
-    function of the number of INDEPENDENT observations. Three seeds on one target
-    are three looks at the same target, not three targets: they share the
-    receptor, the pocket, the ligand and the reference pose. Majority-of-seeds
-    collapses them to ONE per-target verdict, so the headline denominator is the
-    number of TARGETS (84), never the number of cells (84 x 3 = 252). Reporting
-    252 would be pseudo-replication — the test would compute significance for a
-    sample size the experiment does not have, and it fails in the flattering
-    direction, so nothing in the output flags it.
-
-    Union is worse than merely non-independent: taking the best of three seeds is
-    a maximum over noise, which is biased upward by construction.
-
-    **The same rule binds any per-item replication, not just seeds:** restarts
-    within a cell, multiple poses of one target, multiple structures of one
-    receptor. MEASURED elsewhere in this project: an n=11 two-state result was 11
-    pairs drawn from only 5 receptors (3+3+2+2+1), so its reported Wilcoxon p was
-    computed over non-independent observations; the honest n was 5. Report the
-    count of independent units and name what the unit is.
-
-    **Residual, to be stated as a limitation rather than fixed:** the 84 Astex
-    targets are not 84 fully independent draws either — the set contains related
-    proteins (several kinases, several proteases). That affects interval width,
-    not the point rate, and it must be declared, not corrected away.
-| **Fallback MD5** | `9dc93717dfed0698006d88dd6a9627bc` (aggregator default; receipt wins) |
-
----
-
-## 3. Aggregator CLI
+## 7. CLI and validation
 
 ```bash
-python3 scripts/aggregate_claim_metrics.py <campaign_dir> [--json out.json]
-python3 scripts/aggregate_claim_metrics.py --c0-full85
-python3 scripts/aggregate_claim_metrics.py <dir> --headline strict   # default
-python3 scripts/aggregate_claim_metrics.py <dir> --headline s1       # RMSD-only diagnostic
-python3 scripts/aggregate_claim_metrics.py <dir> --headline s3 --diagnostic-only
+python3 scripts/aggregate_claim_metrics.py --csv results.csv --json metrics.json
+python3 scripts/aggregate_claim_metrics.py --csv results.csv --expected-seeds 12345,23456,34567
+python3 scripts/aggregate_claim_metrics.py --csv results.csv --arm A --manifest frozen_targets.json
+python3 scripts/aggregate_claim_metrics.py --csv results.csv --symmcorr elected_symmcorr.csv --headline s1
+python3 scripts/aggregate_claim_metrics.py --csv legacy.csv --legacy-observed-denominator --diagnostic-only --headline s1
 ```
 
-`--headline s3` requires `--diagnostic-only` or exit 2.
+The explicit legacy denominator mode produces no STRICT rate. `--headline s3`
+requires `--diagnostic-only`. Exit 2 means malformed input or contract violation;
+exit 1 means no STRICT receipt successes. In diagnostic-only mode, nonempty
+observations can return zero even when STRICT has no successes.
 
----
-
-## 4. PoseBusters receipts (engine)
-
-Upstream `bust` results must preserve **raw CSV before schema failure returns**, and receipt
-(`<pdb>_bust_receipt.json` under the per-target PoseBusters sidecar):
-
-- resolved binary path, file SHA-256, version string (if available)
-- full argv, exit status, raw CSV SHA-256 / path
-- version-pinned mandatory check columns — **every** listed check header required;
-  duplicate headers and header/value column-count mismatches fail closed
-
-Shared strict finite PDB coordinate decoder: `LIB/PoseBust/PdbCoords.h`
-(used by DatasetRunner RMSD and PoseBust loaders). Topology transfer is
-graph-identity only (element sequence + full atom counts including H/Du);
-positional remapping of repeated elements is rejected.
-
-## 5. Dual election estimands (DatasetRunner)
-
-When Softβ / entropy election is active, persist **separately**:
-
-| Estimand | Fields |
-|----------|--------|
-| Generator CF top-1 | `cf_top1_pose_path`, `cf_top1_score`, `cf_top1_rmsd`, `cf_top1_pose_sha256` |
-| Entropy/consensus top-1 | `entropy_top1_pose_path`, `entropy_top1_score`, `entropy_top1_rmsd`, `entropy_top1_pose_sha256` |
-
-Elected headline still uses the Softβ/consensus path; CF top-1 never silently
-overwrites `seed_echo` / elected provenance.
-
-## 6. Pool ceiling naming
-
-`conditional_scanned_pool_ceiling` (= legacy `best_cluster_rmsd`) is the min
-**ordered** RMSD over **actually enumerated** emitted cluster heads and
-existing `_member*` files. It is **not** any-pose / full emission census.
-Pool ceiling must never clear or mutate `seed_echo` or `pose_source`.
+Regression gates: `tests/test_aggregate_claim_metrics.py`, the aggregator wiring
+in `tests/test_rmsd_symmcorr.py`, and
+`tests/p0_claim_contract/test_fixed_denominator.py`.

--- a/ops/engine_repro_gate.py
+++ b/ops/engine_repro_gate.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Isolated engine receipts and exact scientific-output comparisons.
+
+run-one creates a NEW output directory, pins inputs/environment/build metadata,
+runs one explicitly selected binary, and admits only complete outputs. compare
+rechecks artifact hashes and shapes, then compares ranks and grid ordering. Only
+FLEXAID.commit and FLEXAID.dirty values on their dedicated provenance REMARK may
+be normalized; every other emitted byte, including the seed, is retained.
+
+All gate comparisons require generation-zero receipts. Explicit observer-off
+transparency runs are non-gate diagnostics and cannot pass a gate comparison. METHODOLOGY.md sections 1-2 define gate interpretation.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import signal
+import struct
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+RUN_SCHEMA = "flexaidds.engine_repro_run.v1"
+GEN0_SCHEMA = "flexaidds.ga_population_receipt.v1"
+SEED = "12345"
+EXPECTED_POPULATION = 1000
+RANK_COUNT = 10
+PROVENANCE = re.compile(rb"^(REMARK FLEXAID\.commit=)([^ \r\n]+)( FLEXAID\.dirty=)([012])( FLEXAID\.seed=([0-9]+)[^\r\n]*)(\r?\n|$)", re.MULTILINE)
+CF_LINE = re.compile(rb"^REMARK CF=\s*([^\s\r\n]+)\s*$", re.MULTILINE)
+BITS64 = re.compile(r"0x[0-9a-fA-F]{16}\Z")
+BITS32 = re.compile(r"0x[0-9a-fA-F]{8}\Z")
+CF_FIELDS = {"com_bits", "con_bits", "wal_bits", "sas_bits", "elec_bits", "gist_bits",
+             "hbond_bits", "gist_desolv_bits", "metal_coord_bits", "h_rep_bits", "entropy_bits",
+             "pb_clash_bits", "totsas_bits", "nor_bits", "rclash"}
+RECORD_FIELDS = {"index", "status", "genes", "cf", "evalue_bits", "app_evalue_bits", "fitnes_bits",
+                 "boltzmann_weight_bits", "free_energy_bits", "ring_phases_bits", "ring_six", "ring_five"}
+PROTECTED_ENV = {"FLEXAID_SEED", "OMP_NUM_THREADS", "FLEXAIDDS_NO_SEC", "FLEXAIDDS_RESTARTS",
+                 "FLEXAIDDS_DATA_DIR", "FLEXAIDDS_PARALLEL_REPRODUCE", "FLEXAIDDS_GEN0_RECEIPT", "FLEXAIDDS_CACHE_READONLY",
+                 "FLEXAIDDS_VORONOI_KEYED_JITTER"}
+
+
+class GateError(ValueError):
+    pass
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def pin_file(path: Path) -> dict[str, Any]:
+    path = path.resolve(strict=True)
+    if not path.is_file() or path.stat().st_size == 0:
+        raise GateError(f"missing or empty file: {path}")
+    if "Mobile Documents" in path.parts or "com~apple~CloudDocs" in path.parts:
+        raise GateError("stage all inputs locally; CloudDocs is not a compute filesystem")
+    return {"path": str(path), "bytes": path.stat().st_size, "sha256": sha256(path)}
+
+
+def json_read(path: Path) -> dict:
+    def unique_pairs(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise GateError(f"duplicate JSON key {key!r} in {path}")
+            result[key] = value
+        return result
+    def finite_float(text):
+        value = float(text)
+        if not math.isfinite(value):
+            raise GateError(f"nonfinite JSON number in {path}")
+        return value
+    value = json.loads(path.read_text(), object_pairs_hook=unique_pairs, parse_float=finite_float,
+                       parse_constant=lambda value: (_ for _ in ()).throw(GateError(f"nonfinite JSON token: {value}")))
+    if not isinstance(value, dict):
+        raise GateError(f"JSON object required: {path}")
+    return value
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n")
+
+
+def checked_git(source: Path, *args: str) -> bytes:
+    result = subprocess.run(["git", "-C", str(source), *args], capture_output=True, timeout=30)
+    if result.returncode:
+        raise GateError(f"cannot capture source metadata: git {' '.join(args)}: {result.stderr.decode(errors='replace')}")
+    return result.stdout
+
+
+def source_build_metadata(source: Path, build: Path) -> dict:
+    source, build = source.resolve(strict=True), build.resolve(strict=True)
+    cache = build / "CMakeCache.txt"
+    cache_pin = pin_file(cache)
+    entries = {}
+    for line in cache.read_text().splitlines():
+        if line and not line.startswith(("#", "//")) and "=" in line and ":" in line.split("=", 1)[0]:
+            key, value = line.split("=", 1)
+            entries[key.split(":", 1)[0]] = value
+    if not entries.get("CMAKE_HOME_DIRECTORY") or Path(entries["CMAKE_HOME_DIRECTORY"]).resolve() != source:
+        raise GateError("CMake cache source directory does not match --source-dir")
+    generated = [build / name for name in ("build.ninja", "Makefile") if (build / name).is_file()]
+    if not generated:
+        raise GateError("build metadata requires a generated build.ninja or Makefile")
+    diff = checked_git(source, "diff", "--binary", "HEAD")
+    untracked = []
+    for raw in checked_git(source, "ls-files", "--others", "--exclude-standard", "-z").split(b"\0"):
+        if raw:
+            path = source / os.fsdecode(raw)
+            if path.is_file():
+                untracked.append({"relative_path": os.fsdecode(raw), "sha256": sha256(path), "bytes": path.stat().st_size})
+    files = [cache_pin, *(pin_file(path) for path in generated)]
+    if entries.get("FLEXAIDS_USE_OPENMP", "").upper() not in ("ON", "1", "TRUE", "YES"):
+        raise GateError("merge validation requires FLEXAIDS_USE_OPENMP=ON")
+    compile_flags = []
+    commands_path = build / "compile_commands.json"
+    if commands_path.is_file():
+        commands = json.loads(commands_path.read_text())
+        for entry in commands:
+            command = entry.get("command", "") or " ".join(entry.get("arguments", []))
+            if Path(entry.get("file", "")).name == "gaboom.cpp" and "CMakeFiles/FlexAIDdS.dir/" in command:
+                compile_flags.append(command)
+    if not compile_flags:
+        flags_path = build / "CMakeFiles/FlexAIDdS.dir/flags.make"
+        if flags_path.is_file():
+            compile_flags.append(flags_path.read_text())
+            files.append(pin_file(flags_path))
+    if not compile_flags or any("-fopenmp" not in text or re.search(r"[-/]D\s*FLEXAID_DETERMINISTIC(?:\b|=)", text) for text in compile_flags):
+        raise GateError("actual FlexAIDdS/gaboom compile flags must enable OpenMP and omit FLEXAID_DETERMINISTIC")
+    for name in ("compile_commands.json", "CMakeFiles/TargetDirectories.txt"):
+        if (build / name).is_file():
+            files.append(pin_file(build / name))
+    return {"source_dir": str(source), "source_commit": checked_git(source, "rev-parse", "HEAD").decode().strip(),
+            "source_status": checked_git(source, "status", "--porcelain=v1", "--untracked-files=all").decode(),
+            "tracked_diff_sha256": hashlib.sha256(diff).hexdigest(), "untracked_files": untracked,
+            "build_dir": str(build), "build_files": files, "openmp_compile_flags": compile_flags,
+            "cmake": {key: value for key, value in entries.items() if key.startswith(("CMAKE_", "BUILD_", "USE_", "ENABLE_", "FLEXAID", "OpenMP_"))},
+            "evidence_limit": "Source/build metadata captured; this receipt does not independently prove compiler execution."}
+
+
+def validate_config(path: Path) -> dict:
+    config = json_read(path)
+    ga = config.get("ga", {})
+    reference = config.get("reference_ligand", {})
+    if ga.get("num_generations") != 2000 or ga.get("num_chromosomes") != 1000:
+        raise GateError("merge gate requires explicit ga.num_generations=2000 and ga.num_chromosomes=1000")
+    if reference.get("pose_seed_enabled") is not False or reference.get("seed_fraction") != 0:
+        raise GateError("merge gate requires explicit disabled native-pose seeding and zero seed_fraction")
+    if config.get("grid_file"):
+        raise GateError("grid_file reuse is forbidden: this gate must generate and compare new grids")
+    return config
+
+
+def normalize_pose(path: Path) -> tuple[bytes, dict]:
+    data = path.read_bytes()
+    matches = list(PROVENANCE.finditer(data))
+    if len(matches) != 1 or matches[0].group(6).decode() != SEED:
+        raise GateError(f"{path.name}: exactly one recognized commit/dirty/seed={SEED} REMARK required")
+    cf = list(CF_LINE.finditer(data))
+    if len(cf) != 1:
+        raise GateError(f"{path.name}: exactly one elected CF REMARK required")
+    try:
+        if not math.isfinite(float(cf[0].group(1))):
+            raise ValueError()
+    except ValueError:
+        raise GateError(f"{path.name}: nonfinite or invalid elected CF")
+    if not data.splitlines() or data.splitlines()[-1] != b"END":
+        raise GateError(f"{path.name}: missing final END record")
+    atoms = [line for line in data.splitlines() if line.startswith((b"ATOM  ", b"HETATM"))]
+    if not atoms:
+        raise GateError(f"{path.name}: no coordinate records")
+    for line in atoms:
+        try:
+            if not all(math.isfinite(float(line[start:start + 8])) for start in (30, 38, 46)):
+                raise ValueError()
+        except ValueError:
+            raise GateError(f"{path.name}: malformed/nonfinite coordinate")
+    normalized = PROVENANCE.sub(lambda m: m.group(1) + b"<commit>" + m.group(3) + b"<dirty>" + m.group(5) + m.group(7), data)
+    return normalized, {"cf_text": cf[0].group(1).decode(), "coordinate_record_count": len(atoms),
+                        "commit_remark": matches[0].group(2).decode(), "dirty_remark": matches[0].group(4).decode(),
+                        "seed_remark": matches[0].group(6).decode()}
+
+
+def validate_grid(path: Path) -> dict:
+    data = path.read_bytes()
+    if len(data) < 12:
+        raise GateError("missing/truncated RRG header")
+    for endian in ("<", ">"):
+        magic, version, count = struct.unpack(endian + "IIi", data[:12])
+        if magic == 0x56435400:
+            break
+    else:
+        raise GateError("unrecognized RRG magic")
+    if version != 1 or count <= 0 or len(data) != 12 + count * 32:
+        raise GateError("invalid RRG version/count/record width or trailing bytes")
+    for offset in range(12, len(data), 32):
+        values = struct.unpack(endian + "ii6f", data[offset:offset + 32])
+        if not all(math.isfinite(value) for value in values[2:]):
+            raise GateError("RRG contains nonfinite coordinate/internal-coordinate values")
+    return {"version": version, "point_count": count, "record_bytes": 32,
+            "byte_order": "little" if endian == "<" else "big",
+            "ordered_records_sha256": hashlib.sha256(data[12:]).hexdigest()}
+
+
+def _integer(value: Any, low: int, high: int, field: str) -> None:
+    if type(value) is not int or not low <= value <= high:
+        raise GateError(f"invalid integer {field}")
+
+
+def _bits(value: Any, width: int, field: str) -> None:
+    pattern = BITS64 if width == 64 else BITS32
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise GateError(f"invalid IEEE bit string for {field}")
+    # Nonfinite values cannot establish a usable initial scoring population.
+    number = struct.unpack(">d" if width == 64 else ">f", bytes.fromhex(value[2:]))[0]
+    if not math.isfinite(number):
+        raise GateError(f"nonfinite generation-zero {field}")
+
+
+def validate_execution(value: Any, expected_threads: int) -> dict:
+    """Require witnessed, complete RANDOM initialization on the requested team."""
+    if (not isinstance(value, dict)
+            or set(value) != {"openmp_compiled", "deterministic_compile", "evaluation_batches"}
+            or value["openmp_compiled"] is not True or value["deterministic_compile"] is not False):
+        raise GateError("generation-zero execution requires OpenMP without deterministic compilation")
+    if type(expected_threads) is not int or expected_threads not in (1, 4):
+        raise GateError("invalid expected OpenMP team size")
+    batches = value["evaluation_batches"]
+    if not isinstance(batches, list) or len(batches) != 1:
+        raise GateError("canonical RANDOM initialization requires one witnessed evaluation batch")
+    batch = batches[0]
+    if (not isinstance(batch, dict)
+            or set(batch) != {"region", "population_count", "popoffset", "workspace_slots", "workers"}
+            or batch["region"] != "populate_chromosomes"):
+        raise GateError("invalid initial-population evaluation batch")
+    _integer(batch["population_count"], EXPECTED_POPULATION, EXPECTED_POPULATION, "batch population_count")
+    _integer(batch["popoffset"], 0, 0, "batch popoffset")
+    _integer(batch["workspace_slots"], expected_threads, 100000, "batch workspace_slots")
+    workers = batch["workers"]
+    if not isinstance(workers, list) or len(workers) != expected_threads:
+        raise GateError("every requested OpenMP worker must witness completed evaluations")
+    ids, evaluated = set(), 0
+    for worker in workers:
+        if not isinstance(worker, dict) or set(worker) != {"worker_id", "team_size", "evaluated_chromosomes"}:
+            raise GateError("invalid observed worker record")
+        _integer(worker["worker_id"], 0, expected_threads - 1, "worker_id")
+        _integer(worker["team_size"], expected_threads, expected_threads, "observed team_size")
+        _integer(worker["evaluated_chromosomes"], 1, EXPECTED_POPULATION, "evaluated_chromosomes")
+        if worker["worker_id"] in ids:
+            raise GateError("duplicate observed worker id")
+        ids.add(worker["worker_id"])
+        evaluated += worker["evaluated_chromosomes"]
+    if evaluated != EXPECTED_POPULATION:
+        raise GateError("witnessed initial evaluations must total configured 1000 chromosomes")
+    return {**value, "observed_threads": expected_threads, "evaluated_chromosomes": evaluated}
+
+
+def validate_gen0(path: Path, expected_threads: int = 1) -> dict:
+    value = json_read(path)
+    if set(value) != {"schema", "boundary", "generation", "population_count", "n_genes", "seed", "execution", "records", "complete"}:
+        raise GateError("unexpected or missing generation-zero top-level fields")
+    if (value.get("schema") != GEN0_SCHEMA or value.get("boundary") != "initial_population_complete_before_reproduction"
+            or type(value.get("generation")) is not int or value.get("generation") != 0
+            or value.get("complete") is not True or value.get("seed") != SEED):
+        raise GateError("invalid generation-zero schema, completion, boundary, generation or seed")
+    count, n_genes = value.get("population_count"), value.get("n_genes")
+    if count != EXPECTED_POPULATION or type(count) is not int:
+        raise GateError("generation-zero population must match configured 1000 chromosomes")
+    execution = validate_execution(value["execution"], expected_threads)
+    _integer(n_genes, 1, 100000, "n_genes")
+    records = value.get("records")
+    if not isinstance(records, list) or len(records) != count:
+        raise GateError("generation-zero population count mismatch")
+    indices, canonical = set(), []
+    for record in records:
+        if not isinstance(record, dict) or set(record) != RECORD_FIELDS:
+            raise GateError("incomplete generation-zero record")
+        index = record["index"]
+        _integer(index, 0, count - 1, "record index")
+        if index in indices:
+            raise GateError("duplicate generation-zero record index")
+        indices.add(index)
+        if type(record["status"]) is not int or record["status"] != ord("n"):
+            raise GateError("generation-zero record is not evaluated (status must be n)")
+        if not isinstance(record["genes"], list) or len(record["genes"]) != n_genes:
+            raise GateError("generation-zero gene count mismatch")
+        for gene in record["genes"]:
+            if not isinstance(gene, dict) or set(gene) != {"to_int32", "to_ic_bits"}:
+                raise GateError("incomplete generation-zero gene")
+            _integer(gene["to_int32"], -(2**31), 2**31 - 1, "gene.to_int32")
+            _bits(gene["to_ic_bits"], 64, "gene.to_ic_bits")
+        cf = record["cf"]
+        if not isinstance(cf, dict) or set(cf) != CF_FIELDS:
+            raise GateError("incomplete generation-zero CF components")
+        for key in CF_FIELDS - {"rclash"}:
+            _bits(cf[key], 64, key)
+        _integer(cf["rclash"], -(2**31), 2**31 - 1, "rclash")
+        for key in ("evalue_bits", "app_evalue_bits", "fitnes_bits", "boltzmann_weight_bits", "free_energy_bits"):
+            _bits(record[key], 64, key)
+        for key in ("ring_phases_bits", "ring_six", "ring_five"):
+            if not isinstance(record[key], list) or len(record[key]) != 16:
+                raise GateError(f"invalid {key}: schema v1 requires MAX_RING_FLEX=16 entries")
+        for bits in record["ring_phases_bits"]:
+            _bits(bits, 32, "ring phase")
+        for key in ("ring_six", "ring_five"):
+            for integer in record[key]:
+                _integer(integer, 0, 255, key)
+        canonical.append(json.dumps({k: v for k, v in record.items() if k != "index"}, sort_keys=True, separators=(",", ":"), allow_nan=False))
+    # Sort whole gene/component pairs. Never sort each channel independently or
+    # discard duplicates: either operation could disguise a broken pairing.
+    canonical.sort()
+    payload = "\n".join(canonical).encode()
+    return {"population_count": count, "n_genes": n_genes,
+            "order_independent_records_sha256": hashlib.sha256(payload).hexdigest(),
+            "distinct_record_count": len(Counter(canonical)), "boundary": value["boundary"],
+            "execution": execution}
+
+
+def inspect_outputs(out: Path, require_gen0: bool, expected_threads: int = 1) -> dict:
+    found = sorted(path.name for path in out.glob("d_*.pdb") if re.fullmatch(r"d_[0-9]+\.pdb", path.name))
+    expected = sorted(f"d_{rank}.pdb" for rank in range(RANK_COUNT))
+    if found != expected:
+        raise GateError(f"exactly ranks 0..9 required; found {found}")
+    poses = []
+    for rank in range(RANK_COUNT):
+        path = out / f"d_{rank}.pdb"
+        if path.is_symlink():
+            raise GateError("output artifacts must not be symlinks")
+        normalized, detail = normalize_pose(path)
+        poses.append({"rank": rank, "file": path.name, **pin_file(path), **detail,
+                      "scientific_sha256": hashlib.sha256(normalized).hexdigest()})
+    grid = out / "d.rrg"
+    if grid.is_symlink():
+        raise GateError("output artifacts must not be symlinks")
+    grid_info = {"file": grid.name, **pin_file(grid), **validate_grid(grid)}
+    receipt = out / "gen0.json"
+    if require_gen0:
+        if receipt.is_symlink():
+            raise GateError("output artifacts must not be symlinks")
+        gen0 = {"file": receipt.name, **pin_file(receipt), **validate_gen0(receipt, expected_threads)}
+    else:
+        gen0 = {"status": "observer_off_transparency_non_gate"}
+        if receipt.exists():
+            raise GateError("unexpected generation-zero file when observer was not requested")
+    return {"poses": poses, "grid": grid_info, "gen0": gen0}
+
+
+def verify_pins(pins: dict) -> None:
+    for group in ("inputs", "runtime_data"):
+        for record in pins[group].values():
+            if pin_file(Path(record["path"])) != record:
+                raise GateError(f"input changed after pinning: {record['path']}")
+
+
+def run_one(args: argparse.Namespace) -> int:
+    args.require_gen0 = not args.observer_off_transparency
+    out = args.out.resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.mkdir(exist_ok=False)
+    manifest_path = out / "run_manifest.json"
+    manifest = {"schema": RUN_SCHEMA, "label": args.label, "run_dir": str(out), "status": "preflight_failed",
+                "started_unix_ns": time.time_ns(), "require_gen0": args.require_gen0, "gate_eligible": args.require_gen0,
+                "normalization": "only commit and dirty values in the dedicated FLEXAID provenance REMARK",
+                "errors": []}
+    try:
+        if not math.isfinite(args.timeout) or args.timeout <= 0:
+            raise GateError("timeout must be finite and positive")
+        if not args.label.strip() or any(c in args.label for c in "\r\n"):
+            raise GateError("run label must be nonempty and single-line")
+        inputs = {name: pin_file(getattr(args, name)) for name in ("engine", "receptor", "ligand", "config")}
+        if not os.access(inputs["engine"]["path"], os.X_OK):
+            raise GateError("engine is not executable")
+        validate_config(Path(inputs["config"]["path"]))
+        data_dir = args.data_dir.resolve(strict=True)
+        matrix = data_dir / "MC_st0r5.2_6.dat"
+        runtime_data = {matrix.name: pin_file(matrix)}
+        for path in sorted(data_dir.iterdir()):
+            if path.is_file() and path.suffix.lower() in {".dat", ".def", ".tbl"}:
+                runtime_data[path.name] = pin_file(path)
+        metadata = source_build_metadata(args.source_dir, args.build_dir)
+        (out / "tmp").mkdir()
+        environment = {"PATH": os.environ.get("PATH", os.defpath), "HOME": os.environ.get("HOME", str(out)),
+                       "TMPDIR": str(out / "tmp"), "LANG": "C", "LC_ALL": "C", "TZ": "UTC",
+                       "FLEXAID_SEED": SEED, "FLEXAIDDS_NO_SEC": "1", "FLEXAIDDS_RESTARTS": "1",
+                       "FLEXAIDDS_CACHE_READONLY": "1",
+                       "FLEXAIDDS_DATA_DIR": str(data_dir), "OMP_NUM_THREADS": str(args.omp_threads),
+                       "OMP_DYNAMIC": "FALSE", "FLEXAIDDS_PARALLEL_REPRODUCE": "1" if args.parallel_reproduce == "on" else "0"}
+        for entry in args.env:
+            key, separator, value = entry.partition("=")
+            if (not separator or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) or key in PROTECTED_ENV
+                    or key.startswith(("OMP_", "KMP_", "GOMP_")) or "DETERMINISTIC" in key):
+                raise GateError(f"invalid/protected explicit environment override: {entry!r}")
+            if key in environment:
+                raise GateError(f"duplicate explicit environment key: {key}")
+            environment[key] = value
+        if args.require_gen0:
+            environment["FLEXAIDDS_GEN0_RECEIPT"] = str(out / "gen0.json")
+        argv = [inputs["engine"]["path"], inputs["receptor"]["path"], inputs["ligand"]["path"],
+                "-c", inputs["config"]["path"], "-o", str(out / "d"), "--data-dir", str(data_dir)]
+        manifest.update(inputs=inputs, runtime_data=runtime_data, source_build=metadata, argv=argv,
+                        environment=environment, status="running")
+        write_json(manifest_path, manifest)
+        start = time.monotonic()
+        with (out / "run.log").open("wb") as log:
+            process = subprocess.Popen(argv, cwd=out, env=environment, stdout=log,
+                                       stderr=subprocess.STDOUT, start_new_session=True)
+            try:
+                manifest["exit_code"] = process.wait(timeout=args.timeout)
+            except (subprocess.TimeoutExpired, KeyboardInterrupt) as exc:
+                # Terminate only the process group launched for this run, including
+                # child tools. Never leave timed-out engines running untracked.
+                try:
+                    os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    try:
+                        os.killpg(process.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.wait()
+                manifest["exit_code"] = process.returncode
+                manifest["timed_out"] = isinstance(exc, subprocess.TimeoutExpired)
+                raise GateError("engine timeout" if manifest["timed_out"] else "run interrupted")
+        manifest["wall_seconds"] = time.monotonic() - start
+        manifest["log"] = pin_file(out / "run.log") if (out / "run.log").stat().st_size else {"path": str(out / "run.log"), "bytes": 0, "sha256": sha256(out / "run.log")}
+        if manifest["exit_code"] != 0:
+            raise GateError(f"engine exited {manifest['exit_code']}")
+        verify_pins(manifest)
+        manifest["outputs"] = inspect_outputs(out, args.require_gen0, args.omp_threads)
+        manifest["status"] = "complete"
+    except (GateError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        manifest["status"] = "failed"
+        manifest["errors"].append(str(exc))
+    manifest["observed_artifacts"] = []
+    for path in sorted(out.iterdir()):
+        if path.is_file() and not path.is_symlink() and path.name != "run_manifest.json":
+            manifest["observed_artifacts"].append({"file": path.name, "bytes": path.stat().st_size,
+                                                   "sha256": sha256(path)})
+    manifest["finished_unix_ns"] = time.time_ns()
+    write_json(manifest_path, manifest)
+    print(json.dumps({"manifest": str(manifest_path), "status": manifest["status"], "errors": manifest["errors"]}))
+    return 0 if manifest["status"] == "complete" else 1
+
+
+def load_run(path: Path) -> dict:
+    path = path / "run_manifest.json" if path.is_dir() else path
+    manifest = json_read(path)
+    out = path.parent.resolve()
+    if manifest.get("schema") != RUN_SCHEMA or manifest.get("run_dir") != str(out):
+        raise GateError("invalid run schema or manifest/output-directory identity")
+    if manifest.get("status") != "complete" or manifest.get("exit_code") != 0 or manifest.get("timed_out"):
+        raise GateError(f"run did not complete successfully: {out}")
+    if manifest.get("gate_eligible") is not True or manifest.get("require_gen0") is not True:
+        raise GateError("observer-off transparency runs cannot pass a gate: generation-zero evidence required")
+    verify_pins(manifest)
+    current = inspect_outputs(out, manifest.get("require_gen0") is True, int(manifest["environment"]["OMP_NUM_THREADS"]))
+    if current != manifest.get("outputs"):
+        raise GateError(f"output artifacts changed after receipt: {out}")
+    return manifest
+
+
+def comparison(args: argparse.Namespace) -> int:
+    report = {"schema": "flexaidds.engine_repro_comparison.v1", "kind": args.kind, "pass": False, "errors": []}
+    try:
+        runs = [load_run(path) for path in args.runs]
+        if len({run["run_dir"] for run in runs}) != len(runs):
+            raise GateError("cannot compare a run with itself")
+        report["runs"] = [{"label": run["label"], "run_dir": run["run_dir"], "engine_sha256": run["inputs"]["engine"]["sha256"],
+                           "source_commit": run["source_build"]["source_commit"], "outputs": run["outputs"]} for run in runs]
+        if args.kind == "parity":
+            if len(runs) != 2 or any(run["environment"]["OMP_NUM_THREADS"] != "1" or run["environment"]["FLEXAIDDS_PARALLEL_REPRODUCE"] != "0" for run in runs):
+                raise GateError("parity requires exactly two OMP1 runs with parallel reproduction OFF")
+            if runs[0]["inputs"]["engine"]["path"] == runs[1]["inputs"]["engine"]["path"]:
+                raise GateError("parity requires distinct baseline and candidate engine paths")
+            if len({run["require_gen0"] for run in runs}) != 1:
+                raise GateError("parity observer requirements must match")
+        else:
+            if len(runs) != 4 or sorted(run["environment"]["OMP_NUM_THREADS"] for run in runs) != ["1", "1", "4", "4"]:
+                raise GateError("determinism requires two OMP1 and two OMP4 runs")
+            if any(run["environment"]["FLEXAIDDS_PARALLEL_REPRODUCE"] != "1" or not run["require_gen0"] for run in runs):
+                raise GateError("determinism requires reproduction ON and generation-zero receipts in all four runs")
+            if len({run["inputs"]["engine"]["sha256"] for run in runs}) != 1:
+                raise GateError("determinism requires the same candidate binary")
+        reference = runs[0]
+        for run in runs[1:]:
+            for name in ("receptor", "ligand", "config"):
+                if run["inputs"][name]["sha256"] != reference["inputs"][name]["sha256"]:
+                    raise GateError(f"{name} differs across runs")
+            data = lambda r: {k: v["sha256"] for k, v in r["runtime_data"].items()}
+            if data(run) != data(reference):
+                raise GateError("runtime data or matrix differs across runs")
+            excluded = {"OMP_NUM_THREADS", "FLEXAIDDS_DATA_DIR", "FLEXAIDDS_GEN0_RECEIPT", "TMPDIR"}
+            env = lambda r: {k: v for k, v in r["environment"].items() if k not in excluded}
+            if env(run) != env(reference):
+                raise GateError("scientific environment differs across runs")
+            for left, right in zip(reference["outputs"]["poses"], run["outputs"]["poses"]):
+                if left["rank"] != right["rank"] or left["scientific_sha256"] != right["scientific_sha256"] or left["cf_text"] != right["cf_text"]:
+                    raise GateError(f"rank {left['rank']} scientific payload/CF differs")
+            if run["outputs"]["grid"]["sha256"] != reference["outputs"]["grid"]["sha256"]:
+                raise GateError("RRG shape or ordered grid payload differs")
+            if reference["require_gen0"]:
+                for key in ("population_count", "n_genes", "order_independent_records_sha256"):
+                    if run["outputs"]["gen0"][key] != reference["outputs"]["gen0"][key]:
+                        raise GateError(f"generation-zero exact gene/component population differs: {key}")
+        report["raw_pose_bytes_identical"] = all([p["sha256"] for p in run["outputs"]["poses"]] == [p["sha256"] for p in reference["outputs"]["poses"]] for run in runs[1:])
+        report["generation_zero"] = "pass" if reference["require_gen0"] else "not_requested_for_parity"
+        report["normalization"] = "only FLEXAID.commit and FLEXAID.dirty values; all seed and science bytes retained"
+        report["pass"] = True
+    except (GateError, OSError, ValueError, KeyError) as exc:
+        report["errors"].append(str(exc))
+    if args.json:
+        write_json(args.json, report)
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    run = commands.add_parser("run-one")
+    for name in ("engine", "source-dir", "build-dir", "receptor", "ligand", "config", "data-dir", "out"):
+        run.add_argument("--" + name, type=Path, required=True)
+    run.add_argument("--label", required=True)
+    run.add_argument("--omp-threads", type=int, choices=(1, 4), required=True)
+    run.add_argument("--parallel-reproduce", choices=("off", "on"), required=True)
+    run.add_argument("--require-gen0", action="store_true", help="Generation-zero receipt is mandatory for gates (default)")
+    run.add_argument("--observer-off-transparency", action="store_true", help="Non-gate diagnostic only; cannot pass compare")
+    run.add_argument("--timeout", type=float, default=21600)
+    run.add_argument("--env", action="append", default=[])
+    compare = commands.add_parser("compare")
+    compare.add_argument("--kind", choices=("parity", "determinism"), required=True)
+    compare.add_argument("--runs", type=Path, nargs="+", required=True)
+    compare.add_argument("--json", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        return run_one(args) if args.command == "run-one" else comparison(args)
+    except (GateError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/engine_repro_gate.py
+++ b/ops/engine_repro_gate.py
@@ -9,6 +9,8 @@ be normalized; every other emitted byte, including the seed, is retained.
 
 All gate comparisons require generation-zero receipts. Explicit observer-off
 transparency runs are non-gate diagnostics and cannot pass a gate comparison. METHODOLOGY.md sections 1-2 define gate interpretation.
+Canonical FLEXAID_ and FLEXAIDDS_ scientific controls are pinned internally;
+they cannot be supplied or overridden through --env.
 """
 from __future__ import annotations
 
@@ -43,7 +45,16 @@ RECORD_FIELDS = {"index", "status", "genes", "cf", "evalue_bits", "app_evalue_bi
                  "boltzmann_weight_bits", "free_energy_bits", "ring_phases_bits", "ring_six", "ring_five"}
 PROTECTED_ENV = {"FLEXAID_SEED", "OMP_NUM_THREADS", "FLEXAIDDS_NO_SEC", "FLEXAIDDS_RESTARTS",
                  "FLEXAIDDS_DATA_DIR", "FLEXAIDDS_PARALLEL_REPRODUCE", "FLEXAIDDS_GEN0_RECEIPT", "FLEXAIDDS_CACHE_READONLY",
-                 "FLEXAIDDS_VORONOI_KEYED_JITTER"}
+                 "FLEXAIDDS_VORONOI_KEYED_JITTER", "FLEXAIDDS_VCF_DIAG"}
+SCIENCE_ENV_PREFIXES = ("FLEXAID_", "FLEXAIDDS_")
+CANONICAL_SCIENCE_ENV = {"FLEXAID_SEED", "FLEXAIDDS_NO_SEC", "FLEXAIDDS_RESTARTS",
+                         "FLEXAIDDS_CACHE_READONLY", "FLEXAIDDS_VCF_DIAG", "FLEXAIDDS_DATA_DIR",
+                         "FLEXAIDDS_PARALLEL_REPRODUCE", "FLEXAIDDS_GEN0_RECEIPT"}
+SCORING_FAILURE_MARKERS = (
+    b"[VCF-DIAG]",
+    b"Atom OptRes pointer is not owned by the master OptRes array",
+    b"Atom/OptRes workspace sizes changed after binding capture",
+)
 
 
 class GateError(ValueError):
@@ -362,6 +373,28 @@ def verify_pins(pins: dict) -> None:
                 raise GateError(f"input changed after pinning: {record['path']}")
 
 
+def pin_run_log(path: Path) -> dict:
+    # Empty stdout/stderr is allowed, but a missing or redirected log is not.
+    if path.is_symlink() or not path.is_file():
+        raise GateError("run.log must be an existing regular file, not a symlink")
+    return {"path": str(path.resolve(strict=True)), "bytes": path.stat().st_size,
+            "sha256": sha256(path)}
+
+
+def validate_run_log(path: Path) -> None:
+    """Reject skipped scoring and ownership failures even after child exit zero."""
+    carry = b""
+    overlap = max(map(len, SCORING_FAILURE_MARKERS)) - 1
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            data = carry + block
+            for marker in SCORING_FAILURE_MARKERS:
+                if marker in data:
+                    raise GateError("run.log reports skipped scoring or an ownership invariant failure: "
+                                    + marker.decode("ascii"))
+            carry = data[-overlap:]
+
+
 def run_one(args: argparse.Namespace) -> int:
     args.require_gen0 = not args.observer_off_transparency
     out = args.out.resolve()
@@ -392,13 +425,13 @@ def run_one(args: argparse.Namespace) -> int:
         environment = {"PATH": os.environ.get("PATH", os.defpath), "HOME": os.environ.get("HOME", str(out)),
                        "TMPDIR": str(out / "tmp"), "LANG": "C", "LC_ALL": "C", "TZ": "UTC",
                        "FLEXAID_SEED": SEED, "FLEXAIDDS_NO_SEC": "1", "FLEXAIDDS_RESTARTS": "1",
-                       "FLEXAIDDS_CACHE_READONLY": "1",
+                       "FLEXAIDDS_CACHE_READONLY": "1", "FLEXAIDDS_VCF_DIAG": "1",
                        "FLEXAIDDS_DATA_DIR": str(data_dir), "OMP_NUM_THREADS": str(args.omp_threads),
                        "OMP_DYNAMIC": "FALSE", "FLEXAIDDS_PARALLEL_REPRODUCE": "1" if args.parallel_reproduce == "on" else "0"}
         for entry in args.env:
             key, separator, value = entry.partition("=")
             if (not separator or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) or key in PROTECTED_ENV
-                    or key.startswith(("OMP_", "KMP_", "GOMP_")) or "DETERMINISTIC" in key):
+                    or key.startswith(SCIENCE_ENV_PREFIXES + ("OMP_", "KMP_", "GOMP_")) or "DETERMINISTIC" in key):
                 raise GateError(f"invalid/protected explicit environment override: {entry!r}")
             if key in environment:
                 raise GateError(f"duplicate explicit environment key: {key}")
@@ -435,7 +468,8 @@ def run_one(args: argparse.Namespace) -> int:
                 manifest["timed_out"] = isinstance(exc, subprocess.TimeoutExpired)
                 raise GateError("engine timeout" if manifest["timed_out"] else "run interrupted")
         manifest["wall_seconds"] = time.monotonic() - start
-        manifest["log"] = pin_file(out / "run.log") if (out / "run.log").stat().st_size else {"path": str(out / "run.log"), "bytes": 0, "sha256": sha256(out / "run.log")}
+        manifest["log"] = pin_run_log(out / "run.log")
+        validate_run_log(out / "run.log")
         if manifest["exit_code"] != 0:
             raise GateError(f"engine exited {manifest['exit_code']}")
         verify_pins(manifest)
@@ -465,6 +499,16 @@ def load_run(path: Path) -> dict:
         raise GateError(f"run did not complete successfully: {out}")
     if manifest.get("gate_eligible") is not True or manifest.get("require_gen0") is not True:
         raise GateError("observer-off transparency runs cannot pass a gate: generation-zero evidence required")
+    unsupported = sorted(key for key in manifest["environment"]
+                         if key.startswith(SCIENCE_ENV_PREFIXES) and key not in CANONICAL_SCIENCE_ENV)
+    if unsupported:
+        raise GateError("unsupported scientific environment keys in saved run: " + ", ".join(unsupported))
+    if manifest["environment"].get("FLEXAIDDS_VCF_DIAG") != "1":
+        raise GateError("VCF diagnostic guard must be explicitly enabled for a gate")
+    log_pin = pin_run_log(out / "run.log")
+    validate_run_log(out / "run.log")
+    if log_pin != manifest.get("log"):
+        raise GateError(f"run.log changed after receipt: {out}")
     verify_pins(manifest)
     current = inspect_outputs(out, manifest.get("require_gen0") is True, int(manifest["environment"]["OMP_NUM_THREADS"]))
     if current != manifest.get("outputs"):
@@ -539,7 +583,8 @@ def main(argv: list[str] | None = None) -> int:
     run.add_argument("--require-gen0", action="store_true", help="Generation-zero receipt is mandatory for gates (default)")
     run.add_argument("--observer-off-transparency", action="store_true", help="Non-gate diagnostic only; cannot pass compare")
     run.add_argument("--timeout", type=float, default=21600)
-    run.add_argument("--env", action="append", default=[])
+    run.add_argument("--env", action="append", default=[],
+                     help="Additional nonscientific environment only; FLEXAID_/FLEXAIDDS_ overrides are forbidden")
     compare = commands.add_parser("compare")
     compare.add_argument("--kind", choices=("parity", "determinism"), required=True)
     compare.add_argument("--runs", type=Path, nargs="+", required=True)

--- a/ops/gate_parity.sh
+++ b/ops/gate_parity.sh
@@ -1,22 +1,56 @@
-#!/bin/bash
-# METHODOLOGY.md §1 — parity gate. Usage: gate_parity.sh <engineA> <engineB> [target]
-set -u
-REPO="/Users/lp.more/Projects/FlexAIDdS"; cd "$REPO"
-A="$1"; B="$2"; T="${3:-1G9V}"
-CACHE=/tmp/ab_bench_cache/astex_diverse
-[ -d "$CACHE/$T" ] || CACHE="$REPO/benchmarks/astex_diverse/astex_diverse"
-rec="$CACHE/$T/${T}_apo.pdb"; lig="$CACHE/$T/${T}_ligand.sdf"
-export FLEXAID_SEED=12345 FLEXAIDDS_NO_SEC=1 FLEXAIDDS_RESTARTS=1 FLEXAIDDS_DATA_DIR="$REPO/build"
-cfg=/tmp/parity.json
-for eng in "$A" "$B"; do
-  tag=$(basename "$eng"); out=/tmp/gate_parity/$tag/$T; mkdir -p "$out"
-  OMP_NUM_THREADS=1 "$eng" "$rec" "$lig" -c "$cfg" -o "$out/d" > "$out/run.log" 2>&1
+#!/usr/bin/env bash
+# Isolated two-engine parity per METHODOLOGY.md section 1.
+# All scientific inputs and both source/build identities are explicit.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: gate_parity.sh ENGINE_A ENGINE_B \
+  --baseline-source DIR --baseline-build DIR \
+  --candidate-source DIR --candidate-build DIR \
+  --receptor FILE --ligand FILE --config FILE --data-dir DIR --out NEW_DIR
+
+No input or matrix fallback is inferred from a mutable checkout. NEW_DIR must
+not exist. Engines with the same basename receive distinct P0/P1 output trees.
+EOF
+}
+if [[ ${1:-} == --help ]]; then usage; exit 0; fi
+if [[ $# -lt 2 ]]; then usage >&2; exit 2; fi
+engine_a=$1; engine_b=$2; shift 2
+baseline_source= baseline_build= candidate_source= candidate_build=
+receptor= ligand= config= data_dir= output=
+while [[ $# -gt 0 ]]; do
+  if [[ $# -lt 2 ]]; then usage >&2; exit 2; fi
+  case "$1" in
+    --baseline-source) baseline_source=$2 ;;
+    --baseline-build) baseline_build=$2 ;;
+    --candidate-source) candidate_source=$2 ;;
+    --candidate-build) candidate_build=$2 ;;
+    --receptor) receptor=$2 ;;
+    --ligand) ligand=$2 ;;
+    --config) config=$2 ;;
+    --data-dir) data_dir=$2 ;;
+    --out) output=$2 ;;
+    *) printf 'Unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift 2
 done
-# compare 10 elected poses byte-identical
-ta=$(basename "$A"); tb=$(basename "$B"); ok=1
-for i in $(seq 0 9); do
-  fa=/tmp/gate_parity/$ta/$T/d_${i}.pdb; fb=/tmp/gate_parity/$tb/$T/d_${i}.pdb
-  [ -f "$fa" ] && [ -f "$fb" ] || { echo "MISSING pose $i"; ok=0; break; }
-  cmp -s "$fa" "$fb" || { echo "POSE $i DIFFERS"; ok=0; }
+for value in "$baseline_source" "$baseline_build" "$candidate_source" "$candidate_build" \
+             "$receptor" "$ligand" "$config" "$data_dir" "$output"; do
+  if [[ -z "$value" ]]; then usage >&2; exit 2; fi
 done
-[ "$ok" = 1 ] && echo "PARITY PASS ($T, 10/10 poses byte-identical)" || echo "PARITY FAIL ($T)"
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+python_bin=${PYTHON:-python3}
+if [[ -e "$output" ]]; then printf 'Output already exists: %s\n' "$output" >&2; exit 2; fi
+mkdir -p -- "$(dirname -- "$output")"
+mkdir -- "$output"
+"$python_bin" "$script_dir/engine_repro_gate.py" run-one --label P0 \
+  --engine "$engine_a" --source-dir "$baseline_source" --build-dir "$baseline_build" \
+  --receptor "$receptor" --ligand "$ligand" --config "$config" --data-dir "$data_dir" \
+  --out "$output/P0" --omp-threads 1 --parallel-reproduce off --require-gen0
+"$python_bin" "$script_dir/engine_repro_gate.py" run-one --label P1 \
+  --engine "$engine_b" --source-dir "$candidate_source" --build-dir "$candidate_build" \
+  --receptor "$receptor" --ligand "$ligand" --config "$config" --data-dir "$data_dir" \
+  --out "$output/P1" --omp-threads 1 --parallel-reproduce off --require-gen0
+"$python_bin" "$script_dir/engine_repro_gate.py" compare --kind parity \
+  --runs "$output/P0" "$output/P1" --json "$output/parity.json"

--- a/scripts/aggregate_claim_metrics.py
+++ b/scripts/aggregate_claim_metrics.py
@@ -1,964 +1,607 @@
 #!/usr/bin/env python3
-"""Aggregate claim-table metrics under the admission + S1/S2/STRICT/S3 contract.
+"""Aggregate target-level S1/S2/STRICT/S3 under METHODOLOGY.md section 0.3.
 
-Normative contract:
-  benchmarks/protocols/admission_metrics_contract.md
+STRICT is recomputed from complete, internally consistent receipt fields. This
+CSV tool does not authenticate validator execution or hash the underlying pose,
+receptor, and raw validator artifacts. See evidence_level in every report.
 
-Claim admission (fail-closed):
-  seed_echo == 0, native_pose_seeded == 0, matrix pin, protocol_claim_eligible
-  claim_ready == 1 (strict table) + PoseBusters/tENCoM/Eigen/hash receipts when present
+One observation per target is the default. Repeated targets require a declared
+--expected-seeds list; missing seeds fail and strictly more than half must pass.
+Never mix arms or endpoints. Directory layouts must identify a single source;
+use --csv to choose explicitly when both per-target and summary files exist.
 
-Metrics (always separate):
-  S1      symmetry-corrected elected-pose RMSD ≤ 2.0 Å  (RMSD-only diagnostic)
-  S2      S1 ∧ pb_pass / success_pb
-  STRICT  claim_ready == 1  ← primary headline
-  S3      conditional scanned-pool ceiling ≤ 2.0 Å (diagnostic only; never any-pose)
-
-S1 metric — read this before quoting a number (#365).
-  "Success at 2.0 Å" used to have two producers with two meanings. This file
-  MANDATED the serial column ("S1 MUST use rmsd_to_crystal only") while
-  METHODOLOGY.md §claim, docs/swarm/2026-08-13/score_canonical.py and
-  ops/gate_accuracy_rmsd.py all meant spyRMSD. Both were live. S1 now converges
-  on the symmetry-corrected value, produced by exactly one implementation:
-
-    scripts/rmsd_symmcorr.py  →  spyrmsd.rmsd.symmrmsd
-    (METHODOLOGY.md §0 method 2 contract: crystal SDF bond block, heavy atoms,
-     center=False, minimize=False — in-place, never superposed)
-
-  Supply it with --symmcorr <sidecar.csv>. Rows are joined on pdb_id and, when
-  both sides carry it, on pose_sha256 — so a sidecar from a different run
-  cannot be silently attached to this claim table.
-
-  `rmsd_to_crystal` KEEPS ITS MEANING: ordered/serial, identity atom mapping,
-  as the engine documents (LIB/DatasetRunner.cpp). It is not redefined here.
-  Without a sidecar S1 falls back to it, which is SAFE BUT CONSERVATIVE:
-  symmetry correction minimises over graph automorphisms and the identity
-  mapping is one of them, so symmcorr ≤ serial always. The serial gate can
-  therefore under-count successes but never over-count them. The report says
-  which metric produced the number; an unlabelled RMSD is not reportable.
-
-  rmsd_hungarian remains BANNED for S1. Element-only Hungarian minimises over
-  all same-element bijections — a superset of the chemically valid
-  automorphisms — so it is over-permissive, not merely different: the repo
-  measured it inflating the pool ceiling from 48.8% to 57.8%.
-  Ordering, by construction: hungarian ≤ symmcorr ≤ serial.
-
---headline s3 requires --diagnostic-only.
-
-Usage:
-  python3 scripts/aggregate_claim_metrics.py <campaign_dir> [--json out.json]
-  python3 scripts/aggregate_claim_metrics.py --c0-full85
-  python3 scripts/aggregate_claim_metrics.py <dir> --headline s1
-  python3 scripts/aggregate_claim_metrics.py <dir> --headline s3 --diagnostic-only
-
-Exit codes:
-  0  OK (N_claim > 0)
-  1  no claim-eligible rows / empty campaign
-  2  usage or contract violation
+The frozen roster is mandatory. --legacy-observed-denominator is available only
+with --diagnostic-only and a diagnostic headline; it cannot produce STRICT rates.
+Exit codes: 0 = strict receipt success (or diagnostic observations), 1 = no strict
+receipt successes, 2 = input/contract error.
 """
 from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import math
 import os
+import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Iterable
 
-# Production matrix pin used by three-engine / C0 full85 (see RUN_RECEIPT).
 DEFAULT_MATRIX_MD5 = "9dc93717dfed0698006d88dd6a9627bc"
 RMSD_SUCCESS_A = 2.0
+EXPECTED_PB_CHECKS = 27  # Versioned mandatory schema in LIB/PoseBust/BustCli.cpp.
+SCORE_DELTA_TOLERANCE = 1e-4
 C0_FULL85_REL = "campaigns/C0_full85_defined_cleft_nativeseed_forbidden"
-
-SUMMARY_CSV_NAMES = (
-    "astex_diverse_results.csv",
-    "astex_crossdock_85_results.csv",
-    "results.csv",
-    "summary.csv",
-    "claim_summary.csv",
-)
-
-
-# ── helpers ──────────────────────────────────────────────────────────────────
+SUMMARY_CSV_NAMES = ("astex_diverse_results.csv", "astex_crossdock_85_results.csv",
+                     "results.csv", "summary.csv", "claim_summary.csv")
+SYMMCORR_COL = "rmsd_symmcorr"
+SYMMCORR_COLS = (SYMMCORR_COL, "rmsd_spyrmsd")
+SHA256 = re.compile(r"[0-9a-fA-F]{64}\Z")
 
 
 def _f(row: dict[str, str], *keys: str) -> float:
-    for k in keys:
-        v = row.get(k)
-        if v is None or v == "" or str(v).upper() == "NA":
+    for key in keys:
+        value = row.get(key)
+        if value is None or str(value).strip() in ("", "NA"):
             continue
         try:
-            x = float(v)
-            if math.isfinite(x):
-                return x
-        except (TypeError, ValueError):
+            result = float(value)
+        except (ValueError, TypeError):
             continue
+        if math.isfinite(result):
+            return result
     return float("nan")
 
 
 def _truth(row: dict[str, str], key: str) -> bool:
-    return str(row.get(key, "")).strip() in ("1", "True", "true", "YES", "yes")
+    return str(row.get(key, "")).strip().lower() in ("1", "true", "yes")
 
 
 def _flag0(row: dict[str, str], key: str) -> bool:
-    """True when the admission flag is *explicitly* zero / false.
-
-    Fail-closed: missing or blank keys fail admission (return False).
-    Explicit non-zero also fails. Accept common zero spellings including "0.0".
-    """
-    if key not in row or row.get(key) is None:
-        return False
-    s = str(row.get(key, "")).strip()
-    if s == "":
-        return False
-    return s in ("0", "0.0", "False", "false", "NO", "no")
+    return str(row.get(key, "")).strip().lower() in ("0", "0.0", "false", "no")
 
 
 def _pdb_id(row: dict[str, str]) -> str:
-    return str(row.get("pdb_id") or row.get("pdb") or row.get("target") or "?").strip()
+    return str(row.get("pdb_id") or row.get("pdb") or row.get("target") or "?").strip().upper()
+
+
+def _hash(row: dict[str, str], key: str) -> str:
+    return str(row.get(key, "")).strip().lower()
+
+
+def _valid_sha(value: str) -> bool:
+    return bool(SHA256.fullmatch(value))
 
 
 def resolve_c0_full85_dir() -> Path:
-    """Resolve C0 full85 campaign dir from FLEXAIDDS_RESULTS (or FLEXAIDDS_ICLOUD)."""
+    # Live aggregation is local first. CloudDocs needs icloud_safe_io.py staging.
     results = os.environ.get("FLEXAIDDS_RESULTS", "").strip()
     if results:
-        return Path(results) / "campaigns" / "C0_full85_defined_cleft_nativeseed_forbidden"
-    icloud = os.environ.get("FLEXAIDDS_ICLOUD", "").strip()
-    if icloud:
-        # FLEXAIDDS_ICLOUD may be the benchmarks root or the nested astex_entropy path
-        base = Path(icloud)
-        candidates = [
-            base / "results" / C0_FULL85_REL,
-            base.parent / "results" / C0_FULL85_REL if base.name else None,
-        ]
-        for c in candidates:
-            if c is not None and c.is_dir():
-                return c
-        return base / "results" / C0_FULL85_REL
-    # Documented default relative to home iCloud Drive (not hardcoded user)
-    home = Path.home()
-    return (
-        home
-        / "Library"
-        / "Mobile Documents"
-        / "com~apple~CloudDocs"
-        / "FlexAIDdS_benchmarks"
-        / "results"
-        / "campaigns"
-        / "C0_full85_defined_cleft_nativeseed_forbidden"
-    )
+        return Path(results) / C0_FULL85_REL
+    local = Path(os.environ.get("FLEXAIDDS_LOCAL_ROOT", str(Path.home() / "flexaidds_results")))
+    return local / C0_FULL85_REL
+
+
+def _require_local(path: Path) -> None:
+    resolved = path.resolve()
+    if "Mobile Documents" in resolved.parts or "com~apple~CloudDocs" in resolved.parts:
+        raise ValueError("stage CloudDocs inputs locally with scripts/icloud_safe_io.py before aggregation")
 
 
 def _normalize_matrix_pin(md: str) -> str:
-    s = str(md).strip().lower()
-    if len(s) != 32 or any(c not in "0123456789abcdef" for c in s):
-        raise ValueError(f"matrix_md5 pin must be 32 hex chars, got {md!r}")
-    return s
+    value = str(md).strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{32}", value):
+        raise ValueError(f"matrix_md5 pin must be 32 hex characters, got {md!r}")
+    return value
 
 
 def load_matrix_pin(campaign_dir: Path, cli_pin: str | None) -> tuple[str, str]:
-    """Return (md5, source_label)."""
+    _require_local(campaign_dir)
+    pins: dict[str, str] = {}
     if cli_pin:
-        return _normalize_matrix_pin(cli_pin), "cli"
+        pins["cli"] = _normalize_matrix_pin(cli_pin)
     for name in ("RUN_RECEIPT.json", "provenance.json"):
-        p = campaign_dir / name
-        if not p.is_file():
-            continue
-        try:
-            data = json.loads(p.read_text())
-        except (OSError, json.JSONDecodeError):
-            continue
-        md = data.get("matrix_md5")
-        if md:
-            return _normalize_matrix_pin(str(md)), name
-    return _normalize_matrix_pin(DEFAULT_MATRIX_MD5), "default_pin"
-
-
-def load_campaign_rows(out_dir: Path) -> list[dict[str, str]]:
-    """Load per-target result.csv trees first, then flat summary CSVs."""
-    rows: list[dict[str, str]] = []
-    for rc in sorted(out_dir.glob("*/result.csv")):
-        try:
-            batch = list(csv.DictReader(rc.open(newline="")))
-            if batch:
-                # One authoritative row per target dir (first row)
-                rows.append(dict(batch[0]))
-        except OSError:
-            continue
-    if rows:
-        return rows
-    for name in SUMMARY_CSV_NAMES:
-        p = out_dir / name
-        if p.is_file():
-            try:
-                return [dict(r) for r in csv.DictReader(p.open(newline=""))]
-            except OSError:
-                continue
-    # Also accept a single CSV path masquerading as "dir" (handled by caller)
-    return rows
+        path = campaign_dir / name
+        if path.is_file():
+            _require_local(path)
+            data = json.loads(path.read_text())
+            if not isinstance(data, dict):
+                raise ValueError(f"{path}: receipt must be an object")
+            if data.get("matrix_md5"):
+                pins[name] = _normalize_matrix_pin(str(data["matrix_md5"]))
+    if len(set(pins.values())) > 1:
+        raise ValueError(f"conflicting matrix pins: {pins}")
+    if pins:
+        return next(iter(pins.values())), "+".join(pins)
+    return _normalize_matrix_pin(DEFAULT_MATRIX_MD5), "default_expected_pin (row identity still required)"
 
 
 def load_rows_from_csv(path: Path) -> list[dict[str, str]]:
-    with path.open(newline="") as fh:
-        return [dict(r) for r in csv.DictReader(fh)]
+    _require_local(path)
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.reader(handle, strict=True)
+        header = next(reader, None)
+        if not header or any(not key or key != key.strip() for key in header):
+            raise ValueError(f"{path}: missing, blank, or whitespace-padded CSV header")
+        if len(set(header)) != len(header):
+            raise ValueError(f"{path}: duplicate CSV header")
+        if not {"pdb_id", "pdb", "target"}.intersection(header):
+            raise ValueError(f"{path}: missing target identity column")
+        rows = []
+        for values in reader:
+            if len(values) != len(header):
+                raise ValueError(f"{path}:{reader.line_num}: CSV row width {len(values)} != {len(header)}")
+            row = dict(zip(header, values))
+            identities = {str(row[k]).strip().upper() for k in ("pdb_id", "pdb", "target") if row.get(k)}
+            if len(identities) != 1 or "?" in identities:
+                raise ValueError(f"{path}:{reader.line_num}: missing or conflicting target identity")
+            rows.append(row)
+    return rows
 
 
-SYMMCORR_COL = "rmsd_symmcorr"
-# The frozen nine-arm table (PER_POSE_CF_RMSD_NINE_ARMS.csv) and
-# docs/swarm/2026-08-13/score_canonical.py already call this same quantity
-# `rmsd_spyrmsd`. Accept both names rather than minting a rival one — the whole
-# point of #365 is one quantity with one meaning.
-SYMMCORR_COLS = (SYMMCORR_COL, "rmsd_spyrmsd")
+def load_campaign_rows(out_dir: Path) -> list[dict[str, str]]:
+    _require_local(out_dir)
+    per_target = sorted(out_dir.glob("*/result.csv"))
+    summaries = [out_dir / name for name in SUMMARY_CSV_NAMES if (out_dir / name).is_file()]
+    if (per_target and summaries) or len(summaries) > 1:
+        raise ValueError("ambiguous campaign sources; choose the intended source explicitly with --csv")
+    sources = per_target or summaries
+    rows = []
+    for source in sources:
+        batch = load_rows_from_csv(source)
+        if source in per_target and len(batch) != 1:
+            raise ValueError(f"{source}: per-target result.csv must contain exactly one observation")
+        rows.extend(batch)
+    return rows
 
 
 def elected_rmsd_labelled(row: dict[str, str]) -> tuple[float, str]:
-    """Elected-pose RMSD for S1, with the name of the metric that produced it.
-
-    Preference order (#365):
-      1. `rmsd_symmcorr`  — symmetry-corrected, spyrmsd graph automorphism,
-         joined from scripts/rmsd_symmcorr.py. This is the claim metric.
-      2. `rmsd_to_crystal` — ordered/serial identity mapping. Conservative
-         fallback: symmcorr ≤ serial always, so this can only under-count.
-      3. `rmsd_top1` — legacy three-engine ordered top-1, when neither is present.
-
-    rmsd_hungarian is never consulted: it is over-permissive (see module
-    docstring). Returns (value, metric_name); value is nan when none is finite.
-    """
-    rs = _f(row, *SYMMCORR_COLS)
-    if math.isfinite(rs):
-        return rs, "symmcorr"
-    rc = _f(row, "rmsd_to_crystal")
-    if math.isfinite(rc):
-        return rc, "serial"
-    # Legacy engines without rmsd_to_crystal may emit ordered rmsd_top1 only.
+    value = _f(row, *SYMMCORR_COLS)
+    if math.isfinite(value):
+        return value, "symmcorr"
+    value = _f(row, "rmsd_to_crystal")
+    if math.isfinite(value):
+        return value, "serial"
     return _f(row, "rmsd_top1"), "serial_legacy_top1"
 
 
 def elected_rmsd(row: dict[str, str]) -> float:
-    """Elected-pose RMSD used by S1. See elected_rmsd_labelled()."""
     return elected_rmsd_labelled(row)[0]
 
 
 def is_s1(row: dict[str, str]) -> bool:
-    """S1: symmetry-corrected elected RMSD ≤ 2.0 Å (RMSD-only diagnostic).
-
-    A finite RMSD always wins over success_* flags so a stale flag cannot
-    admit a high-RMSD pose. In particular the engine's `success_rmsd` column
-    is a SERIAL gate; when a symmetry-corrected value is present it supersedes
-    that flag rather than deferring to it — otherwise the engine's stricter
-    definition would silently keep governing the claim (#365).
-
-    Hungarian is never consulted.
-    """
-    if _truth(row, "seed_echo"):
-        return False
-    rh = elected_rmsd(row)
-    if math.isfinite(rh):
-        return 0.0 <= rh <= RMSD_SUCCESS_A
-    # No finite ordered RMSD: fall back to engine flags only
-    if "success_s1" in row and str(row.get("success_s1", "")).strip() != "":
-        return _truth(row, "success_s1")
-    if "success_rmsd" in row and str(row.get("success_rmsd", "")).strip() != "":
-        return _truth(row, "success_rmsd")
-    if "success" in row and str(row.get("success", "")).strip() != "":
-        return _truth(row, "success")
-    return False
+    value = elected_rmsd(row)
+    return _flag0(row, "seed_echo") and math.isfinite(value) and 0.0 <= value <= RMSD_SUCCESS_A
 
 
-def load_symmcorr_sidecar(path: Path) -> dict[str, dict[str, str]]:
-    """Load scripts/rmsd_symmcorr.py output, keyed by pdb_id.
-
-    Only rows with status == "ok" and a finite value are usable. Everything
-    else is dropped here so a blank or errored row cannot be mistaken for a
-    measurement.
-    """
-    out: dict[str, dict[str, str]] = {}
-    with path.open(newline="") as fh:
-        for rec in csv.DictReader(fh):
-            if str(rec.get("status", "")).strip() != "ok":
-                continue
-            val = ""
-            for col in SYMMCORR_COLS:
-                val = str(rec.get(col, "")).strip()
-                if val:
-                    break
-            if val == "":
-                continue
-            rec = dict(rec)
-            rec[SYMMCORR_COL] = val
-            pid = str(rec.get("pdb_id", "")).strip().upper()
-            if pid:
-                out[pid] = dict(rec)
+def load_symmcorr_sidecar(path: Path) -> dict[tuple[str, str], dict[str, str]]:
+    out = {}
+    for row in load_rows_from_csv(path):
+        if str(row.get("status", "")).strip() != "ok":
+            continue
+        value = _f(row, *SYMMCORR_COLS)
+        if not math.isfinite(value) or value < 0:
+            raise ValueError(f"{path}: status=ok requires a finite, nonnegative symmetry-corrected RMSD")
+        sha = _hash(row, "pose_sha256")
+        if not _valid_sha(sha):
+            raise ValueError(f"{path}: sidecar requires a valid pose_sha256")
+        key = (_pdb_id(row), sha)
+        if key in out:
+            raise ValueError(f"{path}: duplicate sidecar target/pose identity {key}")
+        row[SYMMCORR_COL] = str(value)
+        out[key] = row
     return out
 
 
-def join_symmcorr(
-    rows: list[dict[str, str]], sidecar: dict[str, dict[str, str]]
-) -> dict[str, Any]:
-    """Attach `rmsd_symmcorr` to claim rows. Returns a provenance summary.
-
-    The join requires pose identity: when both the claim row and the sidecar
-    carry a pose_sha256 they must be equal, otherwise the sidecar value
-    describes a different pose and is refused. This is the same same-pose
-    discipline the engine applies via rmsd_pose_sha256 == pose_sha256.
-    """
+def join_symmcorr(rows: list[dict[str, str]], sidecar: dict) -> dict[str, Any]:
+    # Accept the earlier direct-Python target-keyed API while enforcing hashes.
+    index: dict[tuple[str, str], dict[str, str]] = {}
+    targets = set()
+    for rec in sidecar.values():
+        pid = _pdb_id(rec)
+        targets.add(pid)
+        key = (pid, _hash(rec, "pose_sha256"))
+        if key in index:
+            raise ValueError(f"duplicate sidecar target/pose identity {key}")
+        index[key] = rec
     joined = 0
-    refused: list[str] = []
+    refused = []
     for row in rows:
-        pid = _pdb_id(row).upper()
-        rec = sidecar.get(pid)
-        if rec is None:
+        pid, sha = _pdb_id(row), _hash(row, "pose_sha256")
+        if pid not in targets:
             continue
-        row_sha = str(row.get("pose_sha256", "")).strip()
-        side_sha = str(rec.get("pose_sha256", "")).strip()
-        if row_sha and side_sha and row_sha != side_sha:
+        rec = index.get((pid, sha))
+        if not _valid_sha(sha) or rec is None or not _valid_sha(_hash(rec, "pose_sha256")):
             refused.append(pid)
             continue
-        row[SYMMCORR_COL] = rec["rmsd_symmcorr"]
+        value = _f(rec, *SYMMCORR_COLS)
+        if not math.isfinite(value) or value < 0:
+            raise ValueError(f"invalid symmetry-corrected RMSD for {pid}")
+        row[SYMMCORR_COL] = str(value)
         joined += 1
-    return {
-        "joined": joined,
-        "refused_sha_mismatch": sorted(refused),
-        "sidecar_rows": len(sidecar),
-    }
+    return {"joined": joined, "refused_sha_mismatch": sorted(set(refused)), "sidecar_rows": len(sidecar)}
 
 
 def is_s2(row: dict[str, str], s1: bool) -> bool:
-    """S2: S1 ∧ PoseBusters pass on the same elected pose."""
-    if not s1:
+    # Diagnostics are independent of STRICT's tENCoM/score gates, not immune
+    # to contradictions in their own PB measurements.
+    if "pb_ran" in row and not _truth(row, "pb_ran"):
         return False
-    if "success_pb" in row and str(row.get("success_pb", "")).strip() != "":
-        return _truth(row, "success_pb") and s1
-    if "pb_pass" in row and str(row.get("pb_pass", "")).strip() != "":
-        return _truth(row, "pb_pass")
-    return False
+    for key in ("pb_n_checks", "pb_n_pass"):
+        if key in row and _f(row, key) != EXPECTED_PB_CHECKS:
+            return False
+    if "pb_n_fail" in row and _f(row, "pb_n_fail") != 0:
+        return False
+    if str(row.get("pb_failed_keys", "")).strip():
+        return False
+    if "pb_backend" in row and str(row["pb_backend"]).strip() != "bust_cli":
+        return False
+    pose = _hash(row, "pose_sha256")
+    return (s1 and _truth(row, "pb_pass") and _valid_sha(pose)
+            and _hash(row, "posebusters_pose_sha256") == pose)
 
 
 def is_s3(row: dict[str, str]) -> bool:
-    """S3: conditional scanned-pool ceiling (diagnostic only; not any-pose)."""
-    bc = _f(
-        row,
-        "conditional_scanned_pool_ceiling",
-        "best_cluster_rmsd",
-        "rmsd_bcr",
-    )
-    if math.isfinite(bc):
-        return 0.0 <= bc <= RMSD_SUCCESS_A
-    if "success_s3" in row and str(row.get("success_s3", "")).strip() != "":
-        return _truth(row, "success_s3")
-    return False
+    value = _f(row, "conditional_scanned_pool_ceiling", "best_cluster_rmsd", "rmsd_bcr")
+    return math.isfinite(value) and 0.0 <= value <= RMSD_SUCCESS_A
 
 
 def _hash_receipts_ok(row: dict[str, str]) -> tuple[bool, list[str]]:
-    """When hash columns are present, require identity with pose_sha256."""
-    reasons: list[str] = []
-    pose = str(row.get("pose_sha256", "")).strip()
-    if not pose:
-        return True, reasons  # absent → not checked at row level
-    for key in (
-        "rmsd_pose_sha256",
-        "posebusters_pose_sha256",
-        "tencom_pose_sha256",
-    ):
-        if key not in row or str(row.get(key, "")).strip() == "":
-            continue
-        if str(row.get(key, "")).strip() != pose:
+    reasons = []
+    pose = _hash(row, "pose_sha256")
+    if not _valid_sha(pose):
+        reasons.append("pose_sha256_missing_or_invalid")
+    for key in ("rmsd_pose_sha256", "posebusters_pose_sha256", "tencom_pose_sha256"):
+        value = _hash(row, key)
+        if not _valid_sha(value):
+            reasons.append(f"{key}_missing_or_invalid")
+        elif value != pose:
             reasons.append(f"{key}_mismatch")
-    return (len(reasons) == 0, reasons)
-
-
-def is_claim_ready(row: dict[str, str]) -> bool:
-    """STRICT claim success: engine claim_ready when present."""
-    if "claim_ready" in row and str(row.get("claim_ready", "")).strip() != "":
-        return _truth(row, "claim_ready")
-    return False
-
-
-def is_strict_success(row: dict[str, str]) -> bool:
-    """STRICT: claim_ready with receipts when available."""
-    if not is_claim_ready(row):
-        return False
-    ok, _ = _hash_receipts_ok(row)
-    if not ok:
-        return False
-    if "tencom_status" in row and str(row.get("tencom_status", "")).strip() != "":
-        if str(row.get("tencom_status", "")).strip().lower() != "ok":
-            return False
-    if "eigen_status" in row and str(row.get("eigen_status", "")).strip() != "":
-        if str(row.get("eigen_status", "")).strip().lower() != "ok":
-            return False
-    if "pb_backend" in row and str(row.get("pb_backend", "")).strip() != "":
-        if str(row.get("pb_backend", "")).strip() != "bust_cli":
-            return False
-    return True
+    if not _valid_sha(_hash(row, "posebusters_input_sha256")):
+        reasons.append("posebusters_input_sha256_missing_or_invalid")
+    return not reasons, reasons
 
 
 def row_matrix_ok(row: dict[str, str], pin: str) -> bool:
-    md = str(row.get("matrix_md5", "")).strip().lower()
-    if not md:
-        return True  # campaign-level pin applies
-    return md == pin
+    try:
+        return _normalize_matrix_pin(str(row.get("matrix_md5", ""))) == pin
+    except ValueError:
+        return False
 
 
 def is_claim_eligible(row: dict[str, str], matrix_pin: str) -> tuple[bool, list[str]]:
-    """Admission gates for the claim table. Returns (ok, fail reasons).
-
-    Strict admission requires claim_ready==1 when the column is present.
-    """
-    reasons: list[str] = []
-    if not _flag0(row, "seed_echo"):
-        reasons.append("seed_echo!=0")
-    if not _flag0(row, "native_pose_seeded"):
-        reasons.append("native_pose_seeded!=0")
+    """Protocol eligibility only: failures remain visible in diagnostic counts."""
+    reasons = []
+    for key in ("seed_echo", "native_pose_seeded"):
+        if not _flag0(row, key):
+            reasons.append(f"{key}!=0")
+    if not _truth(row, "protocol_claim_eligible"):
+        reasons.append("protocol_claim_eligible!=1")
     if not row_matrix_ok(row, matrix_pin):
-        reasons.append(
-            f"matrix_md5_mismatch(got={row.get('matrix_md5')!r}, pin={matrix_pin})"
-        )
-    if "protocol_claim_eligible" in row and str(
-        row.get("protocol_claim_eligible", "")
-    ).strip() != "":
-        if not _truth(row, "protocol_claim_eligible"):
-            reasons.append("protocol_claim_eligible=0")
-    # Strict table: claim_ready required when column present
-    if "claim_ready" in row and str(row.get("claim_ready", "")).strip() != "":
-        if not _truth(row, "claim_ready"):
-            reasons.append("claim_ready=0")
-        else:
-            ok_h, h_reasons = _hash_receipts_ok(row)
-            if not ok_h:
-                reasons.extend(h_reasons)
-            if "tencom_status" in row and str(row.get("tencom_status", "")).strip() != "":
-                if str(row.get("tencom_status", "")).strip().lower() != "ok":
-                    reasons.append("tencom_status!=ok")
-            if "eigen_status" in row and str(row.get("eigen_status", "")).strip() != "":
-                if str(row.get("eigen_status", "")).strip().lower() != "ok":
-                    reasons.append("eigen_status!=ok")
-            if "pb_backend" in row and str(row.get("pb_backend", "")).strip() != "":
-                if str(row.get("pb_backend", "")).strip() != "bust_cli":
-                    reasons.append("pb_backend!=bust_cli")
-    return (len(reasons) == 0, reasons)
+        reasons.append("matrix_md5_missing_or_mismatch")
+    if "native_pose_seed_fraction" in row:
+        if _f(row, "native_pose_seed_fraction") != 0:
+            reasons.append("native_pose_seed_fraction!=0")
+    return not reasons, reasons
 
 
-def load_target_manifest() -> tuple[list[str], str] | tuple[None, None]:
-    """Load the frozen pre-registered Astex-85 denominator manifest.
+def strict_failure_reasons(row: dict[str, str], matrix_pin: str = DEFAULT_MATRIX_MD5) -> list[str]:
+    _, reasons = is_claim_eligible(row, matrix_pin)
+    # The producer flag is required as an attestation, never sufficient evidence.
+    for key in ("claim_ready", "success_rmsd", "success_pb", "pb_pass", "score_pose_consistent"):
+        if not _truth(row, key):
+            reasons.append(f"{key}!=1")
+    if "docking_completed" in row and not _truth(row, "docking_completed"):
+        reasons.append("docking_completed!=1")
+    if "docking_exit_code" in row and _f(row, "docking_exit_code") != 0:
+        reasons.append("docking_exit_code!=0")
+    # Current STRICT requires the full PB schema and actual Eigen output fields.
+    # Missing older fields remain useful only for separately labelled diagnostics.
+    for key in ("pb_n_checks", "pb_n_pass"):
+        if _f(row, key) != EXPECTED_PB_CHECKS:
+            reasons.append(f"{key}!={EXPECTED_PB_CHECKS}")
+    if not _truth(row, "pb_ran"):
+        reasons.append("pb_ran!=1")
+    if _f(row, "pb_n_fail") != 0:
+        reasons.append("pb_n_fail!=0")
+    modes = _f(row, "eigen_n_modes")
+    if not math.isfinite(modes) or modes <= 0 or not modes.is_integer():
+        reasons.append("eigen_n_modes_not_positive_integer")
+    if not math.isfinite(_f(row, "elected_H_vib")):
+        reasons.append("elected_H_vib_not_finite")
+    if "num_poses" in row:
+        poses = _f(row, "num_poses")
+        if not math.isfinite(poses) or poses <= 0 or not poses.is_integer():
+            reasons.append("num_poses_not_positive_integer")
+    if str(row.get("pb_failed_keys", "")).strip():
+        reasons.append("pb_failed_keys_nonempty")
+    if "rmsd_fail_reason" in row and str(row["rmsd_fail_reason"]).strip() != "none":
+        reasons.append("rmsd_fail_reason!=none")
+    serial = _f(row, "rmsd_to_crystal")
+    if not math.isfinite(serial) or not 0 <= serial <= RMSD_SUCCESS_A:
+        reasons.append("serial_rmsd_not_finite_or_outside_cutoff")
+    delta = _f(row, "score_pose_delta")
+    if not math.isfinite(delta) or abs(delta) > SCORE_DELTA_TOLERANCE:
+        reasons.append("score_pose_delta_not_finite_or_outside_tolerance")
+    for key, value in (("tencom_status", "ok"), ("eigen_status", "ok"), ("pb_backend", "bust_cli")):
+        if str(row.get(key, "")).strip() != value:
+            reasons.append(f"{key}!={value}")
+    _, hash_reasons = _hash_receipts_ok(row)
+    reasons.extend(hash_reasons)
+    return reasons
 
-    Returns (sorted_upper_codes, sha256) or (None, None) if absent. When present,
-    claim rates use the FIXED manifest count as denominator: a preregistered target
-    that is absent from the campaign or dropped in admission counts as a FAILURE and
-    is NEVER removed from the denominator. This is the P0 anti-inflation invariant.
-    """
+
+def is_claim_ready(row: dict[str, str]) -> bool:
+    return _truth(row, "claim_ready")
+
+
+def is_strict_success(row: dict[str, str], matrix_pin: str = DEFAULT_MATRIX_MD5) -> bool:
+    return not strict_failure_reasons(row, matrix_pin)
+
+
+def load_target_manifest(path: Path | None = None) -> tuple[list[str], str]:
     here = Path(__file__).resolve().parent
-    for cand in (
-        here.parent / "benchmarks" / "protocols" / "astex85_target_manifest.json",
+    candidates = ([path] if path is not None else [
+        here.parent / "benchmarks/protocols/astex85_target_manifest.json",
         here / "astex85_target_manifest.json",
-    ):
-        if cand.is_file():
-            try:
-                m = json.loads(cand.read_text())
-                codes = [str(c).strip().upper() for c in m.get("targets", [])]
-                if codes:
-                    return sorted(set(codes)), str(m.get("sha256_of_sorted_codes", ""))
-            except (ValueError, OSError):
-                pass
-    return None, None
+    ])
+    manifest_path = next((p for p in candidates if p.is_file()), None)
+    if manifest_path is None:
+        raise ValueError("frozen target manifest missing; supply --manifest (no implicit denominator fallback)")
+    _require_local(manifest_path)
+    data = json.loads(manifest_path.read_text())
+    if (not isinstance(data, dict)
+            or data.get("schema") != "flexaidds.astex.target_manifest/v1"
+            or not isinstance(data.get("targets"), list)):
+        raise ValueError("invalid target manifest schema")
+    codes = data["targets"]
+    if (not codes or any(not isinstance(c, str) or not re.fullmatch(r"[A-Z0-9]{4}", c) for c in codes)
+            or len(set(codes)) != len(codes) or type(data.get("N")) is not int
+            or data.get("N") != len(codes)):
+        raise ValueError("manifest must contain unique uppercase four-character targets and matching N")
+    codes = sorted(codes)
+    digest = hashlib.sha256(",".join(codes).encode("ascii")).hexdigest()
+    if data.get("sha256_of_sorted_codes") != digest:
+        raise ValueError("target manifest digest mismatch (SHA256 of comma-joined sorted codes)")
+    return codes, digest
 
 
-def aggregate_rows(
-    rows: Iterable[dict[str, str]],
-    matrix_pin: str,
-    matrix_pin_source: str,
-    campaign_dir: str | None = None,
-    fixed_denominator: bool = True,
-) -> dict[str, Any]:
-    all_rows = list(rows)
-    claim: list[dict[str, str]] = []
-    dropped: list[dict[str, Any]] = []
+def _seed_id(value: Any) -> str:
+    """Canonical uint64 decimal identity, matching the engine's seed domain."""
+    text = str(value).strip()
+    if not text:
+        return ""  # Legacy one-observation producers may omit seed metadata.
+    if not re.fullmatch(r"[0-9]+", text) or int(text) > 2**64 - 1:
+        raise ValueError(f"seed must be an unsigned 64-bit decimal integer, got {value!r}")
+    return str(int(text))
 
-    for r in all_rows:
-        ok, reasons = is_claim_eligible(r, matrix_pin)
-        if ok:
-            claim.append(r)
-        else:
-            dropped.append({"pdb_id": _pdb_id(r), "reasons": reasons})
 
-    n = len(claim)
-
-    # --- P0 fixed-denominator invariant ---------------------------------------
-    # Claim rates must be reported over a FROZEN pre-registered target count, not
-    # over the number of rows that happened to pass admission. Otherwise dropping
-    # or losing hard targets mechanically inflates the rate. The denominator is
-    # max(manifest N, observed distinct targets) so extra rows can never *shrink*
-    # it below the preregistered set either.
-    manifest_codes, manifest_sha = load_target_manifest()
-    observed_ids = {_pdb_id(r).upper() for r in all_rows if _pdb_id(r)}
-    if fixed_denominator and manifest_codes:
-        denom = len(manifest_codes)
-        missing_targets = sorted(set(manifest_codes) - observed_ids)
-        denom_source = f"frozen_manifest(N={denom},sha={manifest_sha[:12]})"
-        manifest_set: set[str] | None = {c.upper() for c in manifest_codes}
+def _observation_groups(rows: list[dict[str, str]], expected_seeds: list[str] | None,
+                        arm: str | None) -> tuple[list[dict[str, str]], dict, dict]:
+    selected = rows
+    if arm is not None:
+        selected = [r for r in rows if str(r.get("arm", "")).strip() == arm]
+        if not selected:
+            raise ValueError(f"no observations for selected arm {arm!r}")
+    for field in ("arm", "endpoint"):
+        labels = {str(r.get(field, "")).strip() for r in selected}
+        if len(labels) > 1:
+            raise ValueError(f"mixed {field} identities; select one explicit arm/endpoint source")
+    groups: dict[str, list[dict[str, str]]] = defaultdict(list)
+    seen = set()
+    for row in selected:
+        pid = _pdb_id(row)
+        if pid == "?":
+            raise ValueError("missing target identity")
+        key = (pid, _seed_id(row.get("seed", "")))
+        if key in seen:
+            raise ValueError(f"duplicate observation target/seed identity: {key}")
+        seen.add(key)
+        groups[pid].append(row)
+    if expected_seeds is None:
+        if any(len(group) != 1 for group in groups.values()):
+            raise ValueError("repeated targets require an explicit --expected-seeds list")
+        seed_labels = {_seed_id(r.get("seed", "")) for r in selected}
+        if len(seed_labels) > 1:
+            raise ValueError("mixed seed identities require an explicit --expected-seeds list")
+        mode, required = "single_observation", 1
     else:
-        denom = n
-        missing_targets = []
-        denom_source = "claim_eligible_rows(legacy)"
-        manifest_set = None
+        expected_seeds = [_seed_id(s) for s in expected_seeds]
+        if not expected_seeds or any(not s for s in expected_seeds) or len(set(expected_seeds)) != len(expected_seeds):
+            raise ValueError("expected seeds must be a nonempty unique list")
+        if any(_seed_id(r.get("seed", "")) not in expected_seeds for r in selected):
+            raise ValueError("observation has missing or unexpected seed")
+        mode, required = "majority_of_expected_seeds", len(expected_seeds) // 2 + 1
+    meta = {"mode": mode, "expected_seeds": expected_seeds, "required_passes": required,
+            "arm": next(iter({str(r.get('arm', '')).strip() for r in selected}), "") or "unspecified",
+            "endpoint": next(iter({str(r.get('endpoint', '')).strip() for r in selected}), "") or "unspecified",
+            "N_filtered_by_arm": len(rows) - len(selected), "missing_expected_observations": [],
+            "missing_policy": "missing expected target/seed observations do not pass"}
+    return selected, groups, meta
 
-    s1_ids: list[str] = []
-    s2_ids: list[str] = []
-    strict_ids: list[str] = []
-    s3_ids: list[str] = []
-    election_gap_ids: list[str] = []
-    s1_fail_ids: list[str] = []
-    n_legacy = 0
 
-    for r in all_rows:
-        if "claim_ready" not in r or str(r.get("claim_ready", "")).strip() == "":
-            if _flag0(r, "seed_echo") and _flag0(r, "native_pose_seeded"):
-                n_legacy += 1
-
-    for r in claim:
-        pid = _pdb_id(r)
-        s1 = is_s1(r)
-        s2 = is_s2(r, s1)
-        s3 = is_s3(r)
-        strict = is_strict_success(r)
-        if s1:
-            s1_ids.append(pid)
-        else:
-            s1_fail_ids.append(pid)
-        if s2:
-            s2_ids.append(pid)
-        # STRICT numerator is ∩ the frozen 85-target manifest. Off-manifest
-        # extras must not inflate n while the denominator stays 85.
-        if strict and (
-            manifest_set is None or pid.strip().upper() in manifest_set
-        ):
-            strict_ids.append(pid)
-        if s3:
-            s3_ids.append(pid)
-        if s3 and not s1:
-            election_gap_ids.append(pid)
-
-    def rate(k: int) -> float:
-        return (k / denom) if denom else 0.0
-
-    # Targets whose RMSD verdict changes under the corrected metric. This is a
-    # metric-only statement: it compares serial vs symmcorr on the SAME elected
-    # pose and says nothing about admission. Direction is one-way by
-    # construction (symmcorr <= serial), so this list can only ever contain
-    # fail -> PASS moves; a pass -> fail entry would be a bug and is asserted
-    # against in tests/test_rmsd_symmcorr.py.
-    symmcorr_gained: list[str] = []
-    for r in claim:
-        rs = _f(r, *SYMMCORR_COLS)
-        rc = _f(r, "rmsd_to_crystal")
-        if not math.isfinite(rs):
-            continue
-        serial_pass = math.isfinite(rc) and 0.0 <= rc <= RMSD_SUCCESS_A
-        if (0.0 <= rs <= RMSD_SUCCESS_A) and not serial_pass:
-            symmcorr_gained.append(_pdb_id(r))
-
-    # Which metric actually produced the S1 numbers on this table? An
-    # unlabelled RMSD is not reportable (METHODOLOGY.md §0).
-    _metrics_seen = sorted(
-        {
-            elected_rmsd_labelled(r)[1]
-            for r in claim
-            if math.isfinite(elected_rmsd_labelled(r)[0])
-        }
-    ) or ["none_finite"]
-    s1_metric_used = "+".join(_metrics_seen)
-
-    report: dict[str, Any] = {
-        "contract": "admission_metrics_contract",
-        "contract_doc": "benchmarks/protocols/admission_metrics_contract.md",
-        "campaign_dir": campaign_dir,
-        "matrix_md5_pin": matrix_pin,
-        "matrix_md5_pin_source": matrix_pin_source,
-        "N_raw": len(all_rows),
-        "N_claim": n,
-        "N_denominator": denom,
-        "N_denominator_source": denom_source,
-        "N_missing_from_manifest": len(missing_targets),
-        "missing_targets": missing_targets,
-        "N_dropped": len(dropped),
-        "N_legacy_no_claim_ready": n_legacy,
-        "dropped_rows": dropped,
-        "metrics": {
-            "S1": {
-                "definition": (
-                    "symmetry-corrected elected-pose RMSD <= 2.0 A "
-                    "(spyrmsd graph automorphism, in-place; never hungarian). "
-                    "Falls back to ordered rmsd_to_crystal when no symmcorr "
-                    "sidecar is joined — conservative, since symmcorr <= serial."
-                ),
-                "metric_used": s1_metric_used,
-                "role": "rmsd_only_diagnostic",
-                "n": len(s1_ids),
-                "rate": rate(len(s1_ids)),
-                "ids": s1_ids,
-            },
-            "S2": {
-                "definition": "S1 AND PoseBusters pass on same elected pose",
-                "role": "rmsd_and_pb_diagnostic",
-                "n": len(s2_ids),
-                "rate": rate(len(s2_ids)),
-                "ids": s2_ids,
-            },
-            "STRICT": {
-                "definition": (
-                    "claim_ready==1 with PB + tENCoM/Eigen + hash receipts; "
-                    "numerator ∩ frozen 85-target manifest"
-                ),
-                "role": "primary_headline",
-                "n": len(strict_ids),
-                "rate": rate(len(strict_ids)),
-                "ids": strict_ids,
-            },
-            "S3": {
-                "definition": (
-                    "conditional_scanned_pool_ceiling / best_cluster_rmsd <= 2.0 A "
-                    "(scanned heads/members only; NOT any-pose)"
-                ),
-                "role": "diagnostic_only",
-                "n": len(s3_ids),
-                "rate": rate(len(s3_ids)),
-                "ids": s3_ids,
-                "warning": (
-                    "Do not report S3 as abstract / headline success. "
-                    "Ceiling is conditional on scanned emission pool."
-                ),
-            },
-        },
-        "election_gap": {
-            "definition": "S3=1 and S1=0 (scanned pool had near-native; elector missed)",
-            "n": len(election_gap_ids),
-            "rate": rate(len(election_gap_ids)),
-            "ids": election_gap_ids,
-        },
-        "S1_fail_ids": s1_fail_ids,
-        "symmcorr_delta": {
-            "definition": (
-                "targets whose elected-pose RMSD verdict moves fail->PASS when "
-                "the serial metric is replaced by the symmetry-corrected one"
-            ),
-            "n": len(symmcorr_gained),
-            "ids": symmcorr_gained,
-            "direction_note": (
-                "one-way by construction: symmetry correction minimises over "
-                "graph automorphisms and the identity mapping is one of them, "
-                "so symmcorr <= serial and no target can move PASS->fail"
-            ),
-        },
-        "strict_metric_inheritance": {
-            "note": (
-                "STRICT is the engine's claim_ready column. In the engine "
-                "claim_ready requires success_pb, and success_pb := "
-                "success_rmsd AND pb_pass, where success_rmsd gates on the "
-                "SERIAL rmsd_to_crystal (LIB/DatasetRunner.cpp). STRICT "
-                "therefore still inherits the serial definition and is a "
-                "CONSERVATIVE lower bound: it can under-count but never "
-                "over-count. Repointing the engine gate is the remaining half "
-                "of #365 and requires a rebuild."
-            ),
-            "s1_metric": s1_metric_used,
-            "strict_metric": "serial (via engine success_pb)",
-        },
-        "headline": {
-            "metric": "STRICT",
-            "n": len(strict_ids),
-            "N": denom,
-            "rate": rate(len(strict_ids)),
-            "label": "claim_ready strict success (rate over frozen 85-target denominator)",
-        },
-        "admission": {
-            "seed_echo": 0,
-            "native_pose_seeded": 0,
-            "matrix_md5": matrix_pin,
-            "claim_ready": 1,
-        },
+def aggregate_rows(rows: Iterable[dict[str, str]], matrix_pin: str, matrix_pin_source: str,
+                   campaign_dir: str | None = None, fixed_denominator: bool = True,
+                   *, manifest_path: Path | None = None, expected_seeds: list[str] | None = None,
+                   arm: str | None = None) -> dict[str, Any]:
+    all_rows = list(rows)
+    matrix_pin = _normalize_matrix_pin(matrix_pin)
+    selected, groups, aggregation = _observation_groups(all_rows, expected_seeds, arm)
+    if fixed_denominator:
+        codes, digest = load_target_manifest(manifest_path)
+        denominator_source = f"frozen_manifest(N={len(codes)},sha={digest})"
+    else:
+        codes, digest = sorted(groups), None
+        denominator_source = "observed_targets (explicit diagnostic legacy mode; STRICT unavailable)"
+    roster = set(codes)
+    denominator = len(codes)
+    missing = sorted(roster - set(groups))
+    dropped, strict_rows, eligible_rows = [], [], []
+    verdicts: dict[str, list[dict]] = defaultdict(list)
+    for row in selected:
+        pid = _pdb_id(row)
+        eligible, _ = is_claim_eligible(row, matrix_pin)
+        reasons = strict_failure_reasons(row, matrix_pin)
+        if pid not in roster:
+            reasons.append("off_manifest")
+        if reasons:
+            dropped.append({"pdb_id": pid, "seed": row.get("seed", ""), "reasons": reasons})
+        elif fixed_denominator:
+            strict_rows.append(row)
+        if eligible and pid in roster:
+            eligible_rows.append(row)
+        s1 = eligible and is_s1(row)
+        verdicts[pid].append({"S1": s1, "S2": eligible and is_s2(row, s1),
+                              "S3": eligible and is_s3(row), "STRICT": not reasons and fixed_denominator})
+    required = aggregation["required_passes"]
+    if expected_seeds is not None:
+        for pid in codes:
+            present = {_seed_id(r.get("seed", "")) for r in groups.get(pid, [])}
+            for seed in aggregation["expected_seeds"]:
+                if seed not in present:
+                    aggregation["missing_expected_observations"].append({"pdb_id": pid, "seed": seed})
+    definitions = {
+        "S1": "finite elected in-place graph-symmetry RMSD <=2 A, or labelled serial fallback; protocol-eligible rows",
+        "S2": "S1 AND pb_pass with matching elected-pose receipt hash (diagnostic)",
+        "STRICT": "recomputed serial RMSD/PB/score/validator/protocol/matrix receipt checks; underlying artifacts not authenticated",
+        "S3": "finite conditional scanned-pool ceiling <=2 A (diagnostic; not any-pose)",
     }
+    metrics = {}
+    for key in definitions:
+        ids = sorted(pid for pid in roster if sum(v[key] for v in verdicts[pid]) >= required)
+        rate = len(ids) / denominator if denominator else 0.0
+        if key == "STRICT" and not fixed_denominator:
+            rate = None
+        metrics[key] = {"definition": definitions[key], "role": "primary_receipt_headline" if key == "STRICT" else "diagnostic_only",
+                        "n": len(ids), "rate": rate, "ids": ids}
+    metric_used = "+".join(sorted({elected_rmsd_labelled(r)[1] for r in eligible_rows
+                                  if math.isfinite(elected_rmsd(r))})) or "none_finite"
+    metrics["S1"]["metric_used"] = metric_used
+    gap_ids = sorted(set(metrics["S3"]["ids"]) - set(metrics["S1"]["ids"]))
+    symmcorr_gained = sorted({_pdb_id(r) for r in eligible_rows
+                             if math.isfinite(_f(r, *SYMMCORR_COLS))
+                             and 0 <= _f(r, *SYMMCORR_COLS) <= RMSD_SUCCESS_A
+                             and not (math.isfinite(_f(r, "rmsd_to_crystal"))
+                                      and 0 <= _f(r, "rmsd_to_crystal") <= RMSD_SUCCESS_A)})
+    report = {"contract": "admission_metrics_contract/v2", "contract_doc": "METHODOLOGY.md#03-admission-identity-missingness-and-repair-evidence",
+              "campaign_dir": campaign_dir, "matrix_md5_pin": matrix_pin, "matrix_md5_pin_source": matrix_pin_source,
+              "evidence_level": "validated_receipt_fields", "artifacts_verified": False,
+              "evidence_limit": "CSV consistency is not independent proof of validator execution, raw-artifact integrity, receptor condition, or scientific protocol compliance.",
+              "N_raw": len(all_rows), "N_selected": len(selected), "N_claim": len(strict_rows),
+              "N_protocol_eligible": len(eligible_rows), "N_denominator": denominator,
+              "N_denominator_source": denominator_source, "manifest_sha256_of_sorted_codes": digest,
+              "N_missing_from_manifest": len(missing), "missing_targets": missing,
+              "off_manifest_targets": sorted(set(groups) - roster), "N_dropped": len(dropped), "dropped_rows": dropped,
+              "N_legacy_no_claim_ready": sum(not str(r.get("claim_ready", "")).strip() for r in selected),
+              "aggregation": aggregation, "metrics": metrics,
+              "election_gap": {"definition": "target S3 majority passes and target S1 majority fails", "n": len(gap_ids),
+                               "rate": len(gap_ids) / denominator if denominator else 0.0, "ids": gap_ids},
+              "S1_fail_ids": sorted(roster - set(metrics["S1"]["ids"])),
+              "symmcorr_delta": {"definition": "distinct targets with a measured serial-fail / symmcorr-pass observation (not a majority verdict)",
+                                 "n": len(symmcorr_gained), "ids": symmcorr_gained},
+              "strict_metric_inheritance": {"note": "STRICT recomputes the producer's serial gate; symmetry sidecars affect diagnostics only.",
+                                            "s1_metric": metric_used, "strict_metric": "serial (recomputed)"},
+              "legacy_diagnostic_mode": not fixed_denominator}
+    report["headline"] = {"metric": "STRICT", "n": metrics["STRICT"]["n"], "N": denominator,
+                          "rate": metrics["STRICT"]["rate"], "label": definitions["STRICT"]}
     return report
 
 
-def format_text_report(report: dict[str, Any]) -> str:
-    m = report["metrics"]
-    n = report.get("N_denominator", report["N_claim"])
-    lines = [
-        f"campaign_dir: {report.get('campaign_dir')}",
-        f"matrix_md5_pin: {report['matrix_md5_pin']} (source={report['matrix_md5_pin_source']})",
-        f"N_raw={report['N_raw']}  N_claim={report['N_claim']}  "
-        f"N_denominator={n} ({report.get('N_denominator_source','')})  "
-        f"N_dropped={report['N_dropped']}",
-        (
-            f"MISSING from frozen manifest (counted as failures): "
-            f"{report['N_missing_from_manifest']} -> {', '.join(report['missing_targets'][:20])}"
-            + (" ..." if report["N_missing_from_manifest"] > 20 else "")
-        )
-        if report.get("N_missing_from_manifest")
-        else "all preregistered targets present",
-        "",
-        f"STRICT (headline): {m['STRICT']['n']}/{n} = {100.0 * m['STRICT']['rate']:.2f}%  "
-        f"[claim_ready]",
-        f"S1 (RMSD-only):    {m['S1']['n']}/{n} = {100.0 * m['S1']['rate']:.2f}%  "
-        f"[diagnostic; metric={m['S1'].get('metric_used', 'unknown')}]",
-        f"S2 (S1∧PB):        {m['S2']['n']}/{n} = {100.0 * m['S2']['rate']:.2f}%",
-        f"S3 (pool ceiling): {m['S3']['n']}/{n} = {100.0 * m['S3']['rate']:.2f}%  "
-        f"[diagnostic; conditional scanned pool — NOT any-pose]",
-        f"election_gap (S3∧¬S1): {report['election_gap']['n']}/{n} = "
-        f"{100.0 * report['election_gap']['rate']:.2f}%",
-    ]
-    _sd = report.get("symmcorr_delta")
-    if _sd is not None:
-        lines.append(
-            f"symmcorr gain (fail->PASS): {_sd['n']}"
-            + (f" -> {', '.join(_sd['ids'])}" if _sd["ids"] else "")
-        )
-    _sm = report.get("symmcorr")
-    if _sm is not None and _sm.get("sidecar"):
-        lines.append(
-            f"symmcorr sidecar: {_sm['joined']}/{_sm['sidecar_rows']} rows joined"
-        )
-    elif report.get("metrics", {}).get("S1", {}).get("metric_used") == "serial":
-        lines.append(
-            "symmcorr sidecar: NONE — S1 used the serial metric "
-            "(conservative; run scripts/rmsd_symmcorr.py and pass --symmcorr)"
-        )
-    if report["N_dropped"]:
-        lines.append("")
-        lines.append("dropped (non-claim):")
-        for d in report["dropped_rows"][:20]:
-            lines.append(f"  {_pdb_id_from_drop(d)}: {', '.join(d['reasons'])}")
-        if report["N_dropped"] > 20:
-            lines.append(f"  ... +{report['N_dropped'] - 20} more")
-    return "\n".join(lines) + "\n"
-
-
-def _pdb_id_from_drop(d: dict[str, Any]) -> str:
-    return str(d.get("pdb_id") or "?")
-
-
-def apply_headline(
-    report: dict[str, Any],
-    headline: str,
-    diagnostic_only: bool,
-) -> tuple[dict[str, Any], int | None]:
-    """Mutate report headline; return (report, error_exit_code_or_None)."""
-    h = headline.strip().lower()
-    if h in ("strict", "claim_ready", "claim-ready"):
-        h = "strict"
-    if h not in ("s1", "s2", "s3", "strict"):
+def apply_headline(report: dict[str, Any], headline: str, diagnostic_only: bool) -> tuple[dict[str, Any], int | None]:
+    key = headline.upper().replace("-", "_")
+    if key == "CLAIM_READY":
+        key = "STRICT"
+    if key not in report["metrics"] or (key == "S3" and not diagnostic_only):
+        print("CONTRACT VIOLATION: S3 headline requires --diagnostic-only", file=sys.stderr)
         return report, 2
-    if h == "s3" and not diagnostic_only:
-        print(
-            "CONTRACT VIOLATION: --headline s3 is not allowed as primary without "
-            "--diagnostic-only. S3 is conditional scanned-pool ceiling only; "
-            "use --headline strict (claim_ready) for claim success.",
-            file=sys.stderr,
-        )
+    if report.get("legacy_diagnostic_mode") and (key == "STRICT" or not diagnostic_only):
+        print("CONTRACT VIOLATION: legacy denominator requires a diagnostic headline and --diagnostic-only", file=sys.stderr)
         return report, 2
-    if h in ("s1", "s2") and not diagnostic_only:
-        # Allowed but must not be mistaken for claim success.
-        pass
-
-    key = "STRICT" if h == "strict" else h.upper()
-    m = report["metrics"][key]
-    report["headline"] = {
-        "metric": key,
-        "n": m["n"],
-        "N": report.get("N_denominator", report["N_claim"]),
-        "rate": m["rate"],
-        "label": m["definition"],
-        "role": m["role"],
-        "diagnostic_only": h in ("s1", "s2", "s3") or diagnostic_only,
-    }
-    if h == "s3":
-        report["headline"]["warning"] = (
-            "S3 is diagnostic only — conditional scanned-pool ceiling, not any-pose."
-        )
-    if h in ("s1", "s2"):
-        report["headline"]["warning"] = (
-            f"{key} is not the claim headline; prefer STRICT (claim_ready)."
-        )
+    metric = report["metrics"][key]
+    report["headline"] = {"metric": key, "n": metric["n"], "N": report["N_denominator"], "rate": metric["rate"],
+                          "label": metric["definition"], "role": metric["role"],
+                          "diagnostic_only": key != "STRICT" or diagnostic_only}
     return report, None
 
 
+def format_text_report(report: dict[str, Any]) -> str:
+    lines = [f"campaign_dir: {report['campaign_dir']}",
+             f"evidence_level: {report['evidence_level']}; artifacts_verified=false",
+             f"N_raw={report['N_raw']} N_claim={report['N_claim']} N_protocol_eligible={report['N_protocol_eligible']}",
+             f"denominator: {report['N_denominator']} ({report['N_denominator_source']})",
+             f"aggregation: {report['aggregation']['mode']}; arm={report['aggregation']['arm']}; endpoint={report['aggregation']['endpoint']}"]
+    for key in ("STRICT", "S1", "S2", "S3"):
+        metric = report["metrics"][key]
+        rate = "unavailable" if metric["rate"] is None else f"{100 * metric['rate']:.2f}%"
+        lines.append(f"{key}: {metric['n']}/{report['N_denominator']} = {rate}; {metric['definition']}")
+    lines.append(report["evidence_limit"])
+    return "\n".join(lines) + "\n"
+
+
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    ap.add_argument(
-        "campaign_dir",
-        type=Path,
-        nargs="?",
-        default=None,
-        help="Campaign directory with */result.csv and/or summary CSV",
-    )
-    ap.add_argument(
-        "--c0-full85",
-        action="store_true",
-        help=f"Use $FLEXAIDDS_RESULTS/{C0_FULL85_REL}",
-    )
-    ap.add_argument(
-        "--csv",
-        type=Path,
-        default=None,
-        help="Aggregate a single summary CSV instead of a campaign tree",
-    )
-    ap.add_argument(
-        "--matrix-md5",
-        type=str,
-        default=None,
-        help=f"Matrix pin (default: receipt/provenance or {DEFAULT_MATRIX_MD5})",
-    )
-    ap.add_argument(
-        "--headline",
-        type=str,
-        default="strict",
-        choices=(
-            "strict",
-            "STRICT",
-            "claim_ready",
-            "s1",
-            "s2",
-            "s3",
-            "S1",
-            "S2",
-            "S3",
-        ),
-        help="Primary headline (default strict/claim_ready). s3 requires --diagnostic-only.",
-    )
-    ap.add_argument(
-        "--diagnostic-only",
-        action="store_true",
-        help="Allow --headline s3/s1/s2 as diagnostic headline (never abstract claim success).",
-    )
-    ap.add_argument(
-        "--symmcorr",
-        type=Path,
-        default=None,
-        help=(
-            "Sidecar CSV from scripts/rmsd_symmcorr.py. Supplies the "
-            "symmetry-corrected S1 metric (#365). Without it S1 falls back to "
-            "the ordered serial column, which under-counts but never "
-            "over-counts."
-        ),
-    )
-    ap.add_argument("--json", type=Path, default=None, help="Write full JSON report")
-    ap.add_argument(
-        "--quiet",
-        action="store_true",
-        help="JSON only to stdout (no human text block)",
-    )
-    args = ap.parse_args(argv)
-
-    n_sources = sum(
-        [
-            args.csv is not None,
-            bool(args.c0_full85),
-            args.campaign_dir is not None,
-        ]
-    )
-    if n_sources > 1:
-        print(
-            "error: provide exactly one of campaign_dir, --csv, or --c0-full85",
-            file=sys.stderr,
-        )
-        return 2
-
-    campaign: Path | None = None
-    rows: list[dict[str, str]] = []
-
-    if args.csv is not None:
-        if not args.csv.is_file():
-            print(f"not a file: {args.csv}", file=sys.stderr)
-            return 2
-        rows = load_rows_from_csv(args.csv)
-        campaign = args.csv.parent
-    elif args.c0_full85:
-        campaign = resolve_c0_full85_dir()
-        if not campaign.is_dir():
-            print(
-                f"C0 full85 campaign not found: {campaign}\n"
-                "Source ~/.flexaidds_env or set FLEXAIDDS_RESULTS.",
-                file=sys.stderr,
-            )
-            return 2
-        rows = load_campaign_rows(campaign)
-    elif args.campaign_dir is not None:
-        campaign = args.campaign_dir
-        if campaign.is_file() and campaign.suffix.lower() == ".csv":
-            rows = load_rows_from_csv(campaign)
-            campaign = campaign.parent
-        elif campaign.is_dir():
-            rows = load_campaign_rows(campaign)
-        else:
-            print(f"not a directory or CSV: {campaign}", file=sys.stderr)
-            return 2
-    else:
-        ap.print_help()
-        print(
-            "\nerror: provide campaign_dir, --csv, or --c0-full85",
-            file=sys.stderr,
-        )
-        return 2
-
-    assert campaign is not None
-    symmcorr_provenance: dict[str, Any] = {
-        "sidecar": None,
-        "joined": 0,
-        "refused_sha_mismatch": [],
-        "sidecar_rows": 0,
-    }
-    if args.symmcorr is not None:
-        if not args.symmcorr.is_file():
-            print(f"not a file: {args.symmcorr}", file=sys.stderr)
-            return 2
-        sidecar = load_symmcorr_sidecar(args.symmcorr)
-        symmcorr_provenance = join_symmcorr(rows, sidecar)
-        symmcorr_provenance["sidecar"] = str(args.symmcorr)
-        if symmcorr_provenance["refused_sha_mismatch"]:
-            print(
-                "error: symmcorr sidecar describes different poses for: "
-                + ", ".join(symmcorr_provenance["refused_sha_mismatch"])
-                + "\n(pose_sha256 mismatch — refusing to join a claim number "
-                "to a pose it is not about)",
-                file=sys.stderr,
-            )
-            return 2
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("campaign_dir", type=Path, nargs="?")
+    parser.add_argument("--csv", type=Path)
+    parser.add_argument("--c0-full85", action="store_true")
+    parser.add_argument("--matrix-md5")
+    parser.add_argument("--manifest", type=Path, help="Frozen target roster with N and validated sorted-code SHA256")
+    parser.add_argument("--expected-seeds", help="Comma-separated prespecified seeds; target success requires a strict majority")
+    parser.add_argument("--arm", help="Select this explicit arm value; report excluded row count")
+    parser.add_argument("--headline", default="strict", choices=("strict", "STRICT", "claim_ready", "s1", "s2", "s3", "S1", "S2", "S3"))
+    parser.add_argument("--diagnostic-only", action="store_true")
+    parser.add_argument("--legacy-observed-denominator", action="store_true")
+    parser.add_argument("--symmcorr", type=Path)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
     try:
-        pin, pin_src = load_matrix_pin(campaign, args.matrix_md5)
-    except ValueError as exc:
+        if sum([args.csv is not None, args.campaign_dir is not None, args.c0_full85]) != 1:
+            raise ValueError("provide exactly one of campaign_dir, --csv, or --c0-full85")
+        if args.legacy_observed_denominator and not args.diagnostic_only:
+            raise ValueError("--legacy-observed-denominator requires --diagnostic-only")
+        source = args.csv or (resolve_c0_full85_dir() if args.c0_full85 else args.campaign_dir)
+        _require_local(source)
+        if source.is_file():
+            rows, campaign = load_rows_from_csv(source), source.parent
+        elif source.is_dir() and args.csv is None:
+            rows, campaign = load_campaign_rows(source), source
+        else:
+            raise ValueError(f"not a CSV or campaign directory: {source}")
+        provenance = {"sidecar": None, "joined": 0, "refused_sha_mismatch": [], "sidecar_rows": 0}
+        # Filter explicitly chosen arms before joining; an unrelated arm is not a pose mismatch.
+        if args.arm is not None:
+            side_rows = [r for r in rows if str(r.get("arm", "")).strip() == args.arm]
+        else:
+            side_rows = rows
+        if args.symmcorr is not None:
+            provenance = join_symmcorr(side_rows, load_symmcorr_sidecar(args.symmcorr))
+            provenance["sidecar"] = str(args.symmcorr)
+            if provenance["refused_sha_mismatch"]:
+                raise ValueError("symmcorr pose_sha256 missing, invalid, or mismatched for: " + ", ".join(provenance["refused_sha_mismatch"]))
+        pin, pin_source = load_matrix_pin(campaign, args.matrix_md5)
+        report = aggregate_rows(rows, pin, pin_source, str(campaign.resolve()),
+                                fixed_denominator=not args.legacy_observed_denominator,
+                                manifest_path=args.manifest,
+                                expected_seeds=args.expected_seeds.split(",") if args.expected_seeds is not None else None,
+                                arm=args.arm)
+        report["symmcorr"] = provenance
+        report, error = apply_headline(report, args.headline, args.diagnostic_only)
+        if error:
+            return error
+        output = json.dumps(report, indent=2, allow_nan=False)
+        if args.json is not None:
+            _require_local(args.json)
+            args.json.write_text(output + "\n")
+        if args.quiet:
+            print(output)
+        else:
+            print(format_text_report(report), end="")
+        return 0 if report["metrics"]["STRICT"]["n"] > 0 or (args.diagnostic_only and report["N_selected"] > 0) else 1
+    except (ValueError, OSError, csv.Error) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    report = aggregate_rows(
-        rows,
-        matrix_pin=pin,
-        matrix_pin_source=pin_src,
-        campaign_dir=str(campaign.resolve()),
-    )
-    report["symmcorr"] = symmcorr_provenance
-    report, err = apply_headline(report, args.headline, args.diagnostic_only)
-    if err is not None:
-        return err
-
-    if not args.quiet:
-        print(format_text_report(report), end="")
-        print(
-            f"headline: {report['headline']['metric']} "
-            f"{report['headline']['n']}/{report['headline']['N']} "
-            f"= {100.0 * report['headline']['rate']:.2f}%"
-        )
-
-    text = json.dumps(report, indent=2)
-    if args.json:
-        args.json.write_text(text + "\n")
-    if args.quiet:
-        print(text)
-
-    return 0 if report["N_claim"] > 0 else 1
 
 
 if __name__ == "__main__":

--- a/tests/cf_aggregator_stubs.cpp
+++ b/tests/cf_aggregator_stubs.cpp
@@ -11,6 +11,7 @@
 #include "gaboom.h"
 #include <vector>
 #include <utility>
+#include <stdexcept>
 #include "tENCoM/tencm.h"
 
 namespace vibentropy {
@@ -23,6 +24,9 @@ void apply_sugar_puckers(atom*, const std::vector<std::vector<int>>&,
 }
 namespace tencm {
 void TorsionalENM::build_from_ligand(const atom*, int, int, float, float) {}
+std::vector<double> TorsionalENM::vibrational_eigenvalues(int*, int*) const {
+    throw std::logic_error("CF aggregator fixture must not execute tENCoM");
+}
 }
 
 // Controllable fail points for serial contamination tests (ic2cf restore).

--- a/tests/p0_claim_contract/test_fixed_denominator.py
+++ b/tests/p0_claim_contract/test_fixed_denominator.py
@@ -35,7 +35,11 @@ def strict_row(pid, sha="a" * 64):
         "pdb_id": pid, "seed_echo": "0", "native_pose_seeded": "0",
         "matrix_md5": PIN, "protocol_claim_eligible": "1", "claim_ready": "1",
         "rmsd_to_crystal": "1.0", "pb_pass": "1", "success_pb": "1",
+        "success_rmsd": "1", "score_pose_consistent": "1", "score_pose_delta": "0",
+        "posebusters_input_sha256": "b" * 64,
         "pb_backend": "bust_cli", "tencom_status": "ok", "eigen_status": "ok",
+        "pb_ran": "1", "pb_n_pass": "27", "pb_n_fail": "0", "pb_n_checks": "27",
+        "eigen_n_modes": "1", "elected_H_vib": "-1.5",
         "pose_sha256": sha, "rmsd_pose_sha256": sha,
         "posebusters_pose_sha256": sha, "tencom_pose_sha256": sha,
     }

--- a/tests/test_aggregate_claim_metrics.py
+++ b/tests/test_aggregate_claim_metrics.py
@@ -1,9 +1,12 @@
-#!/usr/bin/env python3
-"""Unit tests for scripts/aggregate_claim_metrics.py admission + STRICT contract."""
+"""Receipt consistency, frozen observation units, and CLI rejection regressions.
 
+Synthetic CSV controls exercise admission logic. They do not stand in for real
+validator execution; every report must state that limitation.
+"""
 from __future__ import annotations
 
 import csv
+import hashlib
 import importlib.util
 import json
 import subprocess
@@ -13,308 +16,397 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = ROOT / "scripts" / "aggregate_claim_metrics.py"
+SCRIPT = ROOT / "scripts/aggregate_claim_metrics.py"
 DEFAULT_PIN = "9dc93717dfed0698006d88dd6a9627bc"
-
-CSV_FIELDS = [
-    "pdb_id",
-    "rmsd_to_crystal",
-    "rmsd_hungarian",
-    "best_cluster_rmsd",
-    "conditional_scanned_pool_ceiling",
-    "success",
-    "success_rmsd",
-    "pb_pass",
-    "success_pb",
-    "claim_ready",
-    "seed_echo",
-    "native_pose_seeded",
-    "protocol_claim_eligible",
-    "matrix_md5",
-    "pose_sha256",
-    "rmsd_pose_sha256",
-    "posebusters_pose_sha256",
-    "tencom_pose_sha256",
-    "tencom_status",
-    "eigen_status",
-    "pb_backend",
-]
+POSE = hashlib.sha256(b"synthetic elected pose").hexdigest()
+PB_INPUT = hashlib.sha256(b"synthetic PB input SDF").hexdigest()
 
 
 def _load():
-    spec = importlib.util.spec_from_file_location("aggregate_claim_metrics", SCRIPT)
-    assert spec and spec.loader
+    spec = importlib.util.spec_from_file_location("aggregate_claim_metrics_test", SCRIPT)
     mod = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
     return mod
 
 
-def _write_campaign(tmp: Path, rows: list[dict], receipt_md5: str | None = DEFAULT_PIN) -> Path:
-    camp = tmp / "campaign"
-    camp.mkdir(parents=True, exist_ok=True)
-    for r in rows:
-        pid = r["pdb_id"]
-        d = camp / pid
-        d.mkdir(exist_ok=True)
-        path = d / "result.csv"
-        with path.open("w", newline="") as fh:
-            w = csv.DictWriter(fh, fieldnames=CSV_FIELDS, extrasaction="ignore")
-            w.writeheader()
-            full = {k: r.get(k, "") for k in CSV_FIELDS}
-            w.writerow(full)
-    if receipt_md5 is not None:
-        (camp / "RUN_RECEIPT.json").write_text(
-            json.dumps({"matrix_md5": receipt_md5, "run_id": "fixture"})
-        )
-    return camp
+@pytest.fixture
+def agg():
+    return _load()
 
 
-def _row(
-    pdb_id: str,
-    *,
-    rmsd_ordered: float,
-    bcr: float,
-    pb: int = 0,
-    seed_echo: int = 0,
-    native_seeded: int = 0,
-    claim: int = 1,
-    claim_ready: int | None = None,
-    matrix_md5: str = "",
-    rmsd_h: float | None = None,
-    pose_hash: str = "abc123",
-) -> dict:
-    """Build a claim row. rmsd_ordered is rmsd_to_crystal (S1 metric)."""
-    s1 = 1 if 0.0 <= rmsd_ordered <= 2.0 and seed_echo == 0 else 0
-    cr = claim_ready if claim_ready is not None else (1 if s1 and pb and claim else 0)
-    h = rmsd_h if rmsd_h is not None else rmsd_ordered + 0.3  # hungarian may differ
-    return {
-        "pdb_id": pdb_id,
-        "rmsd_to_crystal": f"{rmsd_ordered:.4f}",
-        "rmsd_hungarian": f"{h:.4f}",
-        "best_cluster_rmsd": f"{bcr:.4f}",
-        "conditional_scanned_pool_ceiling": f"{bcr:.4f}",
-        "success": str(s1),
-        "success_rmsd": str(s1),
-        "pb_pass": str(pb),
-        "success_pb": str(1 if s1 and pb else 0),
-        "claim_ready": str(cr),
-        "seed_echo": str(seed_echo),
-        "native_pose_seeded": str(native_seeded),
-        "protocol_claim_eligible": str(claim),
-        "matrix_md5": matrix_md5,
-        "pose_sha256": pose_hash if cr else "",
-        "rmsd_pose_sha256": pose_hash if cr else "",
-        "posebusters_pose_sha256": pose_hash if cr else "",
-        "tencom_pose_sha256": pose_hash if cr else "",
-        "tencom_status": "ok" if cr else "not_run",
-        "eigen_status": "ok" if cr else "not_run",
-        "pb_backend": "bust_cli" if cr else "skipped",
-    }
+def _row(pdb_id="1G9V", **changes):
+    row = dict(pdb_id=pdb_id, seed="12345", endpoint="argmin(ACF)",
+               seed_echo="0", native_pose_seeded="0", protocol_claim_eligible="1",
+               matrix_md5=DEFAULT_PIN, rmsd_to_crystal="1.0", rmsd_hungarian="0.4",
+               success_rmsd="1", success_pb="1", pb_pass="1", claim_ready="1",
+               score_pose_consistent="1", score_pose_delta="0", pb_backend="bust_cli",
+               tencom_status="ok", eigen_status="ok", eigen_n_modes="1", elected_H_vib="-1.5",
+               pb_ran="1", pb_n_pass="27", pb_n_fail="0", pb_n_checks="27",
+               pose_sha256=POSE, rmsd_pose_sha256=POSE, posebusters_pose_sha256=POSE,
+               tencom_pose_sha256=POSE, posebusters_input_sha256=PB_INPUT,
+               best_cluster_rmsd="0.5")
+    row.update({k: str(v) for k, v in changes.items()})
+    return row
 
 
-def test_claim_filter_drops_seeded_rows(tmp_path: Path):
-    mod = _load()
-    rows = [
-        _row("1G9V", rmsd_ordered=1.2, bcr=0.8, pb=1, claim_ready=1),
-        _row("SEED1", rmsd_ordered=0.5, bcr=0.4, pb=1, seed_echo=1, claim=0, claim_ready=0),
-        _row("NAT1", rmsd_ordered=0.9, bcr=0.7, pb=1, native_seeded=1, claim=0, claim_ready=0),
-        _row("GOOD2", rmsd_ordered=3.5, bcr=1.1, pb=0, claim_ready=0),
-    ]
-    camp = _write_campaign(tmp_path, rows)
-    pin, src = mod.load_matrix_pin(camp, None)
-    assert pin == DEFAULT_PIN
-    report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
-    # Only 1G9V has claim_ready=1 (and is on the frozen 85-target manifest)
-    assert report["N_claim"] == 1
+def _write(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = list(dict.fromkeys(key for row in rows for key in row))
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+    return path
+
+
+def _cli(path, *args, script=SCRIPT):
+    result = subprocess.run([sys.executable, "-B", str(script), "--csv", str(path), "--quiet", *args],
+                            text=True, capture_output=True, timeout=15)
+    report = json.loads(result.stdout) if result.stdout.strip() else None
+    return result, report
+
+
+def _aggregate(agg, rows, **kwargs):
+    return agg.aggregate_rows(rows, DEFAULT_PIN, "test", **kwargs)
+
+
+def test_valid_receipt_control_cli(tmp_path):
+    result, report = _cli(_write(tmp_path / "result.csv", [_row()]))
+    assert result.returncode == 0, result.stderr
     assert report["metrics"]["STRICT"]["n"] == 1
-    assert report["metrics"]["S1"]["ids"] == ["1G9V"]
+    assert report["headline"]["rate"] == 1 / 85
+    assert report["evidence_level"] == "validated_receipt_fields"
+    assert report["artifacts_verified"] is False
+    assert report["aggregation"]["mode"] == "single_observation"
 
 
-def test_s1_uses_ordered_not_hungarian(tmp_path: Path):
-    """Hungarian ≤2 must not admit S1 when ordered >2."""
-    mod = _load()
-    rows = [
-        _row(
-            "HU",
-            rmsd_ordered=5.0,
-            bcr=1.0,
-            pb=1,
-            rmsd_h=0.5,
-            claim_ready=0,
-        ),
-    ]
-    camp = _write_campaign(tmp_path, rows)
-    # claim_ready=0 → dropped from claim table
-    pin, src = mod.load_matrix_pin(camp, None)
-    report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
+@pytest.mark.parametrize("changes", [
+    {"pb_pass": "0", "success_pb": "0"},
+    {"pb_pass": "0", "success_pb": "1"},
+    {"rmsd_to_crystal": "-1"}, {"rmsd_to_crystal": "9"},
+    {"rmsd_to_crystal": "nan"}, {"rmsd_to_crystal": "inf"},
+    {"score_pose_consistent": "0"}, {"score_pose_delta": "0.0001001"},
+    {"score_pose_delta": "nan"}, {"score_pose_delta": "inf"},
+    {"score_pose_delta": ""}, {"tencom_status": ""}, {"eigen_status": "fail"},
+    {"pb_backend": "internal"}, {"pose_sha256": ""}, {"rmsd_pose_sha256": ""},
+    {"tencom_pose_sha256": "c" * 64}, {"posebusters_pose_sha256": "missing"},
+    {"posebusters_input_sha256": ""}, {"matrix_md5": ""}, {"matrix_md5": "0" * 32},
+    {"protocol_claim_eligible": ""}, {"protocol_claim_eligible": "0"},
+    {"seed_echo": ""}, {"seed_echo": "1"}, {"native_pose_seeded": "1"},
+    {"native_pose_seed_fraction": "0.1"}, {"claim_ready": "0"},
+    {"success_rmsd": "0"}, {"success_pb": "0"},
+    {"docking_completed": "0"}, {"docking_completed": ""},
+    {"docking_exit_code": "-1"}, {"docking_exit_code": ""},
+    {"num_poses": "0"}, {"num_poses": "-1"}, {"num_poses": "1.5"},
+    {"pb_ran": "0"}, {"pb_n_fail": "1"}, {"pb_n_checks": "0"},
+    {"pb_n_pass": "0"}, {"pb_n_pass": "26", "pb_n_checks": "27", "pb_n_fail": "0"},
+    {"eigen_n_modes": "0"}, {"eigen_n_modes": "nan"},
+    {"elected_H_vib": "nan"}, {"native_pose_seed_fraction": ""},
+    {"pb_n_checks": "1", "pb_n_pass": "1"},
+    {"pb_failed_keys": "bond_lengths"}, {"rmsd_fail_reason": "ref_empty"},
+    {"pb_ran": ""}, {"pb_n_checks": ""}, {"elected_H_vib": ""},
+])
+def test_stale_strict_flag_cannot_override_bad_evidence(tmp_path, changes):
+    result, report = _cli(_write(tmp_path / "result.csv", [_row(**changes)]))
+    assert result.returncode == 1, result.stderr
+    assert report["metrics"]["STRICT"]["n"] == 0
+    assert report["dropped_rows"][0]["reasons"]
+
+
+def test_four_field_self_attestation_is_not_strict(tmp_path):
+    minimal = dict(pdb_id="1G9V", seed_echo="0", native_pose_seeded="0", claim_ready="1")
+    result, report = _cli(_write(tmp_path / "result.csv", [minimal]))
+    assert result.returncode == 1
+    assert report["metrics"]["STRICT"]["n"] == 0
+
+
+def test_matching_malformed_hashes_not_receipts(agg):
+    row = _row(**{key: "abc" for key in (
+        "pose_sha256", "rmsd_pose_sha256", "posebusters_pose_sha256", "tencom_pose_sha256", "posebusters_input_sha256")})
+    assert not agg.is_strict_success(row)
+
+
+def test_score_tolerance_and_rmsd_boundary(agg):
+    assert agg.is_strict_success(_row(score_pose_delta="-0.0001", rmsd_to_crystal="2.0"))
+    assert not agg.is_strict_success(_row(score_pose_delta="-0.0001000001"))
+
+
+def test_diagnostics_survive_strict_failure(agg):
+    report = _aggregate(agg, [_row(claim_ready="0", tencom_status="fail")])
     assert report["N_claim"] == 0
-    # Direct unit check
-    r = rows[0]
-    r["claim_ready"] = "1"
-    r["seed_echo"] = "0"
-    assert not mod.is_s1(r)
-    assert mod.elected_rmsd(r) == pytest.approx(5.0)
+    assert report["N_protocol_eligible"] == 1
+    assert {key: metric["n"] for key, metric in report["metrics"].items()} == dict(S1=1, S2=1, STRICT=0, S3=1)
 
 
-def test_s1_vs_s3_diverge_election_gap(tmp_path: Path):
-    mod = _load()
-    rows = [
-        _row("1G9V", rmsd_ordered=1.5, bcr=0.9, pb=1, claim_ready=1),
-        _row("GAP1", rmsd_ordered=5.7, bcr=1.6, pb=0, claim_ready=0),
-        _row("GAP2", rmsd_ordered=4.2, bcr=1.9, pb=0, claim_ready=0),
-        _row("MISS", rmsd_ordered=6.0, bcr=3.5, pb=0, claim_ready=0),
-        _row("NOPB", rmsd_ordered=1.1, bcr=1.0, pb=0, claim_ready=0),
-    ]
-    # Admit GAP/NOPB for S1/S3 comparison by not requiring claim_ready in row
-    # when testing aggregate — only HIT is claim_ready=1.
-    camp = _write_campaign(tmp_path, rows)
-    pin, src = mod.load_matrix_pin(camp, None)
-    report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
-    assert report["N_claim"] == 1
+def test_nonfinite_rmsd_does_not_fall_back_to_stale_success_flags(agg):
+    assert not agg.is_s1(_row(rmsd_to_crystal="nan"))
+    assert not agg.is_s3(_row(best_cluster_rmsd="nan", success_s3="1"))
+
+
+def test_hungarian_never_substitutes_for_serial(agg):
+    row = _row(rmsd_to_crystal="5.0", rmsd_hungarian="0.1")
+    assert not agg.is_s1(row)
+    assert not agg.is_strict_success(row)
+
+
+def test_s2_recomputes_pb_and_requires_pose_identity(agg):
+    assert not agg.is_s2(_row(pb_pass="0", success_pb="1"), True)
+    assert not agg.is_s2(_row(posebusters_pose_sha256=""), True)
+    # Engine success_pb includes serial RMSD; it must not veto a graph-symmetry diagnostic.
+    assert agg.is_s2(_row(success_pb="0"), True)
+
+
+def test_seeded_rows_excluded_from_diagnostics(agg):
+    report = _aggregate(agg, [_row(seed_echo="1")])
+    assert all(metric["n"] == 0 for metric in report["metrics"].values())
+
+
+def test_off_manifest_targets_never_inflate_any_metric(agg):
+    report = _aggregate(agg, [_row(), _row("9XXX")])
+    assert all(metric["n"] == 1 for metric in report["metrics"].values())
+    assert report["off_manifest_targets"] == ["9XXX"]
+
+
+@pytest.mark.parametrize("count", [2, 86])
+def test_duplicate_observations_rejected_cli(tmp_path, count):
+    result, report = _cli(_write(tmp_path / "result.csv", [_row()] * count))
+    assert result.returncode == 2
+    assert report is None
+    assert "duplicate observation" in result.stderr
+
+
+def test_repeated_targets_require_frozen_seed_list(agg):
+    rows = [_row(seed=seed) for seed in ("1", "2", "3")]
+    with pytest.raises(ValueError, match="expected-seeds"):
+        _aggregate(agg, rows)
+
+
+def test_majority_of_expected_seeds_not_union(agg):
+    rows = [_row(seed="1"), _row(seed="2", claim_ready="0"), _row(seed="3", claim_ready="0")]
+    report = _aggregate(agg, rows, expected_seeds=["1", "2", "3"])
+    assert report["metrics"]["STRICT"]["n"] == 0
+    assert report["metrics"]["S1"]["n"] == 1
+    report = _aggregate(agg, [_row(seed="1"), _row(seed="2")], expected_seeds=["1", "2", "3"])
     assert report["metrics"]["STRICT"]["n"] == 1
-    assert report["headline"]["metric"] == "STRICT"
+    assert dict(pdb_id="1G9V", seed="3") in report["aggregation"]["missing_expected_observations"]
 
 
-def test_headline_s3_rejected_without_diagnostic_flag():
-    mod = _load()
-    report = {
-        "N_claim": 1,
-        "metrics": {
-            "S1": {"n": 0, "rate": 0.0, "definition": "s1", "role": "rmsd_only_diagnostic"},
-            "S2": {"n": 0, "rate": 0.0, "definition": "s2", "role": "secondary"},
-            "STRICT": {"n": 0, "rate": 0.0, "definition": "strict", "role": "primary_headline"},
-            "S3": {
-                "n": 1,
-                "rate": 1.0,
-                "definition": "s3",
-                "role": "diagnostic_only",
-            },
-        },
-    }
-    _, err = mod.apply_headline(report, "s3", diagnostic_only=False)
-    assert err == 2
-    out, err2 = mod.apply_headline(report, "s3", diagnostic_only=True)
-    assert err2 is None
-    assert out["headline"]["metric"] == "S3"
+def test_missing_seeds_and_even_seed_ties_fail(agg):
+    report = _aggregate(agg, [_row(seed="1")], expected_seeds=["1", "2", "3"])
+    assert report["metrics"]["STRICT"]["n"] == 0
+    report = _aggregate(agg, [_row(seed="1"), _row(seed="2")], expected_seeds=["1", "2", "3", "4"])
+    assert report["metrics"]["STRICT"]["n"] == 0
 
 
-def test_cli_headline_s3_exits_nonzero(tmp_path: Path):
-    rows = [_row("A", rmsd_ordered=5.0, bcr=1.0, claim_ready=1, pb=1)]
-    camp = _write_campaign(tmp_path, rows)
-    proc = subprocess.run(
-        [sys.executable, str(SCRIPT), str(camp), "--headline", "s3"],
-        capture_output=True,
-        text=True,
-    )
-    assert proc.returncode == 2
-    assert "CONTRACT VIOLATION" in proc.stderr
+@pytest.mark.parametrize("seeds", [["1", "1"], [], [""]])
+def test_invalid_expected_seed_lists_rejected(agg, seeds):
+    with pytest.raises(ValueError, match="expected seeds"):
+        _aggregate(agg, [_row()], expected_seeds=seeds)
 
 
-def test_cli_happy_path_json(tmp_path: Path):
-    rows = [
-        _row("1G9V", rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1),
-        _row("P2", rmsd_ordered=4.0, bcr=1.5, pb=0, claim_ready=0),
-        _row("SEED", rmsd_ordered=0.1, bcr=0.1, pb=1, seed_echo=1, claim=0, claim_ready=0),
-    ]
-    camp = _write_campaign(tmp_path, rows)
-    out_json = tmp_path / "out.json"
-    proc = subprocess.run(
-        [sys.executable, str(SCRIPT), str(camp), "--json", str(out_json), "--quiet"],
-        capture_output=True,
-        text=True,
-    )
-    assert proc.returncode == 0, proc.stderr
-    report = json.loads(out_json.read_text())
-    assert report["N_claim"] == 1
+def test_unexpected_seed_rejected(agg):
+    with pytest.raises(ValueError, match="unexpected seed"):
+        _aggregate(agg, [_row(seed="4")], expected_seeds=["1", "2", "3"])
+
+
+def test_mixed_arms_rejected_and_explicit_selection_counted(agg):
+    rows = [_row(arm="A"), _row(arm="B")]
+    with pytest.raises(ValueError, match="mixed arm"):
+        _aggregate(agg, rows)
+    report = _aggregate(agg, rows, arm="A")
+    assert report["aggregation"]["N_filtered_by_arm"] == 1
+    assert report["aggregation"]["arm"] == "A"
     assert report["metrics"]["STRICT"]["n"] == 1
-    assert report["metrics"]["S3"]["role"] == "diagnostic_only"
-    assert report["headline"]["metric"] == "STRICT"
-    assert "hungarian" not in report["metrics"]["S1"]["definition"].lower() or True
-    assert "ordered" in report["metrics"]["S1"]["definition"].lower()
 
 
-def test_claim_ready_required_when_column_present(tmp_path: Path):
-    mod = _load()
-    r = _row("X", rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=0)
-    camp = _write_campaign(tmp_path, [r])
-    pin, src = mod.load_matrix_pin(camp, None)
-    report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
-    assert report["N_claim"] == 0
-    assert "claim_ready=0" in report["dropped_rows"][0]["reasons"]
+def test_mixed_endpoints_rejected(agg):
+    with pytest.raises(ValueError, match="mixed endpoint"):
+        _aggregate(agg, [_row(), _row("1GM8", endpoint="argmin(CF)")])
 
 
-def test_hash_mismatch_drops_claim(tmp_path: Path):
-    mod = _load()
-    r = _row("H", rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1, pose_hash="aaa")
-    r["rmsd_pose_sha256"] = "bbb"
-    camp = _write_campaign(tmp_path, [r])
-    pin, src = mod.load_matrix_pin(camp, None)
-    report = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, src, str(camp))
-    assert report["N_claim"] == 0
-    assert any("rmsd_pose_sha256_mismatch" in x for x in report["dropped_rows"][0]["reasons"])
+@pytest.mark.parametrize("text", [
+    "pdb_id,claim_ready,claim_ready\n1G9V,0,1\n",
+    "pdb_id,claim_ready\n1G9V,1,extra\n",
+    "pdb_id,claim_ready\n1G9V\n", "pdb_id,\n1G9V,1\n",
+    "pdb_id,target\n1G9V,1GM8\n", "claim_ready\n1\n",
+])
+def test_malformed_csv_rejected_cli(tmp_path, text):
+    path = tmp_path / "result.csv"
+    path.write_text(text)
+    result, report = _cli(path)
+    assert result.returncode == 2
+    assert report is None
 
 
-def test_missing_seed_columns_fail_closed(tmp_path: Path):
-    mod = _load()
-    r = _row("1AAA", rmsd_ordered=1.0, bcr=0.5, claim_ready=1, pb=1)
-    del r["seed_echo"]
-    del r["native_pose_seeded"]
-    camp = _write_campaign(tmp_path, [r])
-    path = camp / "1AAA" / "result.csv"
-    fields = [c for c in CSV_FIELDS if c not in ("seed_echo", "native_pose_seeded")]
-    row = {k: r.get(k, "") for k in fields}
-    with path.open("w", newline="") as fh:
-        w = csv.DictWriter(fh, fieldnames=fields)
-        w.writeheader()
-        w.writerow(row)
-    pin, _ = mod.load_matrix_pin(camp, None)
-    rep = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, "test", str(camp))
-    assert rep["N_claim"] == 0
+def test_stale_tree_cannot_override_summary(agg, tmp_path):
+    _write(tmp_path / "old" / "result.csv", [_row()])
+    _write(tmp_path / "summary.csv", [_row(claim_ready="0")])
+    with pytest.raises(ValueError, match="ambiguous campaign sources"):
+        agg.load_campaign_rows(tmp_path)
 
 
-def test_success_s1_flag_cannot_override_high_rmsd(tmp_path: Path):
-    mod = _load()
-    r = _row("1CCC", rmsd_ordered=5.0, bcr=5.0, claim_ready=1, pb=1)
-    r["success_s1"] = "1"
-    r["success_rmsd"] = "1"
-    camp = _write_campaign(tmp_path, [r])
-    path = camp / "1CCC" / "result.csv"
-    fields = CSV_FIELDS + ["success_s1"]
-    with path.open("w", newline="") as fh:
-        w = csv.DictWriter(fh, fieldnames=fields, extrasaction="ignore")
-        w.writeheader()
-        full = {k: r.get(k, "") for k in CSV_FIELDS}
-        full["success_s1"] = "1"
-        w.writerow(full)
-    pin, _ = mod.load_matrix_pin(camp, None)
-    rep = mod.aggregate_rows(mod.load_campaign_rows(camp), pin, "test", str(camp))
-    assert rep["N_claim"] == 1
-    assert rep["metrics"]["S1"]["n"] == 0
+def test_multiple_flat_summaries_require_explicit_selection(agg, tmp_path):
+    _write(tmp_path / "results.csv", [_row()])
+    _write(tmp_path / "summary.csv", [_row()])
+    with pytest.raises(ValueError, match="ambiguous"):
+        agg.load_campaign_rows(tmp_path)
 
 
-def test_off_manifest_strict_success_does_not_inflate_numerator():
-    """An off-manifest claim_ready row must not bump STRICT n (denom stays 85)."""
-    mod = _load()
-    codes, _ = mod.load_target_manifest()
-    assert codes and len(codes) == 85
-    on = _row(codes[0], rmsd_ordered=1.0, bcr=0.5, pb=1, claim_ready=1)
-    extra = _row("9XXX", rmsd_ordered=0.4, bcr=0.3, pb=1, claim_ready=1)
-    report = mod.aggregate_rows([on, extra], DEFAULT_PIN, "test", fixed_denominator=True)
+def test_per_target_file_cannot_discard_extra_rows(agg, tmp_path):
+    _write(tmp_path / "one" / "result.csv", [_row(), _row("1GM8")])
+    with pytest.raises(ValueError, match="exactly one"):
+        agg.load_campaign_rows(tmp_path)
+
+
+def test_manifest_integrity_and_fixed_denominator(agg):
+    codes, digest = agg.load_target_manifest()
+    assert len(codes) == 85
+    assert digest == hashlib.sha256(",".join(codes).encode()).hexdigest()
+    report = _aggregate(agg, [_row()])
     assert report["N_denominator"] == 85
+    assert report["N_missing_from_manifest"] == 84
+
+
+@pytest.mark.parametrize("mutation", ["digest", "duplicate", "count", "empty"])
+def test_corrupt_manifest_fails(agg, tmp_path, mutation):
+    codes, digest = agg.load_target_manifest()
+    data = dict(schema="flexaidds.astex.target_manifest/v1", N=85, targets=codes, sha256_of_sorted_codes=digest)
+    if mutation == "digest": data["sha256_of_sorted_codes"] = "0" * 64
+    if mutation == "duplicate": data["targets"][-1] = data["targets"][0]
+    if mutation == "count": data["N"] = 84
+    if mutation == "empty": data["targets"] = []
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(data))
+    with pytest.raises(ValueError):
+        agg.load_target_manifest(path)
+
+
+def test_missing_manifest_never_silently_shrinks_denominator(tmp_path):
+    script = tmp_path / "standalone" / "aggregate_claim_metrics.py"
+    script.parent.mkdir()
+    script.write_bytes(SCRIPT.read_bytes())
+    source = _write(tmp_path / "result.csv", [_row()])
+    result, report = _cli(source, script=script)
+    assert result.returncode == 2
+    assert report is None
+    assert "manifest missing" in result.stderr
+    result, report = _cli(source, "--legacy-observed-denominator", "--diagnostic-only", "--headline", "s1", script=script)
+    assert result.returncode == 0
+    assert report["headline"]["diagnostic_only"]
+    assert report["metrics"]["STRICT"]["rate"] is None
+    assert report["metrics"]["STRICT"]["n"] == 0
+
+
+def test_legacy_denominator_cannot_emit_strict_headline(tmp_path):
+    result, report = _cli(_write(tmp_path / "result.csv", [_row()]), "--legacy-observed-denominator", "--diagnostic-only")
+    assert result.returncode == 2
+    assert report is None
+
+
+def test_matrix_receipt_conflicts_are_errors(agg, tmp_path):
+    (tmp_path / "RUN_RECEIPT.json").write_text(json.dumps(dict(matrix_md5="0" * 32)))
+    with pytest.raises(ValueError, match="conflicting matrix pins"):
+        agg.load_matrix_pin(tmp_path, DEFAULT_PIN)
+
+
+@pytest.mark.parametrize("sha", ["", "abc", "c" * 64])
+def test_sidecar_requires_matching_valid_pose_hash(agg, sha):
+    row = _row()
+    sidecar = {"1G9V": dict(pdb_id="1G9V", rmsd_symmcorr="0.5", pose_sha256=sha)}
+    report = agg.join_symmcorr([row], sidecar)
+    assert report["joined"] == 0
+    assert report["refused_sha_mismatch"] == ["1G9V"]
+    assert "rmsd_symmcorr" not in row
+
+
+def test_sidecar_same_target_multiple_poses_joins_by_hash(agg, tmp_path):
+    second = hashlib.sha256(b"second elected pose").hexdigest()
+    side = [dict(pdb_id="1G9V", rmsd_symmcorr="0.5", pose_sha256=POSE, status="ok"),
+            dict(pdb_id="1G9V", rmsd_symmcorr="1.5", pose_sha256=second, status="ok")]
+    rows = [_row(), _row(pose_sha256=second, seed="2")]
+    report = agg.join_symmcorr(rows, agg.load_symmcorr_sidecar(_write(tmp_path / "side.csv", side)))
+    assert report["joined"] == 2
+    assert [r["rmsd_symmcorr"] for r in rows] == ["0.5", "1.5"]
+
+
+def test_sidecar_duplicate_identity_rejected(agg, tmp_path):
+    row = dict(pdb_id="1G9V", rmsd_symmcorr="0.5", pose_sha256=POSE, status="ok")
+    with pytest.raises(ValueError, match="duplicate sidecar"):
+        agg.load_symmcorr_sidecar(_write(tmp_path / "side.csv", [row, row]))
+
+
+def test_s3_primary_requires_diagnostic_flag(tmp_path):
+    source = _write(tmp_path / "result.csv", [_row()])
+    result, _ = _cli(source, "--headline", "s3")
+    assert result.returncode == 2
+    result, report = _cli(source, "--headline", "s3", "--diagnostic-only")
+    assert result.returncode == 0
+    assert report["headline"]["diagnostic_only"]
+
+
+def test_cloud_docs_requires_staging(agg):
+    with pytest.raises(ValueError, match="stage CloudDocs"):
+        agg.load_rows_from_csv(Path("/tmp/Mobile Documents/com~apple~CloudDocs/result.csv"))
+
+
+def test_seed_echo_explicit_zero_float_accepted(agg):
+    assert agg.is_strict_success(_row(seed_echo="0.0", native_pose_seeded="0.0"))
+
+
+def test_explicit_completed_runtime_receipt_accepted(agg):
+    assert agg.is_strict_success(_row(docking_completed="1", docking_exit_code="0", num_poses="2",
+                                      pb_ran="1", pb_n_checks="27", pb_n_fail="0", pb_n_pass="27",
+                                      eigen_n_modes="3", elected_H_vib="-1.5"))
+
+
+def test_cli_exit_uses_target_majority_not_individual_seed_success(tmp_path):
+    result, report = _cli(_write(tmp_path / "result.csv", [_row(seed="1")]), "--expected-seeds", "1,2,3")
+    assert report["N_claim"] == 1
+    assert report["metrics"]["STRICT"]["n"] == 0
+    assert result.returncode == 1
+
+
+
+def test_decimal_seed_aliases_cannot_manufacture_a_majority(agg):
+    with pytest.raises(ValueError, match="duplicate observation"):
+        _aggregate(agg, [_row(seed="1"), _row(seed="01")], expected_seeds=["1", "01", "2"])
+    with pytest.raises(ValueError, match="unique list"):
+        _aggregate(agg, [_row(seed="1")], expected_seeds=["1", "01", "2"])
+
+
+@pytest.mark.parametrize("seed", ["abc", "-1", "1e3", str(2**64)])
+def test_invalid_seed_domain_rejected(agg, seed):
+    with pytest.raises(ValueError, match="unsigned 64-bit"):
+        _aggregate(agg, [_row(seed=seed)])
+
+
+def test_valid_decimal_seed_alias_normalizes_identity(agg):
+    report = _aggregate(agg, [_row(seed="0001")], expected_seeds=["1"])
     assert report["metrics"]["STRICT"]["n"] == 1
-    assert report["headline"]["n"] == 1
-    ids = {str(x).upper() for x in report["metrics"]["STRICT"]["ids"]}
-    assert codes[0].upper() in ids
-    assert "9XXX" not in ids
+    assert report["aggregation"]["expected_seeds"] == ["1"]
 
 
-def test_seed_echo_0_0_accepted():
-    mod = _load()
-    row = {"seed_echo": "0.0", "native_pose_seeded": "0.0", "matrix_md5": ""}
-    assert mod._flag0(row, "seed_echo")
-    assert mod._flag0(row, "native_pose_seeded")
+
+def test_explicit_local_results_root_preserved(agg, monkeypatch, tmp_path):
+    monkeypatch.setenv("FLEXAIDDS_RESULTS", str(tmp_path / "chosen"))
+    monkeypatch.setenv("FLEXAIDDS_LOCAL_ROOT", str(tmp_path / "other"))
+    assert agg.resolve_c0_full85_dir() == tmp_path / "chosen" / agg.C0_FULL85_REL
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+@pytest.mark.parametrize("field", ["pb_ran", "pb_n_checks", "pb_n_pass", "pb_n_fail", "eigen_n_modes", "elected_H_vib"])
+def test_current_strict_requires_complete_pb_eigen_receipts(agg, field):
+    row = _row()
+    del row[field]
+    report = _aggregate(agg, [row])
+    assert report["metrics"]["STRICT"]["n"] == 0
+    assert report["metrics"]["S1"]["n"] == 1
+
+
+
+@pytest.mark.parametrize("changes", [dict(pb_ran="0"), dict(pb_n_checks="1"),
+                                    dict(pb_n_fail="1"), dict(pb_failed_keys="bond_lengths"),
+                                    dict(pb_backend="internal")])
+def test_s2_cannot_ignore_its_own_pb_contradictions(agg, changes):
+    report = _aggregate(agg, [_row(**changes)])
+    assert report["metrics"]["S1"]["n"] == 1
+    assert report["metrics"]["S2"]["n"] == 0

--- a/tests/test_atom_pointer_lifetimes.cpp
+++ b/tests/test_atom_pointer_lifetimes.cpp
@@ -1,0 +1,180 @@
+#include <gtest/gtest.h>
+
+#include "AtomOptResBinding.h"
+#include "rotamer_output.h"
+
+#include <array>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// A ligand and a flexible receptor have separate OptRes owners. The receptor
+// atoms are deliberately absent from the ligand's dirty refresh list.
+struct WorkspaceFixture {
+    std::vector<atom> atoms = std::vector<atom>(32);
+    std::array<OptRes, 2> optres{};
+
+    WorkspaceFixture() {
+        optres[0].type = 0;
+        optres[0].rnum = 1;
+        optres[1].type = 1;
+        optres[1].rnum = 2;
+        atoms[4].optres = &optres[0];
+        atoms[5].optres = &optres[0];
+        atoms[7].optres = &optres[0];
+        atoms[30].optres = &optres[1];
+        atoms[31].optres = &optres[1];
+    }
+};
+
+std::vector<std::array<double, 2>> exercise_workspaces(int threads, bool selective) {
+    WorkspaceFixture master;
+    const flexaids::AtomOptResBinding binding(master.atoms, master.optres);
+    constexpr int chromosomes = 24;
+    std::vector<std::array<double, 2>> written(chromosomes);
+    std::vector<std::thread> workers;
+    for (int tid = 0; tid < threads; ++tid) {
+        workers.emplace_back([&, tid] {
+            auto atoms = master.atoms;
+            auto optres = master.optres;
+            for (int chromosome = tid; chromosome < chromosomes; chromosome += threads) {
+                if (selective) {
+                    atoms[30] = master.atoms[30];
+                    atoms[31] = master.atoms[31];
+                } else {
+                    atoms = master.atoms;
+                }
+                // This is the production operation called after the atom reset.
+                // On the second chromosome the receptor pointers already refer
+                // to optres here, whereas the refreshed ligand pointers do not.
+                binding.bind(atoms, optres);
+                for (int ai : {4, 5, 7}) EXPECT_EQ(atoms[ai].optres, &optres[0]);
+                for (int ai : {30, 31}) EXPECT_EQ(atoms[ai].optres, &optres[1]);
+                EXPECT_EQ(atoms[10].optres, nullptr);
+                for (auto& entry : optres) entry.cf.com = 0.0;
+                // Write through the rebound atom pointers. These are arbitrary
+                // counters testing ownership, not simulated docking scores.
+                for (int ai : {4, 5, 7, 30, 31})
+                    atoms[ai].optres->cf.com += chromosome + 1;
+                written[chromosome] = {optres[0].cf.com, optres[1].cf.com};
+            }
+        });
+    }
+    for (auto& worker : workers) worker.join();
+    EXPECT_DOUBLE_EQ(master.optres[0].cf.com, 0.0);
+    EXPECT_DOUBLE_EQ(master.optres[1].cf.com, 0.0);
+    for (int chromosome = 0; chromosome < chromosomes; ++chromosome) {
+        EXPECT_DOUBLE_EQ(written[chromosome][0], 3 * (chromosome + 1));
+        EXPECT_DOUBLE_EQ(written[chromosome][1], 2 * (chromosome + 1));
+    }
+    return written;
+}
+
+std::string read_output(FILE* output) {
+    rewind(output);
+    std::string result;
+    char buffer[256];
+    while (fgets(buffer, sizeof(buffer), output)) result += buffer;
+    return result;
+}
+
+std::string render_rotamer(std::span<const atom> atoms, std::span<const resid> residues) {
+    std::unique_ptr<FILE, decltype(&fclose)> output(tmpfile(), &fclose);
+    if (!output) throw std::runtime_error("Could not open test output file");
+    const std::array<int, 1> built{2};
+    flexaids::write_rotamer_model(output.get(), atoms, residues, 1, built, 1);
+    return read_output(output.get());
+}
+
+}  // namespace
+
+TEST(AtomOptResBinding, SelectiveRefreshPreservesOwnershipAcrossRepeatedChromosomes) {
+    EXPECT_EQ(exercise_workspaces(1, true), exercise_workspaces(1, false));
+}
+
+TEST(AtomOptResBinding, IndependentWorkspacesAgreeAtOneAndFourThreads) {
+    const auto serial = exercise_workspaces(1, true);
+    EXPECT_EQ(exercise_workspaces(4, true), serial);
+    EXPECT_EQ(exercise_workspaces(4, true), serial);
+    EXPECT_EQ(exercise_workspaces(4, false), serial);
+}
+
+TEST(AtomOptResBinding, RejectsForeignOwnerWithoutSubtractingUnrelatedPointers) {
+    WorkspaceFixture master;
+    OptRes foreign{};
+    master.atoms[4].optres = &foreign;
+    EXPECT_THROW((flexaids::AtomOptResBinding(master.atoms, master.optres)), FlexAIDException);
+}
+
+TEST(AtomOptResBinding, EmptyOptResKeepsUnoptimizedAtomsNull) {
+    std::array<atom, 3> atoms{};
+    std::span<OptRes> empty;
+    flexaids::AtomOptResBinding binding(atoms, empty);
+    binding.bind(atoms, empty);
+    binding.bind(atoms, empty);
+    for (const auto& at : atoms) EXPECT_EQ(at.optres, nullptr);
+}
+
+TEST(AtomOptResBinding, RejectsChangedWorkspaceDimensionsBeforeWriting) {
+    WorkspaceFixture master;
+    flexaids::AtomOptResBinding binding(master.atoms, master.optres);
+    auto atoms = master.atoms;
+    std::array<OptRes, 1> short_optres{};
+    EXPECT_THROW(binding.bind(atoms, short_optres), FlexAIDException);
+    EXPECT_EQ(atoms[4].optres, &master.optres[0]);
+    atoms.pop_back();
+    EXPECT_THROW(binding.bind(atoms, master.optres), FlexAIDException);
+}
+
+TEST(RotamerOutput, AtomIndicesPreservePdbBytesAfterForcedRelocation) {
+    auto atoms = std::make_unique<atom[]>(3);
+    atoms[1].ofres = 1;
+    atoms[1].number = 7;
+    strcpy(atoms[1].name, " CB ");
+    atoms[1].coor[0] = 1.0f;
+    atoms[1].coor[1] = 2.0f;
+    atoms[1].coor[2] = 3.0f;
+    atoms[2].number = 8;
+    strcpy(atoms[2].name, " OG ");
+    atoms[2].coor[0] = 4.0f;
+    atoms[2].coor[1] = 5.0f;
+    atoms[2].coor[2] = 6.0f;
+    std::array<resid, 2> residues{};
+    strcpy(residues[1].name, "SER");
+    residues[1].chn = 'A';
+    residues[1].number = 10;
+    const std::string expected =
+        "MODEL        1\n"
+        "ATOM      7  CB  SER A  10       1.000   2.000   3.000\n"
+        "ATOM      8  OG  SER A  10       4.000   5.000   6.000\n"
+        "ENDMDL\n";
+    EXPECT_EQ(render_rotamer({atoms.get(), 3}, residues), expected);
+
+    // Allocate while the old storage is live to guarantee a different address;
+    // then copy and release it, as a relocating realloc does. No stale pointer
+    // is ever dereferenced. The production writer receives the current base.
+    auto grown = std::make_unique<atom[]>(503);
+    ASSERT_NE(grown.get(), atoms.get());
+    std::copy_n(atoms.get(), 3, grown.get());
+    atoms.reset();
+    EXPECT_EQ(render_rotamer({grown.get(), 503}, residues), expected);
+    grown[1].coor[0] = 9.0f;
+    EXPECT_NE(render_rotamer({grown.get(), 503}, residues), expected);
+}
+
+TEST(RotamerOutput, InvalidAtomIndicesFailBeforeAnyPdbIsWritten) {
+    std::unique_ptr<FILE, decltype(&fclose)> output(tmpfile(), &fclose);
+    ASSERT_NE(output, nullptr);
+    std::array<atom, 3> atoms{};
+    atoms[1].ofres = 1;
+    std::array<resid, 2> residues{};
+    const std::array<int, 1> outside{3};
+    EXPECT_THROW(flexaids::write_rotamer_model(output.get(), atoms, residues, 0, {}, 1),
+                 FlexAIDException);
+    EXPECT_THROW(flexaids::write_rotamer_model(output.get(), atoms, residues, 1, outside, 1),
+                 FlexAIDException);
+    EXPECT_EQ(read_output(output.get()), "");
+}

--- a/tests/test_dataset_runner.cpp
+++ b/tests/test_dataset_runner.cpp
@@ -30,6 +30,7 @@
 #include <filesystem>
 #include <fstream>
 #include <numeric>
+#include <map>
 #include <set>
 #include <sstream>
 #include <vector>
@@ -2313,3 +2314,95 @@ TEST(RestartThrottle, SlidingWindowBoundsLiveChildren) {
     EXPECT_EQ(guard.active_count(), 0u);
 }
 #endif  // !_MSC_VER
+
+
+TEST(ReportRuntime, CompletionIsIndependentOfScientificSuccess) {
+    BenchmarkReport report;
+    EXPECT_EQ(benchmark_runtime_exit_code(report), 2);
+    EXPECT_EQ(benchmark_runtime_exit_code(report, true), 0);
+    report.total_systems = 1;
+    DockingResult result;
+    result.pdb_id = "1G9V";
+    result.num_poses = 2;
+    result.rmsd_to_crystal = 9.0f;
+    result.docking_completed = true;
+    result.docking_exit_code = 0;
+    report.results = {result};
+    // An inaccurate, PB-failing completed search is a completed process.
+    EXPECT_FALSE(report.results[0].success);
+    EXPECT_FALSE(report.results[0].claim_ready);
+    EXPECT_EQ(benchmark_runtime_exit_code(report), 0);
+    report.results[0].docking_exit_code = 139;
+    EXPECT_EQ(benchmark_runtime_exit_code(report), 2);
+    report.results[0].docking_exit_code = 0;
+    report.results[0].num_poses = 0;
+    EXPECT_EQ(benchmark_runtime_exit_code(report), 2);
+    report.results[0] = result;
+    report.results[0].docking_completed = false;
+    EXPECT_EQ(benchmark_runtime_exit_code(report), 2);
+    report.results[0] = result;
+    report.results[0].stuck = true;
+    EXPECT_EQ(benchmark_runtime_exit_code(report), 2);
+    report.results[0] = result;
+    report.total_systems = 2;
+    EXPECT_EQ(benchmark_runtime_exit_code(report), 2);
+}
+
+TEST(ReportRmsd, MissingMeasurementsAreNotZero) {
+    const auto missing = summarize_rmsds({-1.0, std::numeric_limits<double>::quiet_NaN(),
+                                        std::numeric_limits<double>::infinity()});
+    EXPECT_EQ(missing.count, 0u);
+    EXPECT_TRUE(std::isnan(missing.mean));
+    EXPECT_TRUE(std::isnan(missing.median));
+    const auto measured = summarize_rmsds({-1.0, 0.0, 2.0, 4.0, 8.0});
+    EXPECT_EQ(measured.count, 4u);
+    EXPECT_DOUBLE_EQ(measured.mean, 3.5);
+    EXPECT_DOUBLE_EQ(measured.median, 3.0);
+}
+
+TEST(ReportGeneration, ZeroPoseReportPreservesMissingnessAndRuntime) {
+    BenchmarkReport report;
+    report.dataset_name = "Audit Missing";
+    report.total_systems = 1;
+    DockingResult result;
+    result.pdb_id = "1MQ6";
+    result.rmsd_fail_reason = "docking_incomplete";
+    result.docking_exit_code = 139;
+    report.results = {result};
+    const auto dir = fs::temp_directory_path() / "flexaidds_audit_missing_report";
+    fs::create_directories(dir);
+    DatasetRunner runner((dir / "cache").string());
+    runner.write_report(report, dir.string());
+    std::ifstream md(dir / "audit_missing_report.md");
+    const std::string text((std::istreambuf_iterator<char>(md)), {});
+    EXPECT_NE(text.find("| Valid elected ordered RMSDs | 0 |"), std::string::npos);
+    EXPECT_NE(text.find("| Mean elected ordered RMSD (Å) | NA |"), std::string::npos);
+    EXPECT_NE(text.find("| Median elected ordered RMSD (Å) | NA |"), std::string::npos);
+    std::ifstream summary(dir / "audit_missing_summary.csv");
+    std::string header, row;
+    std::getline(summary, header); std::getline(summary, row);
+    EXPECT_EQ(std::count(header.begin(), header.end(), ','), std::count(row.begin(), row.end(), ','));
+    std::stringstream hs(header), rs(row);
+    std::string key, value;
+    std::map<std::string, std::string> fields;
+    while (std::getline(hs, key, ',') && std::getline(rs, value, ',')) fields[key] = value;
+    EXPECT_EQ(fields["mean_rmsd"], "");
+    EXPECT_EQ(fields["median_rmsd"], "");
+    EXPECT_EQ(fields["valid_rmsd_count"], "0");
+    EXPECT_EQ(fields["completed_systems"], "0");
+    std::ifstream results(dir / "audit_missing_results.csv");
+    std::getline(results, header); std::getline(results, row);
+    EXPECT_NE(header.find("rmsd_fail_reason,docking_exit_code,docking_completed"), std::string::npos);
+    EXPECT_NE(row.find("docking_incomplete,139,0"), std::string::npos);
+    fs::remove_all(dir);
+}
+
+TEST(ReportRuntime, CachedExitCodesRetainRecordedFailures) {
+    EXPECT_EQ(docking_exit_code_or_unknown("0"), 0);
+    EXPECT_EQ(docking_exit_code_or_unknown("139"), 139);
+    EXPECT_EQ(docking_exit_code_or_unknown("6"), 6);
+    EXPECT_EQ(docking_exit_code_or_unknown("-1"), -1);
+    EXPECT_EQ(docking_exit_code_or_unknown(""), -1);
+    EXPECT_EQ(docking_exit_code_or_unknown("0garbage"), -1);
+    EXPECT_EQ(docking_exit_code_or_unknown("9999999999999999999999"), -1);
+}

--- a/tests/test_engine_repro_gate.py
+++ b/tests/test_engine_repro_gate.py
@@ -107,6 +107,9 @@ if os.environ.get('FLEXAIDDS_GEN0_RECEIPT') and MODE!='missing_gen0':
     if MODE=='incomplete_gen0': receipt['complete']=False
     Path(os.environ['FLEXAIDDS_GEN0_RECEIPT']).write_text(json.dumps(receipt))
 print('synthetic fake-executable run completed')
+if MODE=='log_vcf_diag': print('[VCF-DIAG] k=1 i=1 | skipped atom scoring')
+if MODE=='log_ownership_pointer': print('Caught: Atom OptRes pointer is not owned by the master OptRes array')
+if MODE=='log_ownership_size': print('Caught: Atom/OptRes workspace sizes changed after binding capture')
 if MODE=='exit_nonzero': sys.exit(7)
 '''
     path.write_text(code)
@@ -166,6 +169,110 @@ def test_same_binary_basename_has_distinct_runs_and_only_provenance_normalizes(s
     assert ma["source_build"]["source_commit"]
     assert len(ma["outputs"]["poses"]) == 10
     assert ma["environment"]["FLEXAID_SEED"] == "12345"
+    assert ma["environment"]["FLEXAIDDS_VCF_DIAG"] == "1"
+
+
+@pytest.mark.parametrize("mode", ["log_vcf_diag", "log_ownership_pointer", "log_ownership_size"])
+def test_complete_artifacts_and_exit_zero_cannot_override_scoring_failure_log(setup, mode):
+    result, manifest, out = run_one(setup, "bad_log", mode=mode)
+    assert manifest["exit_code"] == 0
+    assert len(gate.inspect_outputs(out, True)["poses"]) == 10
+    assert result.returncode == 1
+    assert "skipped scoring or an ownership invariant failure" in manifest["errors"][0]
+    assert manifest["log"]["sha256"] == gate.sha256(out / "run.log")
+
+
+@pytest.mark.parametrize("marker", gate.SCORING_FAILURE_MARKERS)
+def test_saved_run_rescans_scoring_failure_log_even_with_matching_log_receipt(setup, marker):
+    _, _, left = run_one(setup, "left")
+    _, manifest, right = run_one(setup, "right")
+    log = right / "run.log"
+    with log.open("ab") as handle:
+        handle.write(b"prefix " + marker + b" suffix\n")
+    # Represents a receipt from an older producer that admitted diagnostic logs.
+    manifest["log"] = gate.pin_run_log(log)
+    (right / "run_manifest.json").write_text(json.dumps(manifest))
+    result, report = compare(setup, [left, right])
+    assert result.returncode == 1
+    assert "skipped scoring or an ownership invariant failure" in report["errors"][0]
+
+
+@pytest.mark.parametrize("change", ["append", "truncate", "remove", "symlink"])
+def test_saved_run_log_must_remain_present_and_match_original_receipt(setup, change):
+    _, _, left = run_one(setup, "left")
+    _, _, right = run_one(setup, "right")
+    log = right / "run.log"
+    if change == "append":
+        with log.open("ab") as handle: handle.write(b"new output\n")
+    elif change == "truncate":
+        log.write_bytes(b"")
+    else:
+        log.unlink()
+        if change == "symlink": log.symlink_to(left / "run.log")
+    result, report = compare(setup, [left, right])
+    assert result.returncode == 1
+    assert "run.log" in report["errors"][0]
+
+
+@pytest.mark.parametrize("value", ["0", "false", "", "1"])
+def test_vcf_diagnostic_environment_cannot_be_overridden(setup, value):
+    result, manifest, _ = run_one(setup, "override_diag", extra=("--env", "FLEXAIDDS_VCF_DIAG=" + value))
+    assert result.returncode == 1
+    assert "protected" in manifest["errors"][0]
+
+
+@pytest.mark.parametrize("entry", ["FLEXAIDDS_ORACLE_SITE=1", "FLEXAIDDS_SCORE_NATIVE=1",
+                                 "FLEXAIDDS_GRID_CACHE_DIR=/tmp/old_grid", "FLEXAIDDS_EVAL_SCALE_DIHEDRAL=1",
+                                 "FLEXAID_UNSUPPORTED_CONTROL=1"])
+def test_explicit_scientific_overrides_fail_before_execution_without_changing_inputs(setup, entry):
+    inputs = [setup[name] for name in ("config", "receptor", "ligand")]
+    inputs.append(setup["data"] / "MC_st0r5.2_6.dat")
+    before = {path: path.read_bytes() for path in inputs}
+    result, manifest, out = run_one(setup, "science_override", extra=("--env", entry))
+    assert result.returncode == 1
+    assert "protected" in manifest["errors"][0]
+    assert not (out / "run.log").exists()
+    assert {path: path.read_bytes() for path in inputs} == before
+
+
+@pytest.mark.parametrize("entry", ["FLEXAIDDS_ORACLE_SITE", "FLEXAIDDS_SCORE_NATIVE",
+                                 "FLEXAIDDS_GRID_CACHE_DIR", "FLEXAIDDS_EVAL_SCALE_DIHEDRAL",
+                                 "FLEXAID_UNSUPPORTED_CONTROL"])
+def test_saved_run_cannot_admit_unsupported_scientific_environment(setup, entry):
+    _, _, left = run_one(setup, "left")
+    _, manifest, right = run_one(setup, "right")
+    manifest["environment"][entry] = "1"
+    (right / "run_manifest.json").write_text(json.dumps(manifest))
+    result, report = compare(setup, [left, right])
+    assert result.returncode == 1
+    assert "unsupported scientific environment" in report["errors"][0]
+
+
+def test_explicit_nonscientific_environment_is_retained(setup):
+    result, manifest, _ = run_one(setup, "nonscience_env", extra=("--env", "TEST_RECEIPT_NOTE=fixture"))
+    assert result.returncode == 0
+    assert manifest["environment"]["TEST_RECEIPT_NOTE"] == "fixture"
+
+
+@pytest.mark.parametrize("value", [None, "0", "false"])
+def test_saved_run_with_missing_or_disabled_vcf_guard_is_rejected(setup, value):
+    _, _, left = run_one(setup, "left")
+    _, manifest, right = run_one(setup, "right")
+    if value is None:
+        manifest["environment"].pop("FLEXAIDDS_VCF_DIAG")
+    else:
+        manifest["environment"]["FLEXAIDDS_VCF_DIAG"] = value
+    (right / "run_manifest.json").write_text(json.dumps(manifest))
+    result, report = compare(setup, [left, right])
+    assert result.returncode == 1
+    assert "diagnostic guard must be explicitly enabled" in report["errors"][0]
+
+
+def test_log_marker_across_read_boundary_is_rejected(tmp_path):
+    path = tmp_path / "run.log"
+    path.write_bytes(b"x" * (1024 * 1024 - 3) + b"[VCF-DIAG] boundary\n")
+    with pytest.raises(gate.GateError, match="VCF-DIAG"):
+        gate.validate_run_log(path)
 
 
 @pytest.mark.parametrize("mode", ["missing_rank", "extra_rank", "no_artifacts", "nan_cf", "no_cf", "no_atoms",
@@ -343,10 +450,12 @@ def test_gen0_duplicate_multiplicity_is_preserved(tmp_path):
 def test_inherited_science_environment_is_cleared(setup, monkeypatch):
     monkeypatch.setenv("FLEXAIDDS_ORACLE_SITE", "unintended")
     monkeypatch.setenv("FLEXAID_SEED", "98765")
+    monkeypatch.setenv("FLEXAIDDS_VCF_DIAG", "0")
     result, manifest, _ = run_one(setup, "clean_env")
     assert result.returncode == 0
     assert "FLEXAIDDS_ORACLE_SITE" not in manifest["environment"]
     assert manifest["environment"]["FLEXAID_SEED"] == "12345"
+    assert manifest["environment"]["FLEXAIDDS_VCF_DIAG"] == "1"
 
 
 def test_protected_environment_cannot_override_seed(setup):

--- a/tests/test_engine_repro_gate.py
+++ b/tests/test_engine_repro_gate.py
@@ -1,0 +1,425 @@
+"""Synthetic executable/artifact tests; these never invoke FlexAIDdS."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "ops/engine_repro_gate.py"
+WRAPPER = ROOT / "ops/gate_parity.sh"
+spec = importlib.util.spec_from_file_location("engine_repro_gate", SCRIPT)
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+
+def bits(value):
+    return "0x" + struct.pack(">d", value).hex()
+
+
+def execution(threads=1):
+    return dict(openmp_compiled=True, deterministic_compile=False,
+                evaluation_batches=[dict(region="populate_chromosomes", population_count=1000,
+                                         popoffset=0, workspace_slots=threads,
+                                         workers=[dict(worker_id=i, team_size=threads,
+                                                       evaluated_chromosomes=1000 // threads)
+                                                  for i in range(threads)])])
+
+
+def gen0(count=1000, threads=1):
+    records = []
+    for index in range(count):
+        record = dict(index=index, status=110, genes=[dict(to_int32=index, to_ic_bits=bits(float(index)))],
+                      cf={key: bits(0.0) for key in gate.CF_FIELDS - {"rclash"}},
+                      ring_phases_bits=["0x00000000"] * 16, ring_six=[0] * 16, ring_five=[0] * 16)
+        record["cf"].update(rclash=0, com_bits=bits(-float(index + 1)))
+        for key in ("evalue_bits", "app_evalue_bits", "fitnes_bits", "boltzmann_weight_bits", "free_energy_bits"):
+            record[key] = bits(float(index))
+        records.append(record)
+    return dict(schema=gate.GEN0_SCHEMA, boundary="initial_population_complete_before_reproduction", generation=0,
+                population_count=count, n_genes=1, seed="12345", execution=execution(threads), records=records, complete=True)
+
+
+def fake_engine(path, mode="normal", commit="a" * 40, dirty="0"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    code = f'''#!{sys.executable}
+import copy,json,os,struct,sys,time
+from pathlib import Path
+MODE={mode!r}
+COMMIT={commit!r}
+DIRTY={dirty!r}
+receipt={gen0(1)!r}
+template=receipt['records'][0]
+receipt['records']=[]
+receipt['population_count']=1000
+for index in range(1000):
+    record=copy.deepcopy(template)
+    record['index']=index
+    record['genes'][0]={{'to_int32':index,'to_ic_bits':'0x'+struct.pack('>d',float(index)).hex()}}
+    record['cf']['com_bits']='0x'+struct.pack('>d',-float(index+1)).hex()
+    for key in ['evalue_bits','app_evalue_bits','fitnes_bits','boltzmann_weight_bits','free_energy_bits']:
+        record[key]='0x'+struct.pack('>d',float(index)).hex()
+    receipt['records'].append(record)
+args=sys.argv[1:]
+prefix=Path(args[args.index('-o')+1])
+if MODE=='timeout':
+    time.sleep(30)
+if MODE=='no_artifacts':
+    print('no output');sys.exit(0)
+for rank in range(11 if MODE=='extra_rank' else (9 if MODE=='missing_rank' else 10)):
+    seed='12346' if MODE=='wrong_seed' else '12345'
+    score='nan' if MODE=='nan_cf' else '-1.00000'
+    x=2.0 if MODE=='different_coordinate' else 1.0
+    atom=f"HETATM    1  C1  LIG A 900    {{x:8.3f}}{{2.0:8.3f}}{{3.0:8.3f}}  1.00  0.00           C\\n"
+    body=f"REMARK FLEXAID.commit={{COMMIT}} FLEXAID.dirty={{DIRTY}} FLEXAID.seed={{seed}}\\nREMARK CF={{score}}\\nREMARK CF.com=-1.00000\\n"
+    if MODE=='science_remark': body+='REMARK temperature=299\\n'
+    body+=atom+'END\\n'
+    if MODE=='no_end': body=body.replace('END\\n','')
+    if MODE=='no_cf': body=body.replace(f'REMARK CF={{score}}\\n','')
+    if MODE=='no_atoms': body='\\n'.join(line for line in body.splitlines() if not line.startswith('HETATM'))+'\\n'
+    if MODE=='unrecognized_provenance': body=body.replace('FLEXAID.dirty=', 'OTHER.dirty=')
+    Path(str(prefix)+f'_{{rank}}.pdb').write_text(body)
+if MODE!='missing_grid':
+    grid=struct.pack('<IIi',0x56435400,1,2)+struct.pack('<ii6f',0,10,1,2,3,4,5,6)+struct.pack('<ii6f',1,11,7,8,9,10,11,12)
+    if MODE=='reordered_grid': grid=grid[:12]+grid[44:]+grid[12:44]
+    if MODE=='truncated_grid': grid=grid[:-1]
+    Path(str(prefix)+'.rrg').write_bytes(grid)
+if os.environ.get('FLEXAIDDS_GEN0_RECEIPT') and MODE!='missing_gen0':
+    threads=int(os.environ['OMP_NUM_THREADS'])
+    receipt['execution']['evaluation_batches'][0]['workspace_slots']=threads
+    receipt['execution']['evaluation_batches'][0]['workers']=[{{'worker_id':i,'team_size':threads,'evaluated_chromosomes':1000//threads}} for i in range(threads)]
+    if MODE=='serialized_team':
+        receipt['execution']['evaluation_batches'][0]['workers']=[{{'worker_id':0,'team_size':1,'evaluated_chromosomes':1000}}]
+    if os.environ.get('OMP_NUM_THREADS')=='4':
+        receipt['records'].reverse()
+        for i,record in enumerate(receipt['records']): record['index']=i
+    if MODE=='mismatched_gene_pair' and os.environ.get('OMP_NUM_THREADS')=='4':
+        genes=[record['genes'] for record in receipt['records']]
+        receipt['records'][0]['genes'],receipt['records'][1]['genes']=genes[1],genes[0]
+    if MODE=='incomplete_gen0': receipt['complete']=False
+    Path(os.environ['FLEXAIDDS_GEN0_RECEIPT']).write_text(json.dumps(receipt))
+print('synthetic fake-executable run completed')
+if MODE=='exit_nonzero': sys.exit(7)
+'''
+    path.write_text(code)
+    path.chmod(0o755)
+    return path
+
+
+@pytest.fixture
+def setup(tmp_path):
+    config = tmp_path / "parity.json"
+    config.write_text(json.dumps(dict(ga=dict(num_chromosomes=1000, num_generations=2000),
+                                     reference_ligand=dict(pose_seed_enabled=False, seed_fraction=0))))
+    receptor = tmp_path / "receptor.pdb"; receptor.write_text("synthetic receptor fixture\n")
+    ligand = tmp_path / "ligand.sdf"; ligand.write_text("synthetic ligand fixture\n")
+    data = tmp_path / "data"; data.mkdir(); (data / "MC_st0r5.2_6.dat").write_text("synthetic matrix fixture\n")
+    build = tmp_path / "build"; build.mkdir()
+    (build / "CMakeCache.txt").write_text(f"CMAKE_HOME_DIRECTORY:INTERNAL={ROOT}\nCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/c++\nFLEXAIDS_USE_OPENMP:BOOL=ON\n")
+    (build / "Makefile").write_text("# synthetic generated build metadata\n")
+    (build / "CMakeFiles/FlexAIDdS.dir").mkdir(parents=True)
+    (build / "CMakeFiles/FlexAIDdS.dir/flags.make").write_text("CXX_FLAGS = -O2 -fopenmp\n")
+    return dict(root=tmp_path, config=config, receptor=receptor, ligand=ligand, data=data, build=build)
+
+
+def run_one(setup, label, engine=None, mode="normal", omp=1, reproduce="off", observer=True, timeout=10, extra=()):
+    engine = engine or fake_engine(setup["root"] / label / "FlexAIDdS", mode)
+    out = setup["root"] / "runs" / label
+    args = [sys.executable, "-B", str(SCRIPT), "run-one", "--label", label, "--engine", str(engine),
+            "--source-dir", str(ROOT), "--build-dir", str(setup["build"]),
+            "--receptor", str(setup["receptor"]), "--ligand", str(setup["ligand"]),
+            "--config", str(setup["config"]), "--data-dir", str(setup["data"]), "--out", str(out),
+            "--omp-threads", str(omp), "--parallel-reproduce", reproduce, "--timeout", str(timeout), *extra]
+    args.append("--require-gen0" if observer else "--observer-off-transparency")
+    result = subprocess.run(args, capture_output=True, text=True, timeout=20)
+    manifest = json.loads((out / "run_manifest.json").read_text()) if (out / "run_manifest.json").is_file() else None
+    return result, manifest, out
+
+
+def compare(setup, runs, kind="parity"):
+    report = setup["root"] / "comparison.json"
+    result = subprocess.run([sys.executable, "-B", str(SCRIPT), "compare", "--kind", kind,
+                             "--runs", *map(str, runs), "--json", str(report)], capture_output=True, text=True, timeout=20)
+    return result, json.loads(report.read_text())
+
+
+def test_same_binary_basename_has_distinct_runs_and_only_provenance_normalizes(setup):
+    a = fake_engine(setup["root"] / "base/FlexAIDdS", commit="a" * 40)
+    b = fake_engine(setup["root"] / "candidate/FlexAIDdS", commit="b" * 40, dirty="1")
+    ra, ma, pa = run_one(setup, "P0", a)
+    rb, mb, pb = run_one(setup, "P1", b)
+    assert ra.returncode == rb.returncode == 0, (ra.stdout, rb.stdout)
+    result, report = compare(setup, [pa, pb])
+    assert result.returncode == 0, report
+    assert report["pass"]
+    assert not report["raw_pose_bytes_identical"]
+    assert report["generation_zero"] == "pass"
+    assert ma["inputs"]["engine"]["sha256"] != mb["inputs"]["engine"]["sha256"]
+    assert ma["source_build"]["source_commit"]
+    assert len(ma["outputs"]["poses"]) == 10
+    assert ma["environment"]["FLEXAID_SEED"] == "12345"
+
+
+@pytest.mark.parametrize("mode", ["missing_rank", "extra_rank", "no_artifacts", "nan_cf", "no_cf", "no_atoms",
+                                  "wrong_seed", "unrecognized_provenance", "missing_grid", "truncated_grid", "exit_nonzero", "no_end"])
+def test_incomplete_or_failed_fake_engine_never_passes(setup, mode):
+    result, manifest, out = run_one(setup, "bad", mode=mode)
+    assert result.returncode == 1
+    assert manifest["status"] == "failed"
+    assert manifest["errors"]
+    if mode == "exit_nonzero":
+        assert manifest["exit_code"] == 7
+        assert len(manifest["observed_artifacts"]) >= 11
+
+
+def test_reused_output_directory_is_refused_without_overwrite(setup):
+    result, manifest, out = run_one(setup, "one")
+    assert result.returncode == 0
+    before = (out / "run_manifest.json").read_bytes()
+    result, _, _ = run_one(setup, "one")
+    assert result.returncode == 2
+    assert (out / "run_manifest.json").read_bytes() == before
+
+
+def test_timeout_is_failure_with_exit_receipt(setup):
+    result, manifest, _ = run_one(setup, "timeout", mode="timeout", timeout=0.1)
+    assert result.returncode == 1
+    assert manifest["timed_out"]
+    assert manifest["exit_code"] < 0
+
+
+@pytest.mark.parametrize("mode", ["different_coordinate", "science_remark", "reordered_grid"])
+def test_scientific_payload_and_grid_order_differences_fail(setup, mode):
+    _, _, left = run_one(setup, "left")
+    _, _, right = run_one(setup, "right", mode=mode)
+    result, report = compare(setup, [left, right])
+    assert result.returncode == 1
+    assert not report["pass"]
+
+
+def test_changed_input_after_run_is_refused(setup):
+    _, _, left = run_one(setup, "left")
+    _, _, right = run_one(setup, "right")
+    setup["ligand"].write_text("changed ligand\n")
+    result, report = compare(setup, [left, right])
+    assert result.returncode == 1
+    assert "input changed" in report["errors"][0]
+
+
+def test_artifact_changed_after_manifest_is_refused(setup):
+    _, _, left = run_one(setup, "left")
+    _, _, right = run_one(setup, "right")
+    artifact = right / "d_0.pdb"
+    artifact.write_bytes(artifact.read_bytes().replace(b"END\n", b"REMARK changed\nEND\n"))
+    result, report = compare(setup, [left, right])
+    assert result.returncode == 1
+    assert "artifacts changed" in report["errors"][0]
+
+
+def test_cannot_compare_run_with_itself(setup):
+    _, _, out = run_one(setup, "same")
+    result, report = compare(setup, [out, out])
+    assert result.returncode == 1
+    assert "itself" in report["errors"][0]
+
+
+@pytest.mark.parametrize("mode", ["missing_gen0", "incomplete_gen0"])
+def test_missing_or_incomplete_requested_gen0_never_passes(setup, mode):
+    result, manifest, _ = run_one(setup, "bad", mode=mode, observer=True, reproduce="on")
+    assert result.returncode == 1
+    assert manifest["status"] == "failed"
+
+
+def test_full_four_run_matrix_compares_paired_record_multisets(setup):
+    engine = fake_engine(setup["root"] / "candidate/FlexAIDdS")
+    paths = []
+    for label, omp in (("T1a", 1), ("T1b", 1), ("T4a", 4), ("T4b", 4)):
+        result, manifest, path = run_one(setup, label, engine, omp=omp, reproduce="on", observer=True)
+        assert result.returncode == 0, manifest["errors"]
+        paths.append(path)
+    result, report = compare(setup, paths, "determinism")
+    assert result.returncode == 0, report
+    assert report["generation_zero"] == "pass"
+    assert gate.sha256(paths[0] / "gen0.json") != gate.sha256(paths[2] / "gen0.json")
+    assert report["runs"][2]["outputs"]["gen0"]["execution"]["observed_threads"] == 4
+
+
+def test_requested_four_threads_cannot_pass_with_a_serialized_actual_team(setup):
+    result, manifest, _ = run_one(setup, "serialized", mode="serialized_team", omp=4, reproduce="on")
+    assert result.returncode == 1
+    assert "every requested OpenMP worker" in manifest["errors"][0]
+
+
+@pytest.mark.parametrize("mutator", [
+    lambda e: e.update(openmp_compiled=False),
+    lambda e: e.update(deterministic_compile=True),
+    lambda e: e.update(evaluation_batches=[]),
+    lambda e: e["evaluation_batches"][0].update(region="calculate_fitness"),
+    lambda e: e["evaluation_batches"][0].update(popoffset=1),
+    lambda e: e["evaluation_batches"][0].update(population_count=999),
+    lambda e: e["evaluation_batches"][0].update(workspace_slots=3),
+    lambda e: e["evaluation_batches"][0]["workers"][0].update(evaluated_chromosomes=249),
+    lambda e: e["evaluation_batches"][0]["workers"][0].update(evaluated_chromosomes=0),
+    lambda e: e["evaluation_batches"][0]["workers"][0].update(worker_id=1),
+    lambda e: e["evaluation_batches"][0]["workers"][0].update(team_size=1),
+    lambda e: e["evaluation_batches"][0]["workers"][0].update(extra="unknown"),
+])
+def test_incomplete_or_contradictory_worker_evidence_fails(mutator):
+    value = execution(4)
+    mutator(value)
+    with pytest.raises(gate.GateError):
+        gate.validate_execution(value, 4)
+
+
+def test_worker_scheduling_distribution_does_not_change_scientific_hash(tmp_path):
+    first, second = gen0(threads=4), gen0(threads=4)
+    workers = second["execution"]["evaluation_batches"][0]["workers"]
+    workers[0]["evaluated_chromosomes"] = 249
+    workers[1]["evaluated_chromosomes"] = 251
+    a, b = tmp_path / "a.json", tmp_path / "b.json"
+    a.write_text(json.dumps(first)); b.write_text(json.dumps(second))
+    left, right = gate.validate_gen0(a, 4), gate.validate_gen0(b, 4)
+    assert left["execution"] != right["execution"]
+    assert left["order_independent_records_sha256"] == right["order_independent_records_sha256"]
+
+
+def test_gene_component_repairing_cannot_hide_behind_equal_component_sets(setup):
+    engine = fake_engine(setup["root"] / "candidate/FlexAIDdS", mode="mismatched_gene_pair")
+    paths = []
+    for label, omp in (("T1a", 1), ("T1b", 1), ("T4a", 4), ("T4b", 4)):
+        result, _, path = run_one(setup, label, engine, omp=omp, reproduce="on", observer=True)
+        assert result.returncode == 0
+        paths.append(path)
+    result, report = compare(setup, paths, "determinism")
+    assert result.returncode == 1
+    assert "gene/component" in report["errors"][0]
+
+
+def test_determinism_without_gen0_is_not_a_pass(setup):
+    engine = fake_engine(setup["root"] / "candidate/FlexAIDdS")
+    paths = []
+    for label, omp in (("T1a", 1), ("T1b", 1), ("T4a", 4), ("T4b", 4)):
+        _, _, path = run_one(setup, label, engine, omp=omp, reproduce="on", observer=False)
+        paths.append(path)
+    result, report = compare(setup, paths, "determinism")
+    assert result.returncode == 1
+    assert "generation-zero evidence required" in report["errors"][0]
+
+
+@pytest.mark.parametrize("mutator", [
+    lambda r: r.update(complete=False),
+    lambda r: r.update(population_count=3),
+    lambda r: (r.update(population_count=999), r["records"].pop()),
+    lambda r: r["records"][0].update(status=111),
+    lambda r: r["records"][0].update(unexpected="field"),
+    lambda r: r["records"][1].update(index=0),
+    lambda r: r["records"][0]["genes"][0].update(to_ic_bits="0x7ff0000000000000"),
+    lambda r: r["records"][0]["cf"].pop("wal_bits"),
+    lambda r: r["records"][0].update(ring_phases_bits=[]),
+])
+def test_gen0_schema_and_nonfinite_failures(tmp_path, mutator):
+    value = gen0(); mutator(value)
+    path = tmp_path / "gen0.json"; path.write_text(json.dumps(value))
+    with pytest.raises(gate.GateError): gate.validate_gen0(path)
+
+
+def test_gen0_duplicate_multiplicity_is_preserved(tmp_path):
+    first = gen0()
+    second = copy.deepcopy(first)
+    second["records"][1] = copy.deepcopy(second["records"][0]); second["records"][1]["index"] = 1
+    a = tmp_path / "a.json"; a.write_text(json.dumps(first))
+    b = tmp_path / "b.json"; b.write_text(json.dumps(second))
+    assert gate.validate_gen0(a)["order_independent_records_sha256"] != gate.validate_gen0(b)["order_independent_records_sha256"]
+
+
+def test_inherited_science_environment_is_cleared(setup, monkeypatch):
+    monkeypatch.setenv("FLEXAIDDS_ORACLE_SITE", "unintended")
+    monkeypatch.setenv("FLEXAID_SEED", "98765")
+    result, manifest, _ = run_one(setup, "clean_env")
+    assert result.returncode == 0
+    assert "FLEXAIDDS_ORACLE_SITE" not in manifest["environment"]
+    assert manifest["environment"]["FLEXAID_SEED"] == "12345"
+
+
+def test_protected_environment_cannot_override_seed(setup):
+    result, manifest, _ = run_one(setup, "override", extra=("--env", "FLEXAID_SEED=2"))
+    assert result.returncode == 1
+    assert "protected" in manifest["errors"][0]
+
+
+def test_config_cannot_reuse_grid_or_seed_pose(setup):
+    data = json.loads(setup["config"].read_text()); data["grid_file"] = "old.rrg"
+    setup["config"].write_text(json.dumps(data))
+    result, manifest, _ = run_one(setup, "cached")
+    assert result.returncode == 1
+    assert "reuse" in manifest["errors"][0]
+
+
+def test_build_metadata_must_match_declared_source(setup):
+    (setup["build"] / "CMakeCache.txt").write_text("CMAKE_HOME_DIRECTORY:INTERNAL=/different/source\n")
+    result, manifest, _ = run_one(setup, "wrong_build")
+    assert result.returncode == 1
+    assert "source directory" in manifest["errors"][0]
+
+
+def test_wrapper_returns_nonzero_for_failed_engine_and_uses_distinct_names(setup):
+    a = fake_engine(setup["root"] / "base/FlexAIDdS")
+    b = fake_engine(setup["root"] / "candidate/FlexAIDdS", mode="exit_nonzero")
+    out = setup["root"] / "wrapper"
+    args = ["bash", str(WRAPPER), str(a), str(b), "--baseline-source", str(ROOT), "--candidate-source", str(ROOT),
+            "--baseline-build", str(setup["build"]), "--candidate-build", str(setup["build"]),
+            "--receptor", str(setup["receptor"]), "--ligand", str(setup["ligand"]),
+            "--config", str(setup["config"]), "--data-dir", str(setup["data"]), "--out", str(out)]
+    result = subprocess.run(args, env=dict(os.environ, PYTHON=sys.executable), capture_output=True, text=True, timeout=20)
+    assert result.returncode != 0
+    assert (out / "P0/run_manifest.json").is_file()
+    assert (out / "P1/run_manifest.json").is_file()
+    assert not (out / "parity.json").exists()
+
+
+
+@pytest.mark.parametrize("timeout", ["nan", "inf", "0", "-1"])
+def test_invalid_timeout_rejected_before_start(setup, timeout):
+    result, manifest, out = run_one(setup, "bad_timeout", timeout=timeout)
+    assert result.returncode == 1
+    assert "finite and positive" in manifest["errors"][0]
+    assert not (out / "run.log").exists()
+
+
+def test_missing_cmake_source_is_not_current_directory_by_default(setup):
+    (setup["build"] / "CMakeCache.txt").write_text("CMAKE_BUILD_TYPE:STRING=Release\n")
+    result, manifest, _ = run_one(setup, "bad_cache")
+    assert result.returncode == 1
+    assert "source directory" in manifest["errors"][0]
+
+
+
+@pytest.mark.parametrize("key", ["OMP_THREAD_LIMIT=1", "FLEXAID_DETERMINISTIC=1", "KMP_HW_SUBSET=1c",
+                               "FLEXAIDDS_VORONOI_KEYED_JITTER=1"])
+def test_parallel_disabling_overrides_are_rejected(setup, key):
+    result, manifest, _ = run_one(setup, "disabled", extra=("--env", key))
+    assert result.returncode == 1
+    assert "protected" in manifest["errors"][0]
+
+
+@pytest.mark.parametrize("flags", ["CXX_FLAGS = -O2\n", "CXX_FLAGS = -fopenmp -DFLEXAID_DETERMINISTIC=1\n"])
+def test_serial_or_compile_time_deterministic_builds_are_rejected(setup, flags):
+    (setup["build"] / "CMakeFiles/FlexAIDdS.dir/flags.make").write_text(flags)
+    result, manifest, _ = run_one(setup, "serial_build")
+    assert result.returncode == 1
+    assert "compile flags" in manifest["errors"][0]
+
+
+def test_overflowed_json_number_is_not_a_finite_receipt_field(tmp_path):
+    path = tmp_path / "overflow.json"
+    path.write_text('{"number":1e999}')
+    with pytest.raises(gate.GateError, match="nonfinite JSON"):
+        gate.json_read(path)

--- a/tests/test_fleet_runner.cpp
+++ b/tests/test_fleet_runner.cpp
@@ -34,6 +34,8 @@ dataset::DockingResult successful_result() {
     dataset::DockingResult result;
     result.pdb_id = "1GPK";
     result.num_poses = 20;
+    result.docking_completed = true;
+    result.docking_exit_code = 0;
     result.elected_pose_path = "1GPK/elected_pose.pdb";
     result.elected_pose_source = "r2/1GPK_0.pdb";
     result.rmsd_hungarian = 1.25f;
@@ -64,6 +66,8 @@ TEST(FleetRunner, SeparatesExecutionFromScientificSuccess) {
     dataset::DockingResult miss;
     miss.pdb_id = "1HNN";
     miss.num_poses = 20;
+    miss.docking_completed = true;
+    miss.docking_exit_code = 0;
     miss.elected_pose_path = "1HNN/elected_pose.pdb";
     miss.rmsd_hungarian = 8.0f;
     miss.pb_ran = true;
@@ -121,4 +125,45 @@ TEST(FleetRunner, RefusesToOverwritePublishedResult) {
                          std::istreambuf_iterator<char>());
     EXPECT_EQ(contents, "{\"attempt\":1}\n");
     fs::remove_all(root);
+}
+
+TEST(FleetRunner, RetainedPoseDoesNotHideChildFailure) {
+    dataset::BenchmarkReport report;
+    report.total_systems = 1;
+    auto result = successful_result();
+    result.docking_exit_code = 6;
+    result.docking_completed = false;
+    result.claim_ready = false;
+    result.matrix_md5 = std::string(32, 'a');
+    report.results = {result};
+    dataset::DockingConfig config;
+    const auto json = fleet::FleetRunner::serialize_chunk_result(metadata(), report, config, 0.5);
+    EXPECT_NE(json.find("\"execution_completed\": 0"), std::string::npos);
+    EXPECT_NE(json.find("\"execution_failed\": 1"), std::string::npos);
+    EXPECT_NE(json.find("\"docking_exit_code\": 6"), std::string::npos);
+    EXPECT_NE(json.find("\"matrix_md5\": \"" + std::string(32, 'a') + "\""), std::string::npos);
+}
+
+TEST(FleetRunner, CompletedDockWithoutReferenceIsStillRuntimeCompleted) {
+    dataset::BenchmarkReport report;
+    report.total_systems = 1;
+    dataset::DockingResult result;
+    result.pdb_id = "1GPK";
+    result.num_poses = 20;
+    result.docking_completed = true;
+    result.docking_exit_code = 0;
+    // DatasetRunner cannot elect/measure against an unavailable RMSD reference,
+    // but that does not undo the witnessed child exit and its produced poses.
+    result.rmsd_fail_reason = "input_missing";
+    EXPECT_TRUE(result.elected_pose_path.empty());
+    EXPECT_FALSE(result.claim_ready);
+    report.results = {result};
+    EXPECT_EQ(dataset::benchmark_runtime_exit_code(report), 0);
+    dataset::DockingConfig config;
+    const auto json = fleet::FleetRunner::serialize_chunk_result(metadata(), report, config, 0.5);
+    EXPECT_NE(json.find("\"execution_completed\": 1"), std::string::npos);
+    EXPECT_NE(json.find("\"execution_failed\": 0"), std::string::npos);
+    EXPECT_NE(json.find("\"execution_completed\": true"), std::string::npos);
+    EXPECT_NE(json.find("\"validators_complete\": false"), std::string::npos);
+    EXPECT_NE(json.find("\"claim_ready\": false"), std::string::npos);
 }

--- a/tests/test_ga_population_receipt.cpp
+++ b/tests/test_ga_population_receipt.cpp
@@ -1,0 +1,364 @@
+#include <gtest/gtest.h>
+
+#include "GaPopulationReceipt.h"
+#include "json_value.h"
+
+#include <array>
+#include <atomic>
+#include <bit>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <thread>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace {
+
+struct Population {
+    std::array<std::array<gene, 2>, 2> genes{};
+    std::array<chromosome, 2> chrom{};
+
+    Population() {
+        for (std::size_t i = 0; i < chrom.size(); ++i) {
+            chrom[i].genes = genes[i].data();
+            chrom[i].status = 'n';
+        }
+        genes[0][0] = {INT32_MIN, -0.0};
+        genes[0][1] = {INT32_MAX, std::bit_cast<double>(UINT64_C(1))};
+        genes[1][0] = {-7, 1.0};
+        genes[1][1] = {42, -2.0};
+    }
+};
+
+class TempDirectory {
+public:
+    TempDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            path = std::filesystem::temp_directory_path() /
+                   ("ga-population-receipt-test-" + std::to_string(tick) + "-" +
+                    std::to_string(attempt));
+            if (std::filesystem::create_directory(path)) return;
+        }
+        throw std::runtime_error("Cannot create test directory");
+    }
+    ~TempDirectory() { std::error_code ignored; std::filesystem::remove_all(path, ignored); }
+    std::filesystem::path path;
+};
+
+class ReceiptEnvironment {
+public:
+    ReceiptEnvironment() {
+        const char* previous = std::getenv("FLEXAIDDS_GEN0_RECEIPT");
+        present_ = previous != nullptr;
+        if (previous) previous_ = previous;
+    }
+    ~ReceiptEnvironment() { set(present_ ? previous_.c_str() : nullptr); }
+    static void set(const char* value) {
+#ifdef _WIN32
+        _putenv_s("FLEXAIDDS_GEN0_RECEIPT", value ? value : "");
+#else
+        if (value) setenv("FLEXAIDDS_GEN0_RECEIPT", value, 1);
+        else unsetenv("FLEXAIDDS_GEN0_RECEIPT");
+#endif
+    }
+private:
+    bool present_;
+    std::string previous_;
+};
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+std::uint64_t encoded_bits(const json::Value& value) {
+    const auto text = value.as_string();
+    if (text.size() != 18 || text.substr(0, 2) != "0x")
+        throw std::runtime_error("Not an exact IEEE binary64 encoding");
+    std::size_t end = 0;
+    const auto result = std::stoull(text, &end, 16);
+    if (end != text.size()) throw std::runtime_error("Trailing bit encoding content");
+    return result;
+}
+
+}  // namespace
+
+TEST(GaPopulationReceipt, ExactGeneIdentityAndEveryStoredScoreComponent) {
+    Population p;
+    const std::array<std::pair<const char*, double cfstr::*>, 14> fields{{
+        {"com_bits", &cfstr::com}, {"con_bits", &cfstr::con},
+        {"wal_bits", &cfstr::wal}, {"sas_bits", &cfstr::sas},
+        {"elec_bits", &cfstr::elec}, {"gist_bits", &cfstr::gist},
+        {"hbond_bits", &cfstr::hbond}, {"gist_desolv_bits", &cfstr::gist_desolv},
+        {"metal_coord_bits", &cfstr::metal_coord}, {"h_rep_bits", &cfstr::h_rep},
+        {"entropy_bits", &cfstr::entropy}, {"pb_clash_bits", &cfstr::pb_clash},
+        {"totsas_bits", &cfstr::totsas}, {"nor_bits", &cfstr::nor}
+    }};
+    for (std::size_t f = 0; f < fields.size(); ++f)
+        p.chrom[0].cf.*fields[f].second =
+            std::bit_cast<double>(UINT64_C(0x3ff0000000000000) + f);
+    p.chrom[0].cf.rclash = 1;
+    p.chrom[0].evalue = -1.0;
+    p.chrom[0].app_evalue = 2.0;
+    p.chrom[0].fitnes = 4.0;
+    p.chrom[0].boltzmann_weight = 0.5;
+    p.chrom[0].free_energy = -2.0;
+    p.chrom[0].ring_phases[0] = -0.0f;
+    p.chrom[0].ring_phases[MAX_RING_FLEX - 1] = 1.0f;
+    p.chrom[0].ring_six[MAX_RING_FLEX - 1] = 255;
+    p.chrom[0].ring_five[0] = 17;
+
+    const auto receipt = json::parse(flexaids::serialize_ga_population_receipt(
+        p.chrom, 2, UINT64_MAX));
+    EXPECT_EQ(receipt["schema"].as_string(), "flexaidds.ga_population_receipt.v1");
+    EXPECT_EQ(receipt["boundary"].as_string(),
+              "initial_population_complete_before_reproduction");
+    EXPECT_EQ(receipt["generation"].as_int(-1), 0);
+    EXPECT_EQ(receipt["population_count"].as_int(), 2);
+    EXPECT_EQ(receipt["n_genes"].as_int(), 2);
+    EXPECT_EQ(receipt["seed"].as_string(), "18446744073709551615");
+    EXPECT_TRUE(receipt["complete"].as_bool());
+    const auto& records = receipt["records"].as_array();
+    ASSERT_EQ(records.size(), 2U);
+    const auto& first = records[0];
+    EXPECT_EQ(first["index"].as_int(-1), 0);
+    EXPECT_EQ(records[1]["index"].as_int(-1), 1);
+    EXPECT_EQ(first["status"].as_int(), static_cast<int>('n'));
+    const auto& genes = first["genes"].as_array();
+    ASSERT_EQ(genes.size(), 2U);
+    EXPECT_EQ(genes[0]["to_int32"].as_int(), INT32_MIN);
+    EXPECT_EQ(genes[1]["to_int32"].as_int(), INT32_MAX);
+    EXPECT_EQ(encoded_bits(genes[0]["to_ic_bits"]), UINT64_C(0x8000000000000000));
+    EXPECT_EQ(encoded_bits(genes[1]["to_ic_bits"]), UINT64_C(1));
+    ASSERT_EQ(first["cf"].size(), fields.size() + 1);
+    for (std::size_t f = 0; f < fields.size(); ++f)
+        EXPECT_EQ(encoded_bits(first["cf"][fields[f].first]),
+                  UINT64_C(0x3ff0000000000000) + f) << fields[f].first;
+    EXPECT_EQ(first["cf"]["rclash"].as_int(), 1);
+    EXPECT_EQ(encoded_bits(first["evalue_bits"]), UINT64_C(0xbff0000000000000));
+    EXPECT_EQ(encoded_bits(first["app_evalue_bits"]), UINT64_C(0x4000000000000000));
+    EXPECT_EQ(encoded_bits(first["fitnes_bits"]), UINT64_C(0x4010000000000000));
+    EXPECT_EQ(encoded_bits(first["boltzmann_weight_bits"]), UINT64_C(0x3fe0000000000000));
+    EXPECT_EQ(encoded_bits(first["free_energy_bits"]), UINT64_C(0xc000000000000000));
+    ASSERT_EQ(first["ring_phases_bits"].size(), static_cast<std::size_t>(MAX_RING_FLEX));
+    EXPECT_EQ(first["ring_phases_bits"].as_array().front().as_string(), "0x80000000");
+    EXPECT_EQ(first["ring_phases_bits"].as_array().back().as_string(), "0x3f800000");
+    ASSERT_EQ(first["ring_six"].size(), static_cast<std::size_t>(MAX_RING_FLEX));
+    ASSERT_EQ(first["ring_five"].size(), static_cast<std::size_t>(MAX_RING_FLEX));
+    EXPECT_EQ(first["ring_six"].as_array().back().as_int(), 255);
+    EXPECT_EQ(first["ring_five"].as_array().front().as_int(), 17);
+}
+
+TEST(GaPopulationReceipt, PreservesNonfinitePayloadsAndDoesNotMutatePopulation) {
+    Population p;
+    const auto signaling_nan = UINT64_C(0x7ff0000000001234);
+    std::memcpy(&p.chrom[0].cf.com, &signaling_nan, sizeof(signaling_nan));
+    p.chrom[0].cf.wal = std::numeric_limits<double>::infinity();
+    std::array<unsigned char, sizeof(p.chrom)> before_chrom;
+    std::array<unsigned char, sizeof(p.genes)> before_genes;
+    std::memcpy(before_chrom.data(), p.chrom.data(), sizeof(p.chrom));
+    std::memcpy(before_genes.data(), p.genes.data(), sizeof(p.genes));
+    const auto payload = flexaids::serialize_ga_population_receipt(p.chrom, 2, 12345);
+    const auto receipt = json::parse(payload);
+    EXPECT_EQ(encoded_bits(receipt["records"].as_array()[0]["cf"]["com_bits"]), signaling_nan);
+    EXPECT_EQ(encoded_bits(receipt["records"].as_array()[0]["cf"]["wal_bits"]),
+              UINT64_C(0x7ff0000000000000));
+    EXPECT_EQ(std::memcmp(before_chrom.data(), p.chrom.data(), sizeof(p.chrom)), 0);
+    EXPECT_EQ(std::memcmp(before_genes.data(), p.genes.data(), sizeof(p.genes)), 0);
+    EXPECT_EQ(flexaids::serialize_ga_population_receipt(p.chrom, 2, 12345), payload);
+}
+
+TEST(GaPopulationReceipt, DisabledObserverDoesNotInspectInvalidInput) {
+    ReceiptEnvironment environment;
+    environment.set(nullptr);
+    EXPECT_NO_THROW(flexaids::write_ga_population_receipt_if_requested({}, -1, 0));
+    environment.set("");
+    EXPECT_NO_THROW(flexaids::write_ga_population_receipt_if_requested({}, -1, 0));
+}
+
+TEST(GaPopulationReceipt, RequestedObserverWritesCompleteReceiptAndRefusesOverwrite) {
+    Population p;
+    TempDirectory directory;
+    ReceiptEnvironment environment;
+    const auto path = (directory.path / "initial.json").string();
+    environment.set(path.c_str());
+    flexaids::write_ga_population_receipt_if_requested(p.chrom, 2, 12345);
+    const auto original = read_file(path);
+    EXPECT_EQ(original, flexaids::serialize_ga_population_receipt(p.chrom, 2, 12345));
+    p.genes[0][0].to_int32 = 19;
+    EXPECT_THROW(flexaids::write_ga_population_receipt_if_requested(p.chrom, 2, 12345),
+                 FlexAIDException);
+    EXPECT_EQ(read_file(path), original);
+}
+
+TEST(GaPopulationReceipt, ConcurrentInvocationsCannotOverwriteEachOther) {
+    Population p;
+    TempDirectory directory;
+    const auto path = (directory.path / "initial.json").string();
+    std::atomic<int> successes{0}, failures{0};
+    auto write = [&] {
+        try {
+            flexaids::write_ga_population_receipt(path.c_str(), p.chrom, 2, 12345);
+            ++successes;
+        } catch (const FlexAIDException&) { ++failures; }
+    };
+    std::thread first(write), second(write);
+    first.join();
+    second.join();
+    EXPECT_EQ(successes.load(), 1);
+    EXPECT_EQ(failures.load(), 1);
+    EXPECT_EQ(read_file(path), flexaids::serialize_ga_population_receipt(p.chrom, 2, 12345));
+}
+
+TEST(GaPopulationReceipt, InvalidInputAndUnwritableDestinationsFailClosed) {
+    Population p;
+    TempDirectory directory;
+    const auto path = (directory.path / "initial.json").string();
+    EXPECT_THROW(flexaids::write_ga_population_receipt(path.c_str(), {}, 2, 0), FlexAIDException);
+    EXPECT_THROW(flexaids::write_ga_population_receipt(path.c_str(), p.chrom, 0, 0), FlexAIDException);
+    p.chrom[1].genes = nullptr;
+    EXPECT_THROW(flexaids::write_ga_population_receipt(path.c_str(), p.chrom, 2, 0), FlexAIDException);
+    EXPECT_FALSE(std::filesystem::exists(path));
+    p.chrom[1].genes = p.genes[1].data();
+    EXPECT_THROW(flexaids::write_ga_population_receipt(nullptr, p.chrom, 2, 0), FlexAIDException);
+    EXPECT_THROW(flexaids::write_ga_population_receipt("", p.chrom, 2, 0), FlexAIDException);
+    const auto absent_parent = (directory.path / "absent" / "initial.json").string();
+    EXPECT_THROW(flexaids::write_ga_population_receipt(absent_parent.c_str(), p.chrom, 2, 0),
+                 FlexAIDException);
+    const auto directory_path = directory.path.string();
+    EXPECT_THROW(flexaids::write_ga_population_receipt(directory_path.c_str(), p.chrom, 2, 0),
+                 FlexAIDException);
+}
+
+TEST(GaPopulationReceipt, ActualStreamWriteFailureIsReportedWithoutReplacingEvidence) {
+    Population p;
+    TempDirectory directory;
+    const auto path = (directory.path / "existing.json").string();
+    const std::string evidence = "preserved evidence\n";
+    { std::ofstream output(path, std::ios::binary); output << evidence; }
+    FILE* read_only = std::fopen(path.c_str(), "r");
+    ASSERT_NE(read_only, nullptr);
+    const auto payload = flexaids::serialize_ga_population_receipt(p.chrom, 2, 12345);
+    // The production finalizer owns/closes this stream on both success and error.
+    EXPECT_THROW(flexaids::population_receipt_detail::finish_output(
+                     read_only, payload, path.c_str()), FlexAIDException);
+    EXPECT_EQ(read_file(path), evidence);
+}
+
+TEST(GaPopulationReceipt, CountsActualEvaluationWorkersAndTeamSizes) {
+    ReceiptEnvironment environment;
+    environment.set("observation-only-no-file");
+    Population p;
+    constexpr int jobs = 64;
+    std::vector<chromosome> population(jobs, p.chrom[0]);
+#ifdef _OPENMP
+    const int was_dynamic = omp_get_dynamic();
+    omp_set_dynamic(0);
+    const std::array<int, 2> teams{1, 4};
+#else
+    const std::array<int, 1> teams{1};
+#endif
+    for (const int requested : teams) {
+        flexaids::GaPopulationObservation observation;
+        ASSERT_TRUE(flexaids::ga_population_observation_active());
+        std::vector<flexaids::GaPopulationWorkerReceipt> workers(requested);
+#ifdef _OPENMP
+#pragma omp parallel for num_threads(requested) schedule(static)
+#endif
+        for (int i = 0; i < jobs; ++i) {
+#ifdef _OPENMP
+            const int tid = omp_get_thread_num();
+            const int team = omp_get_num_threads();
+#else
+            const int tid = 0, team = 1;
+#endif
+            flexaids::record_ga_population_worker(workers[tid], team);
+        }
+        flexaids::observe_ga_population_workers("populate_chromosomes", jobs, 0, workers);
+        const auto receipt = json::parse(flexaids::serialize_ga_population_receipt(population, 2, 12345));
+        const auto& execution = receipt["execution"];
+#ifdef _OPENMP
+        EXPECT_TRUE(execution["openmp_compiled"].as_bool());
+#else
+        EXPECT_FALSE(execution["openmp_compiled"].as_bool(true));
+#endif
+        const auto& batches = execution["evaluation_batches"].as_array();
+        ASSERT_EQ(batches.size(), 1U);
+        EXPECT_EQ(batches[0]["region"].as_string(), "populate_chromosomes");
+        EXPECT_EQ(batches[0]["population_count"].as_int(), jobs);
+        EXPECT_EQ(batches[0]["popoffset"].as_int(-1), 0);
+        EXPECT_EQ(batches[0]["workspace_slots"].as_int(), requested);
+        const auto& observed_workers = batches[0]["workers"].as_array();
+        ASSERT_EQ(observed_workers.size(), static_cast<std::size_t>(requested));
+        int count = 0;
+        for (int tid = 0; tid < requested; ++tid) {
+            EXPECT_EQ(observed_workers[tid]["worker_id"].as_int(-1), tid);
+            EXPECT_EQ(observed_workers[tid]["team_size"].as_int(), requested);
+            EXPECT_GT(observed_workers[tid]["evaluated_chromosomes"].as_int(), 0);
+            count += observed_workers[tid]["evaluated_chromosomes"].as_int();
+        }
+        EXPECT_EQ(count, jobs);
+    }
+#ifdef _OPENMP
+    omp_set_dynamic(was_dynamic);
+#endif
+    EXPECT_FALSE(flexaids::ga_population_observation_active());
+}
+
+TEST(GaPopulationReceipt, RecursiveInitialBatchesAccumulateButLaterRepopulationIsNotObserved) {
+    ReceiptEnvironment environment;
+    environment.set("observation-only-no-file");
+    Population p;
+    const std::array<flexaids::GaPopulationWorkerReceipt, 1> one{{{1, 1}}};
+    {
+        flexaids::GaPopulationObservation observation;
+        // Model IPFILE: remaining random chromosome first, loaded chromosome
+        // evaluated by initial calculate_fitness second. Retain both witnesses.
+        flexaids::observe_ga_population_workers("populate_chromosomes", 2, 1, one);
+        flexaids::observe_ga_population_workers("calculate_fitness", 2, 0, one);
+        const std::array<flexaids::GaPopulationWorkerReceipt, 1> no_evaluations{};
+        flexaids::observe_ga_population_workers("calculate_fitness", 2, 0, no_evaluations);
+        const auto receipt = json::parse(flexaids::serialize_ga_population_receipt(p.chrom, 2, 12345));
+        const auto& batches = receipt["execution"]["evaluation_batches"].as_array();
+        ASSERT_EQ(batches.size(), 2U);
+        EXPECT_EQ(batches[0]["popoffset"].as_int(), 1);
+        EXPECT_EQ(batches[1]["region"].as_string(), "calculate_fitness");
+        EXPECT_THROW((flexaids::GaPopulationObservation{}), FlexAIDException);
+    }
+    EXPECT_FALSE(flexaids::ga_population_observation_active());
+    flexaids::observe_ga_population_workers("populate_chromosomes", 2, 0, one);
+    const auto after = json::parse(flexaids::serialize_ga_population_receipt(p.chrom, 2, 12345));
+    EXPECT_EQ(after["execution"]["evaluation_batches"].size(), 0U);
+}
+
+TEST(GaPopulationReceipt, CallingThreadCollectorsAreIsolatedAndRejectInvalidWorkerMetadata) {
+    ReceiptEnvironment environment;
+    environment.set("observation-only-no-file");
+    flexaids::GaPopulationObservation parent;
+    std::atomic<int> observed{0};
+    auto child = [&] {
+        if (flexaids::ga_population_observation_active()) return;
+        flexaids::GaPopulationObservation own;
+        const std::array<flexaids::GaPopulationWorkerReceipt, 1> worker{{{1, 1}}};
+        flexaids::observe_ga_population_workers("populate_chromosomes", 1, 0, worker);
+        if (own.batches.size() == 1) ++observed;
+    };
+    std::thread first(child), second(child);
+    first.join();
+    second.join();
+    EXPECT_EQ(observed.load(), 2);
+    EXPECT_TRUE(parent.batches.empty());
+    const std::array<flexaids::GaPopulationWorkerReceipt, 1> oversized_team{{{4, 1}}};
+    const std::array<flexaids::GaPopulationWorkerReceipt, 1> too_many{{{1, 3}}};
+    const std::array<flexaids::GaPopulationWorkerReceipt, 2> too_many_combined{{{2, 2}, {2, 2}}};
+    EXPECT_THROW(flexaids::observe_ga_population_workers("populate_chromosomes", 2, 0, oversized_team), FlexAIDException);
+    EXPECT_THROW(flexaids::observe_ga_population_workers("populate_chromosomes", 2, 0, too_many), FlexAIDException);
+    EXPECT_THROW(flexaids::observe_ga_population_workers("populate_chromosomes", 2, 0, too_many_combined), FlexAIDException);
+    EXPECT_THROW(flexaids::observe_ga_population_workers("unknown", 2, 0, oversized_team), FlexAIDException);
+    EXPECT_TRUE(parent.batches.empty());
+}

--- a/tests/test_pose_provenance.cpp
+++ b/tests/test_pose_provenance.cpp
@@ -1,0 +1,204 @@
+#include <gtest/gtest.h>
+
+#include "PoseProvenance.h"
+#include "flexaid.h"
+
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <memory>
+
+namespace {
+
+class PoseProvenanceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        old_seed_ = flexaids_rng::g_master_seed.load();
+        old_has_seed_ = flexaids_rng::g_has_master_seed.load();
+        old_epoch_ = flexaids_rng::g_seed_epoch.load();
+    }
+    void TearDown() override {
+        flexaids_rng::g_master_seed.store(old_seed_);
+        flexaids_rng::g_has_master_seed.store(old_has_seed_);
+        flexaids_rng::g_seed_epoch.store(old_epoch_);
+    }
+private:
+    std::uint64_t old_seed_ = 0;
+    bool old_has_seed_ = false;
+    std::uint64_t old_epoch_ = 0;
+};
+
+TEST_F(PoseProvenanceTest, FormatterMatchesLegacyBytesIncludingFullSeedRange) {
+    for (const auto seed : {UINT64_C(0), UINT64_C(12345), UINT64_MAX}) {
+        for (const int dirty : {0, 1, 2}) {
+            char legacy[256];
+            std::snprintf(legacy, sizeof(legacy),
+                "REMARK FLEXAID.commit=%s FLEXAID.dirty=%d FLEXAID.seed=%llu\n",
+                "012345ab", dirty, static_cast<unsigned long long>(seed));
+            EXPECT_EQ(flexaids::pose_provenance::format_remark("012345ab", dirty, seed),
+                      legacy);
+        }
+    }
+    EXPECT_EQ(flexaids::pose_provenance::format_remark("unknown", 2, 0),
+              "REMARK FLEXAID.commit=unknown FLEXAID.dirty=2 FLEXAID.seed=0\n");
+}
+
+TEST_F(PoseProvenanceTest, ReadsEffectiveSeedAndRetainsUninitializedFallback) {
+    flexaids_rng::g_has_master_seed.store(false);
+    flexaids_rng::g_master_seed.store(9876);
+    EXPECT_EQ(flexaids::pose_provenance::remark(),
+              flexaids::pose_provenance::format_remark(
+                  FLEXAIDS_GIT_COMMIT, FLEXAIDS_GIT_DIRTY, 0));
+    flexaids_rng::set_master_seed(UINT64_MAX);
+    EXPECT_EQ(flexaids::pose_provenance::remark(),
+              flexaids::pose_provenance::format_remark(
+                  FLEXAIDS_GIT_COMMIT, FLEXAIDS_GIT_DIRTY, UINT64_MAX));
+}
+
+TEST_F(PoseProvenanceTest, ReadingProvenanceDoesNotInitializeOrAdvanceRng) {
+    flexaids_rng::g_has_master_seed.store(false);
+    const auto unseeded_epoch = flexaids_rng::g_seed_epoch.load();
+    (void)flexaids::pose_provenance::remark();
+    EXPECT_FALSE(flexaids_rng::has_master_seed());
+    EXPECT_EQ(flexaids_rng::g_seed_epoch.load(), unseeded_epoch);
+
+    flexaids_rng::set_master_seed(12345);
+    auto& rng = flexaids_rng::lazy_thread_rng(0x9A800D);
+    auto expected = rng;
+    const auto epoch = flexaids_rng::g_seed_epoch.load();
+    for (int i = 0; i < 8; ++i) {
+        (void)flexaids::pose_provenance::add_to_remarks("REMARK CF=-1.25\n");
+    }
+    EXPECT_EQ(flexaids_rng::master_seed(), 12345u);
+    EXPECT_EQ(flexaids_rng::g_seed_epoch.load(), epoch);
+    EXPECT_TRUE(rng == expected);
+    EXPECT_EQ(rng(), expected());
+}
+
+TEST_F(PoseProvenanceTest, FullBoundedScientificBufferIsPreservedByteForByte) {
+    std::string body = "REMARK optimized structure\nREMARK CF=-123.45678\n";
+    body.resize(MAX_REMARK - 1, 'x'); // includes a deliberately incomplete tail
+    const auto before = body;
+    const auto metadata = flexaids::pose_provenance::remark();
+    auto expanded = flexaids::pose_provenance::add_to_remarks(body);
+    const auto position = body.find('\n') + 1;
+    EXPECT_EQ(expanded.substr(position, metadata.size()), metadata);
+    expanded.erase(position, metadata.size());
+    EXPECT_EQ(expanded, before);
+    EXPECT_EQ(body, before);
+}
+
+TEST_F(PoseProvenanceTest, EmptyAndUnterminatedBodiesRetainTheirBytes) {
+    const auto metadata = flexaids::pose_provenance::remark();
+    EXPECT_EQ(flexaids::pose_provenance::add_to_remarks(""), metadata);
+    EXPECT_EQ(flexaids::pose_provenance::add_to_remarks("REMARK CF=-1.0"),
+              metadata + "REMARK CF=-1.0");
+}
+
+class WriterFixture {
+public:
+    WriterFixture() : fa(std::make_unique<FA_Global>()) {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            directory = std::filesystem::temp_directory_path() /
+                ("pose-provenance-test-" + std::to_string(tick) + "-" +
+                 std::to_string(attempt));
+            if (std::filesystem::create_directory(directory)) break;
+            if (attempt == 99) throw std::runtime_error("Cannot create test directory");
+        }
+        fa->res_cnt = 2;
+        fa->num_het = 1;
+        fa->het_res[1] = 2;
+        for (int r = 1; r <= 2; ++r) {
+            residues[r].fatm = &first[r - 1];
+            residues[r].latm = &last[r - 1];
+            residues[r].type = r - 1;
+            residues[r].chn = 'A';
+            residues[r].number = r;
+            std::strcpy(residues[r].name, r == 1 ? "ALA" : "LIG");
+        }
+        for (int i = 1; i <= 3; ++i) {
+            atoms[i].ofres = i == 1 ? 1 : 2;
+            atoms[i].number = i == 1 ? 1 : 89999 + i;
+            std::strcpy(atoms[i].name, i == 1 ? "CA" : i == 2 ? "CL1" : "BR1");
+            std::strcpy(atoms[i].element, i == 1 ? "C" : i == 2 ? "Cl" : "Br");
+            atoms[i].coor[0] = i * 1.25f;
+            atoms[i].coor[1] = i * -2.5f;
+            atoms[i].coor[2] = i * 0.5f;
+        }
+        atoms[2].bond[0] = atoms[3].bond[0] = 1;
+        atoms[2].bond[1] = 3;
+        atoms[3].bond[1] = 2;
+    }
+    ~WriterFixture() {
+        std::error_code ignored;
+        std::filesystem::remove_all(directory, ignored);
+    }
+    std::string write(const char* name, std::string remarks, int models = 0) {
+        auto path = (directory / name).string();
+        if (models == 0) {
+            EXPECT_EQ(write_pdb(fa.get(), atoms.data(), residues.data(),
+                                path.data(), remarks.data()), 0);
+        } else {
+            for (int i = 1; i <= models; ++i)
+                EXPECT_EQ(write_MODEL_pdb(i == 1, i == models, i, fa.get(),
+                    atoms.data(), residues.data(), path.data(), remarks.data()), 0);
+        }
+        std::ifstream input(path, std::ios::binary);
+        if (!input) throw std::runtime_error("Missing PDB test output");
+        return std::string(std::istreambuf_iterator<char>(input), {});
+    }
+    std::unique_ptr<FA_Global> fa;
+    std::array<atom, 4> atoms{};
+    std::array<resid, 3> residues{};
+private:
+    std::array<int, 2> first{1, 2};
+    std::array<int, 2> last{1, 3};
+    std::filesystem::path directory;
+};
+
+void expect_only_metadata_added(const std::string& before, std::string after) {
+    const auto metadata = flexaids::pose_provenance::remark();
+    const auto position = after.find(metadata);
+    ASSERT_NE(position, std::string::npos);
+    EXPECT_EQ(after.find(metadata, position + metadata.size()), std::string::npos);
+    after.erase(position, metadata.size());
+    EXPECT_EQ(after, before); // all scientific REMARKs, ATOM/HETATM, CONECT, END
+    EXPECT_NE(before.find("ATOM  "), std::string::npos);
+    EXPECT_NE(before.find("HETATM"), std::string::npos);
+    EXPECT_NE(before.find("CONECT"), std::string::npos);
+    EXPECT_NE(before.find("REMARK CF=-12.50000"), std::string::npos);
+}
+
+const std::string scientific_remarks =
+    "REMARK optimized structure\nREMARK CF=-12.50000\nREMARK CF.com=-14.00000\n"
+    "REMARK CF.wal= 1.50000\nREMARK rmsd_raw = 3.00000\n";
+
+TEST_F(PoseProvenanceTest, RealPdbWriterAddsOnlyOneMetadataLine) {
+    WriterFixture fixture;
+    auto full_body = scientific_remarks;
+    full_body.resize(MAX_REMARK - 1, 'x');
+    expect_only_metadata_added(fixture.write("before.pdb", full_body),
+        fixture.write("after.pdb", flexaids::pose_provenance::add_to_remarks(full_body)));
+}
+
+TEST_F(PoseProvenanceTest, RealSingleModelWriterPreservesScientificBytes) {
+    WriterFixture fixture;
+    expect_only_metadata_added(fixture.write("before.pdb", scientific_remarks, 1),
+        fixture.write("after.pdb",
+            flexaids::pose_provenance::add_to_remarks(scientific_remarks), 1));
+}
+
+TEST_F(PoseProvenanceTest, RealMultiModelWriterAddsMetadataOnlyToFirstHeader) {
+    WriterFixture fixture;
+    expect_only_metadata_added(fixture.write("before.pdb", scientific_remarks, 3),
+        fixture.write("after.pdb",
+            flexaids::pose_provenance::add_to_remarks(scientific_remarks), 3));
+}
+
+} // namespace

--- a/tests/test_rmsd_symmcorr.py
+++ b/tests/test_rmsd_symmcorr.py
@@ -263,9 +263,9 @@ def test_sidecar_loader_drops_non_ok_rows(tmp_path: Path):
     p = tmp_path / "s.csv"
     p.write_text(
         "pdb_id,rmsd_symmcorr,status,pose_sha256\n"
-        "1AAA,1.0,ok,x\n"
+        f"1AAA,1.0,ok,{hashlib.sha256(b'pose').hexdigest()}\n"
         "1BBB,,no_pose_artifact,y\n"
         "1CCC,9.9,spyrmsd_error:ValueError,z\n"
     )
     loaded = agg.load_symmcorr_sidecar(p)
-    assert set(loaded) == {"1AAA"}
+    assert {pid for pid, sha in loaded} == {"1AAA"}


### PR DESCRIPTION
**Do not merge: the completed engine determinism gate fails, including repeated runs at four threads.**

Repairs independent observation admission, OptRes/rotamer pointer lifetimes, child-process completion and missing measurements, matrix/PoseBusters receipts, and output provenance. Adds direct generation-zero observation and strict engine comparison tooling without changing the production scoring protocol.

Validation at exact clean head `2fffb64e4d316c703207104b79dba461781a2f83`:

- Full CPU/OpenMP build passed; 101/101 CTest entries and 215 affected Python tests passed. Eight output-writer tests also pass plain and with ASan/UBSan.
- All six fresh 1G9V runs completed: seed 12345, population 1000, generations 2000, one restart; individual runtime/provenance admission passed.
- Baseline/candidate one-thread default-path parity **PASS**: all ten PDB files match after replacing only commit/dirty provenance values.
- Candidate one-thread parallel-reproduction-ON repeats match byte-for-byte.
- Candidate four-thread ON repeats **FAIL**, both against one-thread results and each other: all ten CF values and coordinate payloads differ. Four-thread rank-zero CF is −156062.10376 versus −202396.17468 with identical binary, seed and scientific inputs.
- All runs share identical initial indexed gene/score records and freshly generated grid bytes. Both four-thread runs witness all four workers. No serialization, altered scientific flags or relaxed comparison tolerances were used.
- Exact-head CI snapshot at 2026-09-06 08:13 UTC: 22 successful checks; Tier-1 Benchmark (astex_diverse) still in progress. CI success would not override the failed local engine gate.

The official determinism comparator exited 1. Exact cause is unresolved. Source review identifies conditional RNG-stream coupling and a hull-retry coordinate-restoration defect, but neither is established as the cause of these runs. The default-path parity pass does not prove baseline reproducibility with parallel reproduction ON; that baseline comparison was not performed.

The first engine attempt failed provenance admission despite completing. Those outputs are preserved, the writer omission was repaired, and all six comparisons were rerun from fresh v2 outputs. No historical docking accuracy or publication headline is upgraded by these repairs. The external GPCR research prototype is not imported.

PR remains draft. No merge or main push performed. Next work is to witness the first full-population/RNG/scoring divergence, repair its cause with explicit protocol accounting, and rerun the matched gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes parallel GA workspace binding, benchmark exit semantics, and claim admission contracts; the PR author reports a failing four-thread determinism gate that is not resolved in this diff.
> 
> **Overview**
> **Hardens benchmark and claim plumbing** so runtime completion, matrix identity, and child exit codes are recorded separately from RMSD/PB success. `DatasetRunner` stops treating cached skips as successful docks, extends CSV/summary fields (`docking_exit_code`, `docking_completed`, `matrix_md5`, valid RMSD counts), and `benchmark_datasets` can exit nonzero when docking did not complete. Fleet JSON and admission docs align with receipt-level STRICT rules.
> 
> **Fixes unsafe atom/OptRes and rotamer pointer use** in parallel GA evaluation via `AtomOptResBinding` (master-index rebinding instead of pointer subtraction) and index-based rotamer PDB output. **Centralizes pose REMARK provenance** in `PoseProvenance` (unknown dirty tree defaults to `2`, provenance inserted without truncating scientific REMARK buffers).
> 
> **Adds optional generation-zero GA population receipts** (`FLEXAIDDS_GEN0_RECEIPT`) with OpenMP worker witnessing, plus **`ops/engine_repro_gate.py`** and a rewritten **`gate_parity.sh`** for pinned parity/determinism comparisons. CI gains related C++ tests and Python gates (`test_engine_repro_gate`, fixed-denominator claim contract). `METHODOLOGY.md` and `admission_metrics_contract.md` are expanded to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fffb64e4d316c703207104b79dba461781a2f83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance metadata to generated pose files.
  * Added optional generation-zero population receipts for reproducibility checks.
  * Added isolated parity and determinism validation for engine outputs.
  * Benchmark results now report docking completion, exit status, matrix identity, valid RMSD counts, and failure reasons.

* **Bug Fixes**
  * Incomplete or failed docking runs are no longer reported as successful.
  * Missing or invalid RMSD values are displayed as unavailable rather than zero.

* **Documentation**
  * Updated benchmark methodology and admission criteria with clearer receipt and validation requirements.

* **Tests**
  * Expanded coverage for reporting, reproducibility, provenance, population receipts, and output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->