### PR TITLE
[ci] Repair current-main test failures and Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'LIB/**'
+  workflow_dispatch:
+
+concurrency:
+  group: release-build-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -23,10 +34,12 @@ jobs:
             cc: clang
             cxx: clang++
             artifact_name: flexaidds-macos
-          - name: windows-msvc
+          # The full engine requires Clang >=18 or GCC >=14. MSVC's C++20
+          # compatibility path is reserved for the Python extension smoke job.
+          - name: windows-clang
             os: windows-latest
-            cc: cl
-            cxx: cl
+            cc: clang-cl
+            cxx: clang-cl
             artifact_name: flexaidds-windows
     steps:
       - name: Checkout repository
@@ -52,6 +65,12 @@ jobs:
           choco install ninja eigen -y
         shell: cmd
 
+      - name: Set up Windows SDK and linker environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        with:
+          arch: x64
+
       - name: Configure (Unix)
         if: runner.os != 'Windows'
         run: |
@@ -68,36 +87,49 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          clang-cl --version
           cmake -S . -B build -G Ninja ^
             -DCMAKE_BUILD_TYPE=Release ^
+            -DCMAKE_C_COMPILER=clang-cl ^
+            -DCMAKE_CXX_COMPILER=clang-cl ^
+            -DFLEXAIDS_USE_OPENMP=OFF ^
             -DFLEXAIDS_USE_CUDA=OFF ^
             -DFLEXAIDS_USE_METAL=OFF ^
             -DBUILD_PYTHON_BINDINGS=OFF ^
             -DBUILD_TESTING=OFF
 
       - name: Build
-        run: cmake --build build --parallel
+        run: cmake --build build --parallel 2
+
+      - name: Smoke test shipping executables (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          build/FlexAID --help > help.out
+          grep -q 'Usage:' help.out
+          build/FlexAIDdS --version
+
+      - name: Smoke test shipping executables (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          build\FlexAID.exe --help > help.out || exit /b 1
+          findstr /C:"Usage:" help.out || exit /b 1
+          build\FlexAIDdS.exe --version || exit /b 1
 
       - name: Package artifacts (Unix)
         if: runner.os != 'Windows'
         run: |
           mkdir -p dist
-          cp -f build/FlexAID dist/ || true
-          cp -f build/FlexAIDdS dist/ || true
-          cp -f build/tENCoM dist/ || true
-          cp -f LICENSE dist/ || true
+          cp -f build/FlexAID build/FlexAIDdS build/tENCoM LICENSE dist/
           tar -czf ${{ matrix.artifact_name }}.tar.gz dist
 
       - name: Package artifacts (Windows)
         if: runner.os == 'Windows'
         shell: powershell
         run: |
+          $ErrorActionPreference = 'Stop'
           New-Item -ItemType Directory -Force -Path dist | Out-Null
-          Copy-Item build\FlexAID.exe dist\ -ErrorAction SilentlyContinue
-          Copy-Item build\FlexAIDdS.exe dist\ -ErrorAction SilentlyContinue
-          Copy-Item build\tENCoM.exe dist\ -ErrorAction SilentlyContinue
-          Copy-Item LICENSE dist\ -ErrorAction SilentlyContinue
+          Copy-Item build\FlexAID.exe, build\FlexAIDdS.exe, build\tENCoM.exe, LICENSE dist\
           Compress-Archive -Path dist\* -DestinationPath ${{ matrix.artifact_name }}.zip -Force
 
       - name: Upload artifact (Unix)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,12 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             "FlexAIDdS requires C++26 — found GCC "
             "${CMAKE_CXX_COMPILER_VERSION}. Upgrade to GCC ≥ 14.")
     endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # clang-cl simulates the MSVC ABI (MSVC is true), but its language support
+    # is Clang's. Keep C++26 instead of taking cl.exe's bindings-only C++20 cap.
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "18.0")
+        message(FATAL_ERROR "FlexAIDdS requires Clang >= 18 for C++26.")
+    endif()
 elseif(MSVC)
     if(MSVC_VERSION LESS 1940)
         message(FATAL_ERROR

--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -65,9 +65,6 @@
 #include <string>
 #include <vector>
 
-#include <sys/wait.h>
-#include <signal.h>
-#include <unistd.h>
 #include <thread>
 
 #ifndef _MSC_VER

--- a/LIB/DatasetRunner.h
+++ b/LIB/DatasetRunner.h
@@ -44,6 +44,12 @@
 
 namespace dataset {
 
+#ifdef _MSC_VER
+// The existing MSVC subprocess fallback uses integer status/sentinel values,
+// not POSIX process IDs. Keep that API compilable without a global pid_t shim.
+using pid_t = int;
+#endif
+
 // =============================================================================
 // Enums
 // =============================================================================

--- a/tests/test_ga_context.cpp
+++ b/tests/test_ga_context.cpp
@@ -268,6 +268,9 @@ TEST(RngSeedTest, VoronoiKeyedJitterIndependentOfRngStreamFix) {
     }
     {
         ScopedEnv off("FLEXAIDDS_VORONOI_KEYED_JITTER", "off");
+        // Flags are cached for one seed epoch, including environment changes.
+        EXPECT_TRUE(flexaids_rng::voronoi_keyed_jitter_enabled());
+        flexaids_rng::set_master_seed(12345);
         EXPECT_FALSE(flexaids_rng::voronoi_keyed_jitter_enabled());
     }
 }

--- a/tests/test_par_reservation.cpp
+++ b/tests/test_par_reservation.cpp
@@ -43,7 +43,6 @@
 #include "flexaid.h"
 
 #include <cstdlib>
-#include <cstring>
 
 // Defined in LIB/add2_optimiz_vec.cpp
 void reserve_par(FA_Global* FA, int need);
@@ -51,17 +50,27 @@ void realloc_par(FA_Global* FA, int* MIN_PAR);
 
 namespace {
 
-// Minimal FA_Global carrying only the par-array fields. realloc() on a null
-// pointer is malloc(), so a zeroed struct is a valid starting state.
+// realloc_par() owns six separate arrays. Value initialization keeps their
+// pointers null without overwriting FA_Global's nontrivial C++ members.
 struct ParFixture {
     FA_Global FA{};
     ParFixture() {
-        std::memset(&FA, 0, sizeof(FA));
         FA.MIN_PAR = 0;
         FA.map_par = nullptr;
         FA.npar = 0;
     }
-    ~ParFixture() { std::free(FA.map_par); }
+    ParFixture(const ParFixture&) = delete;
+    ParFixture& operator=(const ParFixture&) = delete;
+    ~ParFixture() {
+        // Free the current pointers after any reallocations. free(nullptr)
+        // also handles the disabled-reservation case and early assertions.
+        std::free(FA.map_par);
+        std::free(FA.opt_par);
+        std::free(FA.del_opt_par);
+        std::free(FA.min_opt_par);
+        std::free(FA.max_opt_par);
+        std::free(FA.map_opt_par);
+    }
 };
 
 // The invariant the two guarded call sites rely on: once reserve_par has been


### PR DESCRIPTION
Current main fails the Linux GCC/Clang/MPI, macOS, TSan and Coverage lanes because the jitter-flag test changes the environment inside a cached seed epoch. Clang ASan also exposes five leaked parameter arrays in each allocating reservation-fixture test. This fixes both test defects without changing engine scoring, and repairs the Windows release build that still includes POSIX-only headers.

- Assert that flags remain cached within the epoch, then advance the epoch before asserting the updated value.
- Free every fixture-owned parameter array and value-initialize `FA_Global` without overwriting its C++ members.
- Guard the POSIX includes, use the existing Windows process-ID fallback type, and build the full Windows engine with clang-cl plus a persistent SDK/linker environment. Release builds now run on PR/manual events, smoke-test both executables, and require every packaged binary to exist. These runs upload CI artifacts; they do not publish a release.

Validation: the isolated macOS build ran with `BUILD_TESTING=ON`, OpenMP on, one build/test job, and passed **103/103 CTest checks**. The jitter test is covered by that run. The later reservation cleanup and Windows compiler branch await this PR's hosted sanitizer/Windows evidence; local compilation stopped to preserve RAM for an active benchmark. A source review checked allocation ownership and clang-cl compiler selection. No benchmark results, caches, frozen binaries or live checkout were modified.

Base audited: `fed711e31fe8d47f8685d4f2d7d89299ee81bea6`. Implementation/review: Codex (GPT-6), with independent scoped agent review. This CI repair is separated from the nine scientific/core audit repairs so its results and landing decision can be reviewed independently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI, Windows build tooling, portable includes, and test/fixture hygiene; no production scoring or docking logic is modified.
> 
> **Overview**
> Repairs **CI and release packaging** without changing engine scoring: tests pass again on Linux/macOS sanitizer lanes, and the full Windows engine can build in release.
> 
> **Release workflow** now runs on path-filtered PRs and `workflow_dispatch`, with concurrency cancellation on PRs. The Windows matrix switches from **MSVC to `clang-cl`** (SDK via `msvc-dev-cmd`, OpenMP off), matching a new **CMake Clang ≥18** gate so the full engine keeps **C++26** instead of MSVC’s bindings-only C++20 cap. Builds add **smoke tests** (`FlexAID --help`, `FlexAIDdS --version`) and **strict packaging** (all three binaries required; no silent skips).
> 
> **Portability:** `DatasetRunner` guards POSIX headers and defines `pid_t` on MSVC so Windows release compiles.
> 
> **Tests only:** `test_ga_context` respects **flag caching per seed epoch** (assert stale jitter on, then `set_master_seed` before expecting off). `test_par_reservation` **value-initializes** `FA_Global` and **frees all six** `realloc_par` arrays in the fixture destructor (fixes ASan leaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a1d217cf31e0575420ee5ebfae71085e7ee7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Release**
  - Release builds now support manual triggering and improved pull request validation.
  - Windows builds use Clang tooling with OpenMP disabled and parallel compilation enabled.
  - Packaged executables are smoke-tested on Unix and Windows.
  - Packaging now reports missing files instead of silently continuing.

- **Platform Support**
  - Improved Windows/MSVC compatibility for process-related functionality.
  - Clang versions older than 18 are rejected during configuration because C++26 is required.

- **Tests**
  - Expanded coverage for configuration caching and parameter resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->