### PR TITLE
[fix] Repair audit findings in benchmark observations and core state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest numpy scipy
+          python -m pip install pytest numpy scipy pyyaml
       - name: Run pure-Python tests (no C++ extension needed)
         env:
           PYTHONPATH: python
@@ -63,6 +63,22 @@ jobs:
           python/tests/test_visualization.py
           python/tests/test_dift.py
           benchmarks/tests/test_itc_calibration.py
+
+      - name: DatasetRunner observation and ranking regressions
+        env:
+          PYTHONPATH: python
+          OMP_NUM_THREADS: '1'
+          OPENBLAS_NUM_THREADS: '1'
+        run: >
+          pytest -q
+          python/tests/test_runner_*.py
+          python/tests/test_metrics_*.py
+          python/tests/test_dataset_runner*.py
+          python/tests/test_early_termination_tracking.py
+          python/tests/test_regression_direction.py
+          python/tests/test_baseline_tolerance_sign.py
+          python/tests/test_pose_pdb_preservation.py
+          python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
 
   # Linux C++ matrix only. macOS CPU build+ctest is the dedicated blocking job
   # macos_cpu_tests (no continue-on-error). See docs/CI_RELEASE_GATES.md.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1910,6 +1910,17 @@ flexaids_add_unit_test(test_protocol_config
     flexaids_configure_msvc_test(test_vcontacts)
     add_test(NAME VcontactsTests COMMAND test_vcontacts)
 
+    flexaids_add_unit_test(test_vcontacts_failsafe
+        SOURCES
+            tests/test_vcontacts_failsafe.cpp
+            tests/stubs.cpp
+            LIB/Vcontacts.cpp
+            LIB/geometry.cpp
+        DEFINES FLEXAIDS_VCONTACTS_TEST_HOOKS
+        LINK_OPENMP
+        TEST_NAME VcontactsFailsafeTests
+    )
+
     flexaids_add_unit_test(test_get_yval_lut
         SOURCES
             tests/test_get_yval_lut.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2722,6 +2722,7 @@ flexaids_add_unit_test(test_protocol_config
     flexaids_add_unit_test(test_parallel_dock
         SOURCES
             tests/test_parallel_dock.cpp
+            LIB/GAContext.cpp
             LIB/GridDecomposer.cpp
             LIB/SharedPosePool.cpp
             LIB/statmech.cpp

--- a/LIB/BindingMode.cpp
+++ b/LIB/BindingMode.cpp
@@ -1238,6 +1238,35 @@ Pose::Pose(chromosome* chrom, int index, int iorder, float dist, uint temperatur
 }
 
 
+int chromosome_model_index(const chromosome& chrom, const FA_Global& fa, int num_genes)
+{
+	if (!fa.multi_model) return 0;
+	if (fa.n_models < 1)
+		throw std::invalid_argument("multi-model pose requires a positive model count");
+	if (fa.n_models == 1) return 0;
+	if (!chrom.genes || fa.model_gene_index < 0 || fa.model_gene_index >= num_genes)
+		throw std::invalid_argument("multi-model pose has no valid model gene");
+	const double value = chrom.genes[fa.model_gene_index].to_ic;
+	if (!std::isfinite(value))
+		throw std::invalid_argument("multi-model pose has a non-finite model gene");
+	// Clamp before integer conversion, including for extreme finite genes.
+	return static_cast<int>(std::max(0.0, std::min(
+		static_cast<double>(fa.n_models - 1), std::round(value))));
+}
+
+Pose Pose::from_chromosome(chromosome* chrom, int index, int iorder, float dist,
+                          uint temperature, std::vector<float> coordinates,
+                          const FA_Global& fa, int num_genes)
+{
+	if (!chrom) throw std::invalid_argument("pose requires a chromosome");
+	const int model = chromosome_model_index(*chrom, fa, num_genes);
+	Pose pose(chrom, index, iorder, dist, temperature, std::move(coordinates));
+	pose.model_index = model;
+	// app_evalue already includes any evaluator-injected conformer strain.
+	// Preserve that score; adding model_strain here would count it twice.
+	return pose;
+}
+
 Pose::~Pose() {}
 
 

--- a/LIB/BindingMode.h
+++ b/LIB/BindingMode.h
@@ -25,6 +25,10 @@ bool write_mcf_sidecar(const char* pdb_path,
 /// Surface honesty only: this does not invent an eigenvalue channel or elect poses.
 void format_vibrational_diagnostic_remark(char* buf, size_t buflen, double vib_corr);
 
+/// Decode the same rounded/clamped model gene used by the evaluator.
+/// Invalid multi-model metadata is an error, never an implicit model-zero pose.
+int chromosome_model_index(const chromosome& chrom, const FA_Global& fa, int num_genes);
+
 /*****************************************\
 			  Pose
 \*****************************************/
@@ -34,6 +38,9 @@ struct Pose
 	
 	// public constructor :
 	Pose(chromosome* chrom, int chrom_index, int order, float dist, uint temperature, std::vector<float>);
+	static Pose from_chromosome(chromosome* chrom, int chrom_index, int order,
+	                           float dist, uint temperature, std::vector<float> coordinates,
+	                           const FA_Global& fa, int num_genes);
 	~Pose();
 	// public (default behavior when struct is used instead of class)
 	int chrom_index;

--- a/LIB/FOPTICS.cpp
+++ b/LIB/FOPTICS.cpp
@@ -273,7 +273,9 @@ void FastOPTICS::Execute_FastOPTICS(char* end_strfile, char* tmp_end_strfile)
 		if( (this->points[pt]).first != NULL && (this->points[pt].first)->app_evalue < 0 )
 		{
 			// Calling Pose constructor: Pose holds the point's chromosome at the correct OPTICS position
-			Pose pose((this->points[pt]).first, pt, pos, this->reachDist[pt], this->Population->Temperature, (this->points[pt]).second);
+			Pose pose = Pose::from_chromosome((this->points[pt]).first, pt, pos,
+				this->reachDist[pt], this->Population->Temperature,
+				(this->points[pt]).second, *this->FA, this->GB->num_genes);
             this->OPTICS.push_back(pose);
 		}
 	}
@@ -612,10 +614,8 @@ std::vector<float> FastOPTICS::Vectorized_Cartesian_Coordinates(int chrom_index)
 	// conformers are separated in the joint configuration space.
 	if (this->FA->multi_model && this->FA->n_models > 1 &&
 	    this->FA->model_gene_index >= 0) {
-		int mg = this->FA->model_gene_index;
-		int model_idx = static_cast<int>(std::round(this->chroms[chrom_index].genes[mg].to_ic));
-		if (model_idx < 0) model_idx = 0;
-		if (model_idx >= this->FA->n_models) model_idx = this->FA->n_models - 1;
+		const int model_idx = chromosome_model_index(
+			this->chroms[chrom_index], *this->FA, this->GB->num_genes);
 		// Scale: model_index * (2 * cluster_rmsd) ensures distinct models
 		// are > cluster_rmsd apart in the joint space
 		float model_scale = 2.0f * this->FA->cluster_rmsd;

--- a/LIB/GaEliteBuffer.h
+++ b/LIB/GaEliteBuffer.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "gaboom.h"
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+namespace flexaids {
+
+// The generation loop uses this same capture/restore path before and after
+// reproduction. A cached score belongs to the complete chromosome, including
+// its ring-pucker arrays; genes are the only externally owned chromosome data.
+class GaEliteBuffer {
+public:
+    GaEliteBuffer(int count, int gene_count)
+        : gene_count_(gene_count), elites_(count),
+          genes_(static_cast<std::size_t>(count) * gene_count) {
+        for (int i = 0; i < count; ++i)
+            elites_[i].genes = genes_.data() + static_cast<std::size_t>(i) * gene_count;
+    }
+    GaEliteBuffer(const GaEliteBuffer&) = delete;
+    GaEliteBuffer& operator=(const GaEliteBuffer&) = delete;
+
+    void capture(const chromosome* population, int population_count) {
+        if (elites_.empty()) return;
+        std::vector<int> indices(population_count);
+        std::iota(indices.begin(), indices.end(), 0);
+        std::partial_sort(indices.begin(), indices.begin() + elites_.size(), indices.end(),
+            [&](int a, int b) { return population[a].evalue < population[b].evalue; });
+        for (std::size_t i = 0; i < elites_.size(); ++i)
+            copy_chrom(&elites_[i], &population[indices[i]], gene_count_);
+    }
+
+    void restore(chromosome* population, int population_count) const {
+        if (elites_.empty()) return;
+        std::vector<int> indices(population_count);
+        std::iota(indices.begin(), indices.end(), 0);
+        std::partial_sort(indices.begin(), indices.begin() + elites_.size(), indices.end(),
+            [&](int a, int b) { return population[a].evalue > population[b].evalue; });
+        for (std::size_t i = 0; i < elites_.size(); ++i) {
+            chromosome& destination = population[indices[i]];
+            copy_chrom(&destination, &elites_[i], gene_count_);
+            destination.fitnes = 0.0;
+            destination.boltzmann_weight = 0.0;
+            destination.free_energy = 0.0;
+            // Preserve the captured validity flag: never certify an unscored
+            // chromosome merely because it passed through elitism.
+        }
+    }
+
+private:
+    int gene_count_;
+    std::vector<chromosome> elites_;
+    std::vector<gene> genes_;
+};
+}  // namespace flexaids

--- a/LIB/GaEvaluationPolicy.h
+++ b/LIB/GaEvaluationPolicy.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "EnvFlags.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace flexaids {
+
+// Shared by generation zero and every later CPU fitness evaluation. Limit
+// allocation as well as scheduling, so deterministic runs need one workspace.
+inline int ga_evaluation_threads() {
+#if defined(FLEXAID_DETERMINISTIC) || !defined(_OPENMP)
+    return 1;
+#else
+    return env_bool("FLEXAID_DETERMINISTIC", false) ? 1 : omp_get_max_threads();
+#endif
+}
+
+}  // namespace flexaids

--- a/LIB/ParallelDock.cpp
+++ b/LIB/ParallelDock.cpp
@@ -1,6 +1,7 @@
 // ParallelDock.cpp — Orchestrator for parallel grid-decomposed docking
 #include "ParallelDock.h"
 #include "fileio.h"
+#include "SerialRegionExecution.h"
 
 #include <cstdio>
 #include <cstring>
@@ -54,25 +55,12 @@ void ParallelDockManager::decompose() {
 }
 
 // ============================================================================
-// Phase 2: Run parallel GA instances
+// Phase 2: Run region GA instances (serial within each process)
 // ============================================================================
 
-ParallelDockManager::RegionWorkspace ParallelDockManager::create_workspace() const {
-    RegionWorkspace ws;
-
-    // Shallow copy globals
-    ws.fa = *FA_;
-    ws.gb = *GB_;
-    ws.vc = *VC_;
-
-    // Deep copy mutable arrays. atom[] is 1-based: live atoms occupy
-    // atoms[1]..atoms[atm_cnt] (gaboom.cpp ParEvalWS: atoms + natm + 1).
-    // residue[] is the same layout (res_cnt+1 already). Using atm_cnt as a
-    // half-open C++ end drops atoms[atm_cnt] — the last 1-based atom.
-    ws.atoms_copy.assign(atoms_, atoms_ + flexaid_one_based_copy_n(FA_->atm_cnt));
-    ws.residue_copy.assign(residue_, residue_ + FA_->res_cnt + 1);
-
-    return ws;
+std::unique_ptr<ParallelDockManager::RegionWorkspace>
+ParallelDockManager::create_workspace() const {
+    return std::make_unique<RegionWorkspace>(*FA_, *GB_, *VC_, atoms_, residue_);
 }
 
 void ParallelDockManager::run(
@@ -86,51 +74,35 @@ void ParallelDockManager::run(
     int n_regions = (int)regions_.size();
     results_.resize(n_regions);
 
-    // Seed generator for per-region RNG
-    std::mt19937 seed_gen(42);
+    // Resolve the parent seed once, before a region GA advances the process
+    // master-seed epoch. Region assignment must not depend on scheduling/rank.
+    std::uint64_t parent_seed = 0;
+    if (!flexaids::resolve_region_parent_seed(GB_->seed, parent_seed))
+        throw FlexAIDException("ParallelDock requires GB->seed or FLEXAID_SEED");
+
+    // Scoring scratch is owned per region, but nested pointers and RNG epochs
+    // still prevent safe simultaneous GA calls within one process. Keep the
+    // spatial decomposition and inner GA evaluator parallelism; serialize only
+    // region execution. The shared dispatcher also guards concurrent managers.
+    printf("ParallelDock: serial regions per process; inner GA evaluators retain OpenMP\n");
+    auto execute_region = [&](int r) {
+        const int seed = flexaids::region_seed(parent_seed, r);
+        results_[r] = run_region(regions_[r], static_cast<unsigned int>(seed), target);
+        SharedPose sp;
+        sp.energy = results_[r].best_energy;
+        std::memcpy(sp.grid_coor, results_[r].best_coor, 3 * sizeof(float));
+        sp.source_region = r;
+        pool_.publish(sp);
+    };
 
 #ifdef FLEXAIDS_USE_MPI
-    // MPI distributed mode: each rank processes a subset of regions
-    int rank = MPITransport::rank();
-    int world = MPITransport::world_size();
-
-    // Round-robin assignment
-    for (int r = rank; r < n_regions; r += world) {
-        unsigned int seed = seed_gen() + r;
-        results_[r] = run_region(regions_[r], seed, target);
-
-        // Publish best to shared pool
-        SharedPose sp;
-        sp.energy = results_[r].best_energy;
-        std::memcpy(sp.grid_coor, results_[r].best_coor, 3 * sizeof(float));
-        sp.source_region = r;
-        pool_.publish(sp);
-    }
-
-    // Gather all results to rank 0
-    // (simplified: each rank sends its results)
+    const int rank = MPITransport::rank();
+    const int world = MPITransport::world_size();
+    flexaids::for_each_serial_region(rank, n_regions, world, execute_region);
     auto all_results = MPITransport::gather_results(results_, n_regions);
     if (rank == 0) results_ = std::move(all_results);
-
 #else
-    // Thread-based mode: OpenMP parallel over regions
-    #ifdef _OPENMP
-    #pragma omp parallel for schedule(dynamic, 1)
-    #endif
-    for (int r = 0; r < n_regions; r++) {
-        unsigned int seed;
-        #pragma omp critical
-        { seed = seed_gen() + r; }
-
-        results_[r] = run_region(regions_[r], seed, target);
-
-        // Publish best to shared pool (thread-safe)
-        SharedPose sp;
-        sp.energy = results_[r].best_energy;
-        std::memcpy(sp.grid_coor, results_[r].best_coor, 3 * sizeof(float));
-        sp.source_region = r;
-        pool_.publish(sp);
-    }
+    flexaids::for_each_serial_region(0, n_regions, 1, execute_region);
 #endif
 
     printf("ParallelDock: completed %d region GA runs\n", n_regions);
@@ -173,8 +145,10 @@ RegionResult ParallelDockManager::run_region(
         return result;
     }
 
-    // Create per-region workspace (deep copy of mutable state)
-    RegionWorkspace ws = create_workspace();
+    // Own mutable scoring buffers; all remaining borrowed state is used serially.
+    auto workspace = create_workspace();
+    RegionWorkspace& ws = *workspace;
+    ws.gb.seed = static_cast<int>(rng_seed);
 
     // Override grid parameters for this region
     ws.fa.num_grd = sub_num_grd;
@@ -352,6 +326,7 @@ bool ParallelDockManager::get_best_chromosome(chromosome& out_chrom,
     out_chrom.free_energy     = meta.free_energy;
     std::memcpy(out_chrom.ring_phases, meta.ring_phases, sizeof(out_chrom.ring_phases));
     std::memcpy(out_chrom.ring_six,    meta.ring_six,    sizeof(out_chrom.ring_six));
+    std::memcpy(out_chrom.ring_five,   meta.ring_five,   sizeof(out_chrom.ring_five));
 
     // Copy genes[0..num_genes-1]
     for (int g = 0; g < num_genes; g++) {

--- a/LIB/ParallelDock.h
+++ b/LIB/ParallelDock.h
@@ -13,9 +13,11 @@
 #include "GridDecomposer.h"
 #include "SharedPosePool.h"
 #include "TargetServer.h"
+#include "RegionScoringWorkspace.h"
 #include <vector>
 #include <functional>
 #include <string>
+#include <memory>
 
 struct ParallelDockConfig {
     int target_regions       = 128;   // number of spatial regions
@@ -23,7 +25,7 @@ struct ParallelDockConfig {
     int pose_pool_size       = 256;   // shared pool capacity
     int exchange_interval    = 10;    // generations between pool reads
     int seed_from_pool_count = 5;     // how many pool poses to inject per exchange
-    bool use_mpi             = false; // true for distributed (MPI), false for thread-based
+    bool use_mpi             = false; // MPI ranks may distribute regions; per-process regions run serially
 };
 
 struct RegionResult {
@@ -76,7 +78,9 @@ public:
 
     // Phase 2: Run all GA instances
     //   - MPI mode: distributed across ranks (call from all ranks)
-    //   - Thread mode: OpenMP parallel over regions on single machine
+    //   - Local mode: serial regions, OpenMP remains inside each GA evaluator.
+    // Outer concurrent regions are unsafe while GA seed epochs/nested state
+    // remain process-global. This trades region-level throughput for correctness.
     void run(cfstr (*target)(FA_Global*,VC_Global*,atom*,resid*,gridpoint*,int,double*));
 
     // Phase 3: Aggregate results into global partition function
@@ -132,14 +136,8 @@ private:
         cfstr (*target)(FA_Global*,VC_Global*,atom*,resid*,gridpoint*,int,double*)
     );
 
-    // Create deep copies of mutable state for a region
-    struct RegionWorkspace {
-        FA_Global fa;
-        GB_Global gb;
-        VC_Global vc;
-        std::vector<atom> atoms_copy;
-        std::vector<resid> residue_copy;
-        GAContext ga_ctx;  // per-region GA state for re-entrant execution
-    };
-    RegionWorkspace create_workspace() const;
+    // Own the region's scoring scratch and atom/OptRes bindings. Other nested
+    // pointers are still borrowed, which is why region GAs must remain serial.
+    using RegionWorkspace = flexaids::RegionScoringWorkspace;
+    std::unique_ptr<RegionWorkspace> create_workspace() const;
 };

--- a/LIB/RegionScoringWorkspace.h
+++ b/LIB/RegionScoringWorkspace.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "AtomCopyExtent.h"
+#include "AtomOptResBinding.h"
+#include "GAContext.h"
+#include "Vcontacts.h"
+#include "gaboom.h"
+#include "ga_constants.h"
+#include <algorithm>
+#include <cstdlib>
+#include <new>
+#include <vector>
+
+namespace flexaids {
+
+// Scoring storage for one region. This does not establish complete ownership
+// of every nested FA/atom/residue object: region GAs still run serially.
+struct RegionScoringWorkspace {
+    FA_Global fa;
+    GB_Global gb;
+    VC_Global vc;
+    std::vector<atom> atoms_copy;
+    std::vector<resid> residue_copy;
+    std::vector<OptRes> optres;
+    std::vector<int> contacts, calclist, ca_index, seed, scorable;
+    std::vector<float> contributions;
+    std::vector<atomsas> calc;
+    std::vector<contactlist> contlist;
+    std::vector<ptindex> ptorder;
+    std::vector<vertex> centerpt, poly;
+    std::vector<plane> cont;
+    std::vector<edgevector> vedge;
+    GAContext ga_ctx;
+
+    RegionScoringWorkspace(const FA_Global& source_fa, const GB_Global& source_gb,
+                           const VC_Global& source_vc, const atom* atoms,
+                           const resid* residues)
+        : fa(source_fa), gb(source_gb), vc(source_vc),
+          atoms_copy(atoms, atoms + flexaid_one_based_copy_n(source_fa.atm_cnt)),
+          residue_copy(residues, residues + source_fa.res_cnt + 1),
+          contacts(CONTACTS_BUFFER_SIZE),
+          calclist(source_fa.atm_cnt_real), ca_index(source_fa.atm_cnt_real, -1),
+          seed(3 * source_fa.atm_cnt_real), scorable(source_fa.atm_cnt_real),
+          contributions(source_fa.ntypes * source_fa.ntypes), calc(source_fa.atm_cnt_real),
+          contlist(GA_CONTLIST_SIZE), ptorder(MAX_PT), centerpt(MAX_PT),
+          poly(MAX_POLY), cont(MAX_PT), vedge(MAX_POLY) {
+        // Never let an allocation failure transfer ownership of parent ca_rec.
+        // Allocate this last, after every operation that could otherwise throw.
+        vc.ca_rec = nullptr;
+        if (source_fa.num_optres > 0)
+            optres.assign(source_fa.optres, source_fa.optres + source_fa.num_optres);
+        const AtomOptResBinding binding(
+            std::span<const atom>(atoms + 1, source_fa.atm_cnt),
+            std::span<const OptRes>(source_fa.optres, source_fa.num_optres));
+        binding.bind(std::span<atom>(atoms_copy.data() + 1, source_fa.atm_cnt), optres);
+        fa.contacts = contacts.data();
+        fa.contributions = contributions.data();
+        fa.optres = optres.data();
+        vc.Calc = calc.data();
+        vc.Calclist = calclist.data();
+        vc.ca_index = ca_index.data();
+        vc.seed = seed.data();
+        vc.scorable_list = scorable.data();
+        vc.scorable_cap = source_fa.atm_cnt_real;
+        vc.n_scorable = 0;
+        vc.fastpath_used = 0;
+        vc.calc_count = 0;
+        vc.numcarec = 0;
+        vc.contlist = contlist.data();
+        vc.ptorder = ptorder.data();
+        vc.centerpt = centerpt.data();
+        vc.poly = poly.data();
+        vc.cont = cont.data();
+        vc.vedge = vedge.data();
+        // Vcontacts manages its thread-local indexed box cache. vindex==0
+        // allocates/frees a box per scoring call; neither case is ours to free.
+        vc.box = nullptr;
+        // save_areas() grows ca_rec with realloc: vector storage is invalid here.
+        vc.ca_recsize = std::max(source_vc.ca_recsize, 100);
+        vc.ca_rec = static_cast<ca_struct*>(
+            std::calloc(static_cast<std::size_t>(vc.ca_recsize), sizeof(ca_struct)));
+        if (!vc.ca_rec) throw std::bad_alloc();
+    }
+    ~RegionScoringWorkspace() { std::free(vc.ca_rec); }
+    RegionScoringWorkspace(const RegionScoringWorkspace&) = delete;
+    RegionScoringWorkspace& operator=(const RegionScoringWorkspace&) = delete;
+};
+
+}  // namespace flexaids

--- a/LIB/SerialRegionExecution.h
+++ b/LIB/SerialRegionExecution.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "RngSeed.h"
+#include <cstdint>
+#include <mutex>
+
+namespace flexaids {
+
+// Region GAs still reach nested shared state and process-global seed epochs.
+// This is the production manager's dispatcher, not a claim that arbitrary
+// callers of GA() elsewhere in the process are safe to run concurrently.
+inline std::mutex& region_execution_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+template<class RunRegion>
+void for_each_serial_region(int begin, int end, int stride, RunRegion&& run_region) {
+    std::lock_guard<std::mutex> lock(region_execution_mutex());
+    for (int region = begin; region < end; region += stride)
+        run_region(region);
+}
+
+// A prior region GA advances the process master seed. An explicit parent
+// protocol must take precedence over that mutable fallback on every run.
+inline bool resolve_region_parent_seed(int configured_seed, std::uint64_t& seed) {
+    if (configured_seed != 0) {
+        seed = static_cast<unsigned int>(configured_seed);
+        return true;
+    }
+    if (flexaids_rng::env_seed(seed)) return true;
+    if (!flexaids_rng::has_master_seed()) return false;
+    seed = flexaids_rng::master_seed();
+    return true;
+}
+
+// A pure function of parent seed and global region index: invariant to worker
+// scheduling and MPI rank assignment. GB_Global::seed needs a nonzero int.
+inline int region_seed(std::uint64_t parent_seed, int region_index) {
+    const auto mixed = flexaids_rng::splitmix64(
+        parent_seed + static_cast<std::uint64_t>(region_index));
+    return static_cast<int>(mixed % 2147483647ULL) + 1;
+}
+
+}  // namespace flexaids

--- a/LIB/Vcontacts.cpp
+++ b/LIB/Vcontacts.cpp
@@ -54,6 +54,22 @@ struct FastpathCache {
 	atomindex* box_ptr = nullptr;
 };
 
+// Cached vindex boxes belong to the worker thread, not a transient VC_Global.
+// Release allocations when that thread exits; destroying a map of raw pointers
+// alone would leak every box ever indexed by the worker.
+struct IndexedBoxCache {
+    std::map<std::string, atomindex*> indexed;
+    atomindex* previous_box = nullptr;
+    atomsas* owner_calc = nullptr;
+    atom* owner_atoms = nullptr;
+    resid* owner_residues = nullptr;
+
+    ~IndexedBoxCache()
+    {
+        for (const auto& entry : indexed) std::free(entry.second);
+    }
+};
+
 // The non-convergence failsafe perturbs the working coordinate and retries the
 // hull. These switches remain default OFF; parse them with the same spellings
 // as the other protocol gates. Read once per hull so config overlays take effect
@@ -433,8 +449,25 @@ int Vcontacts(FA_Global* FA,atom* atoms,resid* residue,VC_Global* VC,
 {
 	// Each OpenMP worker owns its indexing cache. Sharing these mutable objects
 	// races map insertion, box clearing, and prev_box updates across poses.
-	static thread_local std::map<std::string, atomindex*> indexed;
-	static thread_local atomindex* prev_box = NULL;
+	static thread_local IndexedBoxCache cache;
+	auto& indexed = cache.indexed;
+	auto& prev_box = cache.previous_box;
+	// TLS outlives individual scoring workspaces. Invalidate on A->B->A
+	// workspace switches as well as a newly constructed workspace, whose heap
+	// addresses can match its predecessor. A zero calc_count marks first use.
+	// The box allocations themselves remain owned by the thread cache.
+	const bool owner_changed = cache.owner_calc != VC->Calc ||
+	                           cache.owner_atoms != atoms ||
+	                           cache.owner_residues != residue;
+	if (VC->calc_count == 0 || owner_changed) {
+		g_fp.valid = false;
+		g_scorable.clear();
+		g_prev_sig.clear();
+		prev_box = nullptr;
+	}
+	cache.owner_calc = VC->Calc;
+	cache.owner_atoms = atoms;
+	cache.owner_residues = residue;
 	
 	//VC->planedef = 'X';  // extended radical plane (default)
 	//VC->planedef = 'R';  // radical plane

--- a/LIB/Vcontacts.cpp
+++ b/LIB/Vcontacts.cpp
@@ -54,143 +54,49 @@ struct FastpathCache {
 	atomindex* box_ptr = nullptr;
 };
 
-// ---------------------------------------------------------------------------
-// FAILSAFE VISIBILITY (log-only, DEFAULT OFF).
-//
-// WHY THIS EXISTS. calc_region()'s non-convergence failsafe (`edgenum >= 200`,
-// below) perturbs an atom's coordinates and recalculates the hull. Its only
-// diagnostic was a commented-out printf, so a run gives NO signal that it
-// fired; the sole trace is the aggregate FA->skipped counter. That failsafe is
-// the measured root cause of fixed-seed non-determinism on the flexible path:
-// the legacy branch draws its displacement from a THREAD_LOCAL RNG, and the GA
-// evaluates chromosomes under `#pragma omp parallel for schedule(dynamic)`
-// (gaboom.cpp:3282), so which thread — and hence which draw — a chromosome
-// gets is not reproducible. Because recalc==1 on the GA path (gaboom.cpp:3244)
-// the hull is recomputed WITH the perturbed coordinate, so the returned CF
-// depends on that draw. Measured firing counts explain the target specificity
-// exactly: 1P2Y 3575, 1OWE 233, 1JD0 170, 1OQ5 38 — and 1P2Y is the only one
-// of the four that is non-reproducible.
-//
-// DEFAULT-PRESERVING BY CONSTRUCTION. The env var is read ONCE into a function
-// static; unset means every diagnostic branch is dead and no coordinate,
-// score, or pose is touched. Proven, not asserted: pose-hash identity against
-// the unpatched baseline on 1P2Y at omp=1 (the deterministic configuration of
-// the target that fires this failsafe 3575 times).
-// ---------------------------------------------------------------------------
-// ---------------------------------------------------------------------------
-// PRISTINE-COORDINATE GUARD for the voronoi_poly2 non-convergence failsafe.
-// Gated by FLEXAIDDS_VCT_COORD_GUARD, DEFAULT OFF.
-//
-// THE DEFECT IT CLOSES, measured on 1P2Y (gen=1000, omp=1, seed 12345):
-//   18,771 failsafe firings across 10,762 voronoi_poly2 calls. 99.7% of those
-//   calls take ONE pass, but 26 calls take ten or more and two exceed a
-//   thousand; the worst reaches pass 1730. Those 26 calls produce 41% of all
-//   firings.
-//
-//   origcoor is re-saved from the CURRENT (already perturbed) coordinates on
-//   every pass, and zeroed at the top of RESTART. So:
-//     (a) a call taking N passes restores the coordinate as of pass N, leaving
-//         N-1 perturbations APPLIED -- up to 1729, RMS 0.21 A per axis;
-//     (b) a pass reaching the restore without re-entering the failsafe restores
-//         (0,0,0) and teleports the atom to the origin -- 79 occurrences;
-//     (c) the `return -1` exit restores nothing at all.
-//
-//   None of that self-heals, because the GA's per-chromosome reset is
-//   SELECTIVE: gaboom.cpp:3042 builds dirty_atm from mov[] and map_par[].atm --
-//   "atom indices modified by ic2cf" -- while this failsafe modifies whichever
-//   atom's hull failed. Measured perturbation set on 1P2Y: 11 ligand atoms
-//   (90001-90011) AND receptor atoms 743 and 2293. A leaked displacement on an
-//   atom outside dirty_atm survives in tl_atoms[tid] for the rest of the run,
-//   independently per thread -- which is a mechanism for thread-dependent
-//   divergence in its own right, distinct from the thread_local RNG draw.
-//
-// WHY A DESTRUCTOR AND NOT A CORRECTED ASSIGNMENT. The guard is ADDITIVE: it
-// does not touch the existing restore. arm() captures the pristine coordinate
-// on the FIRST failsafe pass and is a no-op afterwards, so no pass count can
-// lose the original; the destructor then runs at scope exit -- AFTER the legacy
-// restore and after every `return`, including `return -1` -- so it wins on
-// every exit path without that path having to know it exists. Unarmed, the
-// destructor is a no-op and behaviour is bit-identical to the unpatched engine.
-//
-// NOTE: this makes re-keying the keyed-jitter identity UNNECESSARY. The concern
-// was that arming once would freeze the value passed to pose_atom_identity, so
-// successive passes would apply an identical displacement and the loop could
-// never escape. Because the guard is additive, origcoor keeps its per-pass role
-// as the identity source and still varies pass to pass; only the FINAL restore
-// changes. The identity is deliberately left alone.
-// ---------------------------------------------------------------------------
-// ---------------------------------------------------------------------------
-// LOCAL-PERTURBATION MODE. Gated by FLEXAIDDS_VCT_LOCAL_PERTURB, DEFAULT OFF.
-// The CAUSE fix, where AtomCoordGuard is the symptom fix: instead of mutating
-// the shared atom array and restoring it, the failsafe perturbs a FUNCTION-LOCAL
-// copy that only the hull math reads. Nothing shared is written, so there is
-// nothing to restore, no `return -1` leak, no dirty_atm invariant to violate and
-// no thread interaction -- the defect class stops existing at this site rather
-// than being cleaned up after it.
-//
-// WHY IT IS THIS SMALL (measured, not assumed): the perturbed coordinate has
-// exactly ONE consumer in voronoi_poly2, the plane-normal setup. atomdist comes
-// from contlist[cai].dist, NOT recomputed from coordinates, and
-// save_seeds()/order_faces() read atom->coor zero times.
-//
-// FALSIFIABLE PREDICTION, recorded before the first run: this must reproduce
-// AtomCoordGuard's pose hash e19e6e5562661333 on 1P2Y (omp=1, gen=1000, seed
-// 12345) EXACTLY -- guard-on already means "perturbation visible to the hull,
-// pristine coordinate afterwards". A mismatch means one of the two is wrong and
-// is not to be written off as noise.
-// ---------------------------------------------------------------------------
+// The non-convergence failsafe perturbs the working coordinate and retries the
+// hull. These switches remain default OFF; parse them with the same spellings
+// as the other protocol gates. Read once per hull so config overlays take effect
+// without getenv calls inside the hull's edge loop.
 static bool vct_local_perturb_enabled()
 {
-    static const bool on = []() {
-        const char* raw = std::getenv("FLEXAIDDS_VCT_LOCAL_PERTURB");
-        return raw != nullptr && raw[0] != '\0' && raw[0] != '0';
-    }();
-    return on;
+    return flexaids::env_bool("FLEXAIDDS_VCT_LOCAL_PERTURB", false);
 }
 
 static bool vct_coord_guard_enabled()
 {
-    static const bool on = []() {
-        const char* raw = std::getenv("FLEXAIDDS_VCT_COORD_GUARD");
-        return raw != nullptr && raw[0] != '\0' && raw[0] != '0';
-    }();
-    return on;
+    return flexaids::env_bool("FLEXAIDDS_VCT_COORD_GUARD", false);
 }
 
-namespace {
+static bool vct_failsafe_diag()
+{
+    return flexaids::env_bool("FLEXAIDDS_VCT_FAILSAFE_DIAG", false);
+}
+
+// Input preservation is required even with the opt-in coordinate guard OFF.
+// Arm once before the first in-place perturbation, then restore on every exit.
+// A normal hull never arms this guard. Local perturbation never writes the atom.
 struct AtomCoordGuard {
-    float* coor  = nullptr;
-    float  saved[3] = {0.0f, 0.0f, 0.0f};
-    bool   armed = false;
+    float* coor = nullptr;
+    float saved[3] = {0.0f, 0.0f, 0.0f};
 
     AtomCoordGuard() = default;
     AtomCoordGuard(const AtomCoordGuard&) = delete;
     AtomCoordGuard& operator=(const AtomCoordGuard&) = delete;
 
-    /// Capture the pristine coordinate. ARM ONCE: later calls are no-ops.
     void arm(float* c) noexcept
     {
-        if (armed || c == nullptr) return;
+        if (coor != nullptr || c == nullptr) return;
         saved[0] = c[0]; saved[1] = c[1]; saved[2] = c[2];
-        coor = c; armed = true;
+        coor = c;
     }
 
     ~AtomCoordGuard()
     {
-        if (!armed || coor == nullptr) return;
+        if (coor == nullptr) return;
         coor[0] = saved[0]; coor[1] = saved[1]; coor[2] = saved[2];
     }
 };
-}  // namespace
-
-static bool vct_failsafe_diag()
-{
-    static const bool on = []() {
-        const char* raw = std::getenv("FLEXAIDDS_VCT_FAILSAFE_DIAG");
-        return raw != nullptr && raw[0] != '\0' && raw[0] != '0';
-    }();
-    return on;
-}
 
 thread_local FastpathCache g_fp;
 thread_local std::vector<int> g_scorable;
@@ -737,6 +643,16 @@ int calc_region(FA_Global* FA,VC_Global* VC,atom* atoms,int atmcnt,bool non_scor
  * created 08/07/2001  BJM
  ******************************/
 
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+namespace flexaids_vct_test {
+Trace& trace()
+{
+    static thread_local Trace state;
+    return state;
+}
+}  // namespace flexaids_vct_test
+#endif
+
 int voronoi_poly2(VC_Global *VC,int atomzero, plane cont[], float rado, 
                   int NC, const contactlist* contlist)
 {
@@ -767,28 +683,13 @@ int voronoi_poly2(VC_Global *VC,int atomzero, plane cont[], float rado,
     
 	// failsafe variables:
 	char   recalc;       // flag if hull is being recalculated (orig. unbounded)
-	float  origcoor[3];  // original pdb coordinates for atom. 
-	// PASS COUNTER (instrumentation). Declared BEFORE the RESTART label so it
-	// SURVIVES `goto RESTART` -- origcoor does NOT, and that lifetime mismatch
-	// is exactly the defect this counter exists to size. Always maintained,
-	// logged only under FLEXAIDDS_VCT_FAILSAFE_DIAG. An int increment touches
-	// no coordinate, no RNG and no score, so the default path stays
-	// bit-identical -- proven by pose-hash identity, not asserted.
-	//
-	// WHY A COUNTER AND NOT A LOG HEURISTIC: consecutive same-atom log lines
-	// conflate SEPARATE voronoi_poly2 calls, which put a spurious apparent max
-	// of 1864 passes on a single call. This is the honest per-call number, and
-	// it is what any bound on the RESTART loop must be sized from.
-	int    fs_pass = 0;  // failsafe passes taken by THIS voronoi_poly2 call
-	// Declared BEFORE the RESTART label so `goto RESTART` neither destroys nor
-	// re-constructs it: the label follows this declaration, so no scope is
-	// entered or left and the captured pristine coordinate survives every pass.
+	float  origcoor[3];  // per-pass reference for jitter identity/diagnostics only
+	int    fs_pass = 0;
+	// Lifetimes precede RESTART: neither the pristine input nor the accumulated
+	// working-copy perturbation is lost on a retry.
 	AtomCoordGuard coord_guard;
-	// LOCAL PERTURBATION WORKING COPY. Declared before RESTART so it accumulates
-	// across passes exactly as the legacy in-place perturbation does (pass N adds
-	// on top of pass N-1) without touching shared state. `azc` is chosen ONCE: in
-	// legacy mode it aims at the shared array, so reads through it are
-	// bit-identical to reading atom->coor, and it stays current as either mutates.
+	const bool coord_guard_requested = vct_coord_guard_enabled();
+	const bool failsafe_diag = vct_failsafe_diag();
 	float  az_coor[3] = {0.0f, 0.0f, 0.0f};
 	const bool az_local = vct_local_perturb_enabled() &&
 	                      VC->Calc[atomzero].atom != nullptr;
@@ -799,9 +700,22 @@ int voronoi_poly2(VC_Global *VC,int atomzero, plane cont[], float rado,
 	}
 	const float* const azc = az_local ? az_coor
 	                                  : VC->Calc[atomzero].atom->coor;
+	// Retain the old guard option as eager capture. The default path captures
+	// lazily at the first mutation instead; both restore the pristine input.
+	if (!az_local && coord_guard_requested)
+		coord_guard.arm(VC->Calc[atomzero].atom->coor);
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+	auto& trace = flexaids_vct_test::trace();
+	trace.local_mode = az_local;
+	trace.coord_guard_requested = coord_guard_requested;
+	trace.diagnostics_enabled = failsafe_diag;
+#endif
     
 	recalc = 'N';
 RESTART:
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+	++trace.hull_passes;
+#endif
 	planeA = -1;
 	planeB = -1;
 	planeC = -1;
@@ -1001,12 +915,21 @@ RESTART:
             
 			// ===== failsafe - if solution is not converging, perturb atom  =====
 			// ===== coordinates and recalculate.                            =====
-			if(edgenum >= 200) {
+			int failsafe_edgenum = edgenum;
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+			// Fault injection changes only the trigger. Tests execute this actual
+			// failsafe, jitter, RESTART, completed hull and return paths below.
+			if (trace.force_failsafe_passes > 0) {
+				--trace.force_failsafe_passes;
+				failsafe_edgenum = 200;
+			}
+#endif
+			if(failsafe_edgenum >= 200) {
 				++fs_pass;
-				// Pointless in local mode: nothing shared is written, so there is nothing
-				// to restore. Left UN-armed rather than armed-and-inert so the two
-				// mechanisms cannot be confused in a log.
-				if (!az_local && vct_coord_guard_enabled() && VC->Calc[atomzero].atom)
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+				++trace.failsafe_entries;
+#endif
+				if (!az_local)
 					coord_guard.arm(VC->Calc[atomzero].atom->coor);
 				//printf("********* invalid solution for hull, recalculating *********\n");
 				VC->seed[atomzero*3] = -1;  // reset to no seed vertex
@@ -1050,20 +973,25 @@ RESTART:
 				// Reports which branch supplied the displacement and its actual
 				// magnitude, so the legacy branch's thread-dependence is
 				// observable rather than inferred.
-				if (vct_failsafe_diag()) {
+				if (failsafe_diag) {
 					const int anum_d = VC->Calc[atomzero].atom
 						? VC->Calc[atomzero].atom->number : atomzero;
 					fprintf(stderr,
 						"[VCT-FAILSAFE] fire atom=%d edgenum=%d pass=%d branch=%s "
 						"d=(%.6f,%.6f,%.6f)\n",
-						anum_d, edgenum, fs_pass,
+						anum_d, failsafe_edgenum, fs_pass,
 						flexaids_rng::voronoi_keyed_jitter_enabled() ? "keyed" : "legacy",
-						VC->Calc[atomzero].atom->coor[0] - origcoor[0],
-						VC->Calc[atomzero].atom->coor[1] - origcoor[1],
-						VC->Calc[atomzero].atom->coor[2] - origcoor[2]);
+						azc[0] - origcoor[0],
+						azc[1] - origcoor[1],
+						azc[2] - origcoor[2]);
 				}
                 
-				// *** NEW ***
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+				for (int axis = 0; axis < 3; ++axis) {
+					trace.working_after_perturb[axis] = azc[axis];
+					trace.input_after_perturb[axis] = VC->Calc[atomzero].atom->coor[axis];
+				}
+#endif
                 
 				// Do not recalc
 				if (VC->recalc) {
@@ -1077,6 +1005,9 @@ RESTART:
                 
 				// Abort immediately Scoring
                 
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+				++trace.error_exits;
+#endif
 				return -1;
 			}
 		}
@@ -1153,38 +1084,14 @@ RESTART:
     
 	if(recalc == 'N') {
 		save_seeds(VC->seed,cont, VC->poly, vn, atomzero);
-	} else {
-		// LATENT-BUG GUARD (log-only, dead unless the diag env var is set).
-		//
-		// origcoor is zeroed at the top of RESTART and only re-populated inside
-		// the failsafe block. So a pass arriving here with recalc=='Y' WITHOUT
-		// having re-entered the failsafe would restore (0,0,0) and teleport the
-		// atom to the origin -- tens of Angstroms outside the coordinate box.
-		//
-		// This is a source-reading concern, NOT an observed one. Measured on the
-		// receptor as actually scored (written via
-		// FLEXAIDDS_WRITE_FLEXED_RECEPTOR, 4,169 atoms in common with the apo
-		// input): ZERO atoms moved. And 9,672 atoms across 283 campaign pose
-		// files had none closer than 41 A to the origin. So the path appears
-		// unreachable in practice. This guard makes that OBSERVABLE rather than
-		// assumed, and deliberately does NOT alter the restore: changing
-		// behaviour on a path never seen to fire would reprice results for no
-		// measured benefit.
-		if (vct_failsafe_diag()
-		    && origcoor[0] == 0.0f && origcoor[1] == 0.0f && origcoor[2] == 0.0f) {
-			fprintf(stderr,
-				"[VCT-FAILSAFE] *** origcoor==(0,0,0) at restore, atom=%d pass=%d: "
-				"this restore TELEPORTS THE ATOM TO THE ORIGIN\n",
-				VC->Calc[atomzero].atom
-					? VC->Calc[atomzero].atom->number : atomzero,
-				fs_pass);
-		}
-		// reset atom coordinates to original values
-		VC->Calc[atomzero].atom->coor[0] = origcoor[0];
-		VC->Calc[atomzero].atom->coor[1] = origcoor[1];
-		VC->Calc[atomzero].atom->coor[2] = origcoor[2];
 	}
-    
+	// Do not restore from origcoor: it belongs to a single retry pass, and is
+	// zero on a final successful pass. The guard owns the pristine coordinate;
+	// local mode intentionally performs no writes to the real atom at all.
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+	++trace.success_exits;
+#endif
+
 	return(vn);
 }
 

--- a/LIB/Vcontacts.h
+++ b/LIB/Vcontacts.h
@@ -204,6 +204,26 @@ std::string  generate_dim_sig(float* global_min, int dim);
 void        vc_publish_scorable(VC_Global* VC);
 const int*  vc_scorable_indices(int* n);
 bool        vc_fastpath_active();
+
+#ifdef FLEXAIDS_VCONTACTS_TEST_HOOKS
+// Test-only fault injection and receipts for the production hull retry path.
+// This interface and its instrumentation do not exist in engine builds.
+namespace flexaids_vct_test {
+struct Trace {
+    int force_failsafe_passes = 0;
+    int hull_passes = 0;
+    int failsafe_entries = 0;
+    int success_exits = 0;
+    int error_exits = 0;
+    bool local_mode = false;
+    bool coord_guard_requested = false;
+    bool diagnostics_enabled = false;
+    float working_after_perturb[3] = {};
+    float input_after_perturb[3] = {};
+};
+Trace& trace();
+}
+#endif
 // ========================================================================
 
 /*

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -1,5 +1,6 @@
 #include "gaboom.h"
 #include "GaPopulationReceipt.h"
+#include "GaEliteBuffer.h"
 #include "Vcontacts.h"
 #include "fileio.h"
 #include "coarse_init.h"
@@ -696,9 +697,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 	const int n_elite = (GB->n_elite > 0)
 	                    ? std::min(GB->n_elite, GB->num_chrom)
 	                    : 0;
-	std::vector<gene>   elite_genes_buf(static_cast<size_t>(n_elite) * GB->num_genes);
-	std::vector<cfstr>  elite_cf_buf(n_elite);
-	std::vector<double> elite_eval_buf(n_elite), elite_app_buf(n_elite);
+	flexaids::GaEliteBuffer elite_buffer(n_elite, GB->num_genes);
 	if (n_elite > 0)
 		fprintf(stderr, "[ELITE] GA-internal elitism active: protecting %d "
 		        "lowest-CF individual(s) per generation\n", n_elite);
@@ -1144,27 +1143,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 		// the global best survives both.  Restored over the worst of the new
 		// population right after reproduce() below.  evalue is the (non-apparent)
 		// CF; lower = better pose.
-		if (n_elite > 0) {
-			// Simple CF-minimum elite selection (v31+).
-			// ε-tiebreaker reverted: IC-space distance to opt_par is unreliable for
-			// already-converged poses (IC≠Cartesian proximity; nonlinear FK map +
-			// angular degeneracy). v30 ablation: net-neutral with 6 regressions on
-			// previously-perfect targets (0.00→2-6Å). Revert to plain CF sort.
-			std::vector<int> eidx(GB->num_chrom);
-			for (int q = 0; q < GB->num_chrom; ++q) eidx[q] = q;
-			std::partial_sort(eidx.begin(), eidx.begin() + n_elite, eidx.end(),
-				[&](int a, int b){
-					return (*chrom)[a].evalue < (*chrom)[b].evalue;
-				});
-			for (int e = 0; e < n_elite; ++e) {
-				const chromosome& src = (*chrom)[eidx[e]];
-				elite_cf_buf[e]   = src.cf;
-				elite_eval_buf[e] = src.evalue;
-				elite_app_buf[e]  = src.app_evalue;
-				for (int g = 0; g < GB->num_genes; ++g)
-					elite_genes_buf[static_cast<size_t>(e) * GB->num_genes + g] = src.genes[g];
-			}
-		}
+		elite_buffer.capture(*chrom, GB->num_chrom);
 
 		// ── P5: periodic BOOM random injection (diversity insurance) ──
 		// Every boom_inject_interval generations, replace the worst
@@ -1255,24 +1234,7 @@ int GA(FA_Global* FA, GB_Global* GB,VC_Global* VC,chromosome** chrom,chromosome*
 		// over sharing-reduced fitness).  Overwrite the n_elite WORST individuals
 		// (highest evalue) of the new generation with the elites captured before
 		// boom/sharing, guaranteeing the running best is carried forward intact.
-		if (n_elite > 0) {
-			std::vector<int> widx(GB->num_chrom);
-			for (int q = 0; q < GB->num_chrom; ++q) widx[q] = q;
-			std::partial_sort(widx.begin(), widx.begin() + n_elite, widx.end(),
-				[&](int a, int b){ return (*chrom)[a].evalue > (*chrom)[b].evalue; });
-			for (int e = 0; e < n_elite; ++e) {
-				chromosome& dst = (*chrom)[widx[e]];
-				dst.cf              = elite_cf_buf[e];
-				dst.evalue          = elite_eval_buf[e];
-				dst.app_evalue      = elite_app_buf[e];
-				dst.fitnes          = 0.0;   // recomputed next reproduce()
-				dst.boltzmann_weight = 0.0;
-				dst.free_energy     = 0.0;
-				dst.status          = 'n';   // CF is valid (deep-copied) — no re-eval
-				for (int g = 0; g < GB->num_genes; ++g)
-					dst.genes[g] = elite_genes_buf[static_cast<size_t>(e) * GB->num_genes + g];
-			}
-		}
+		elite_buffer.restore(*chrom, GB->num_chrom);
 
 		// Fix 6: write snapshots COMPACTLY (stride = save_num_chrom), so the
 		// writer's layout matches what the post-GA thermo reader consumes.

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -3165,14 +3165,10 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			// fields: scorable_list, n_scorable, scorable_cap, fastpath_used).
 			std::vector<std::vector<int>>         tl_scorable;
 		};
-		thread_local ParEvalWS ws;  // resident across generations on THIS thread.
-		                       // Must not be process-wide static: --parallel-dock
-		                       // runs GA() under an outer OpenMP parallel-for
-		                       // (ParallelDock.cpp). A shared static races on
-		                       // rebuild and tl_* buffers. Inner eval still
-		                       // shares this thread's tl_* via references
-		                       // captured before the inner omp for, so the
-		                       // serial claim path is unchanged.
+		thread_local ParEvalWS ws;  // Resident across generations on this caller.
+		// Inner evaluators share only this caller's buffers. ParallelDock now
+		// serializes region GAs; thread_local alone never established complete
+		// region ownership of inline scoring buffers or global RNG epochs.
 
 		const bool ws_valid =
 			ws.n_thr == n_thr && ws.natm == natm && ws.nres == nres &&
@@ -3257,8 +3253,12 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 			// Keep optres non-cf fields in sync with the reference (cf fields are
 			// cleared per-chromosome in the eval loop below).
 			std::copy(FA->optres, FA->optres + nopt, tl_optres[t].begin());
+			// A new Calc array has no index; a resident one keeps its own count,
+			// never the parent's. Vcontacts uses zero to invalidate its TLS cache.
+			const int retained_calc_count = ws_valid ? tl_vc[t].calc_count : 0;
 			// Refresh the cheap live VC snapshot, then redirect VC scratch.
 			tl_vc[t] = *VC;
+			tl_vc[t].calc_count = retained_calc_count;
 			tl_vc[t].Calc      = tl_calc[t].data();
 			tl_vc[t].Calclist  = tl_calclist[t].data();
 			tl_vc[t].ca_index  = tl_caidx[t].data();
@@ -4205,6 +4205,7 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 			p_fa[t].contributions = p_contrib[t].data();
 			p_fa[t].optres        = p_optres[t].data();
 			p_vc[t].Calc      = p_calc[t].data();
+			p_vc[t].calc_count = 0;  // fresh Calc storage, independent of parent index
 			p_vc[t].Calclist  = p_calclist[t].data();
 			p_vc[t].ca_index  = p_caidx[t].data();
 			p_vc[t].scorable_list = p_scorable[t].data();

--- a/LIB/gaboom.cpp
+++ b/LIB/gaboom.cpp
@@ -1,6 +1,7 @@
 #include "gaboom.h"
 #include "GaPopulationReceipt.h"
 #include "GaEliteBuffer.h"
+#include "GaEvaluationPolicy.h"
 #include "Vcontacts.h"
 #include "fileio.h"
 #include "coarse_init.h"
@@ -3020,11 +3021,7 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 	// (guarded by omp_in_parallel() in ic2cf.cpp) to avoid concurrent
 	// linked-list corruption; DEE pruning still operates in serial calls.
 	{
-#ifdef _OPENMP
-		const int n_thr = omp_get_max_threads();
-#else
-		const int n_thr = 1;
-#endif
+		const int n_thr = flexaids::ga_evaluation_threads();
 		const int natm  = FA->atm_cnt;
 		const int natmr = FA->atm_cnt_real;
 		const int nres  = FA->res_cnt;
@@ -3293,64 +3290,10 @@ void calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chr
 		}
 		const int n_optres_atoms = (int)optres_atom_list.size();
 
-		// ── FLEXAID_DETERMINISTIC (P3 · CI A/B reproducibility) ──────────────
-		// When set, the parallel CF-eval loop runs on a single thread so its
-		// reduction order is serial-equivalent and bit-reproducible run-to-run
-		// (each chromosome writes only its own chrom[ii].cf, so 1-thread ==
-		// deterministic order). Enabled by the compile-time macro
-		// -DFLEXAID_DETERMINISTIC or by env FLEXAID_DETERMINISTIC=<non-empty,
-		// not "0">. See FLEXAID_FAST_DOCKING_PLAN P3/4.3.
-		//
-		// CORRECTED 2026-09-07. This comment previously described the default
-		// multi-thread path as accepting "the ~0.2% chromosome-level numeric
-		// drift documented in OPTIMIZATION_KNOWN_ISSUES.md". THAT CITATION WAS
-		// MISATTRIBUTED: the 0.2% figure in that document belongs to the
-		// FLEXAIDDS_PARALLEL_REPRODUCE (Opt1) section and is explicitly called
-		// flag-ON specific there; the same document measures flag-OFF at 4
-		// threads as REPRODUCIBLE. So the number never described this path.
-		//
-		// WHAT IS ACTUALLY MEASURED about the default (flag-unset) path, on the
-		// FLEXIBLE-sidechain arm, 1P2Y, gen=1000, FLEXAID_SEED=12345, with
-		// FLEXAIDDS_PARALLEL_REPRODUCE unset:
-		//   omp=3  per-restart pose-set jaccard 0.976 / 0.000 / 0.138
-		//          -> NOT reproducible; best CF ranged -254.86 to -230.86
-		//             across four runs of identical inputs
-		//   omp=1  jaccard 1.000 / 1.000 / 1.000 -> reproducible
-		// That is a different GA trajectory, not a rounding difference. Cause:
-		// the Voronoi non-convergence failsafe (Vcontacts.cpp) draws its
-		// coordinate perturbation from a THREAD_LOCAL RNG, and this loop is
-		// schedule(dynamic), so which thread -- and therefore which draw -- a
-		// chromosome receives is not reproducible. recalc==1 here means the hull
-		// is recomputed WITH the perturbed coordinate, so the returned CF depends
-		// on that draw. It is target-specific via the failsafe firing rate:
-		// 1P2Y fires 3575 times against a median of 42 across the 84-target set,
-		// a 15x outlier with no target in between.
-		//
-		// Setting this flag SUPPRESSES that divergence (eval_threads=1 removes the
-		// scheduling variable) but does not fix it, and pays for determinism by
-		// serialising evaluation. The cause is addressed by
-		// FLEXAIDDS_VCT_COORD_GUARD in Vcontacts.cpp, which keeps the threads.
-		static const bool deterministic_eval = [](){
-#ifdef FLEXAID_DETERMINISTIC
-			return true;
-#else
-			const char* env = std::getenv("FLEXAID_DETERMINISTIC");
-			return env && env[0] != '\0' && env[0] != '0';
-#endif
-		}();
-#ifdef _OPENMP
-		const int eval_threads = deterministic_eval ? 1 : n_thr;
-#else
-		// Scalar build: exactly one evaluation thread by construction.
-		// DECLARED IN BOTH BRANCHES DELIBERATELY. The selective-reset invariant
-		// checker below reads eval_threads unconditionally (std::min against
-		// tl_atoms.size()), so confining the declaration to the _OPENMP branch
-		// made an OpenMP-OFF build fail to COMPILE. The checker's runtime env
-		// gate cannot prevent that: a flag guards execution, not translation.
-		// The Eigen compile failure in test_cf_aggregator masked this on every
-		// CI lane. Found by external audit (CORE-1).
-		const int eval_threads = 1;
-#endif
+		// Generation zero and later evaluation use the same effective count.
+		// One worker removes scheduling-dependent jitter-stream assignment; it
+		// does not claim that coordinate guards alone make parallel GA deterministic.
+		const int eval_threads = n_thr;
 		const bool record_initial_workers = flexaids::ga_population_observation_active();
 		std::vector<flexaids::GaPopulationWorkerReceipt> initial_workers(
 		    record_initial_workers ? n_thr : 0);
@@ -4220,11 +4163,7 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 	// calculate evalue for each chromosome — thread-safe OpenMP parallel eval.
 	// Uses the same per-thread VC/atoms/FA workspace strategy as calculate_fitness.
 	{
-#ifdef _OPENMP
-		const int n_thr = omp_get_max_threads();
-#else
-		const int n_thr = 1;
-#endif
+		const int n_thr = flexaids::ga_evaluation_threads();
 		const int natm  = FA->atm_cnt;
 		const int natmr = FA->atm_cnt_real;
 		const int nres  = FA->res_cnt;
@@ -4332,8 +4271,8 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
 		const int p_n_dirty_res = static_cast<int>(p_dirty_res_idx.size());
 
 #ifdef _OPENMP
-#pragma omp parallel for schedule(dynamic) default(none) \
-	shared(p_record_initial_workers, p_initial_workers) \
+#pragma omp parallel for schedule(dynamic) num_threads(n_thr) default(none) \
+	shared(p_record_initial_workers, p_initial_workers, n_thr) \
 	shared(chrom, FA, GB, VC, gene_lim, atoms, residue, cleftgrid, target, \
 	       popoffset, p_atoms, p_res, p_fa, p_optres, p_vc, natm, nres, nopt, \
 	       n_receptor_chains, p_use_selective, p_dirty_atm, p_dirty_res_idx, \

--- a/LIB/gaboom.h
+++ b/LIB/gaboom.h
@@ -314,7 +314,7 @@ void populate_chromosomes(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* 
                         std::function<int32_t()> &,
                         std::unordered_map<size_t, int> &);
 cfstr 	eval_chromosome(FA_Global* FA,GB_Global* GB,VC_Global* VC,const genlim* gene_lim,atom* atoms,resid* residue,gridpoint* cleftgrid,gene* john, cfstr (*function)(FA_Global*,VC_Global*,atom*,resid*,gridpoint*,int,double*));
-void  	calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chrom, const genlim* gene_lim,atom* atoms,resid* residue,gridpoint* cleftgrid,char method[],int pop_size, int print, cfstr (*target)(FA_Global*,VC_Global*,atom*,resid*,gridpoint*,int, double*));
+void  	calculate_fitness(FA_Global* FA,GB_Global* GB,VC_Global* VC,chromosome* chrom, const genlim* gene_lim,atom* atoms,resid* residue,gridpoint* cleftgrid,char method[],int pop_size, int print, cfstr (*target)(FA_Global*,VC_Global*,atom*,resid*,gridpoint*,int, double*), GAContext& ctx);
 int reproduce(FA_Global* FA,GB_Global* GB,VC_Global* VC, chromosome* chrom,
              const genlim* gene_lim,atom* atoms,resid* residue,gridpoint* cleftgrid,
              char rmodel[], double mutprob, double crossprob, int print,

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -168,6 +168,35 @@ Rules that follow:
 
 ## 0.2 Provenance — what a receipt must capture
 
+### Audit repair contract (September 2026)
+
+Dataset-runner rates use a declared target roster, including failed, empty, and absent
+targets. Astex claim scoring pins `benchmarks/protocols/astex85_target_manifest.json`
+(85 targets); an execution list of 84 targets does not change that claim denominator.
+Record both the executed roster and the expected roster with the scorer revision. Score
+comparison arms together with that revision and roster; do not compare pre-fix and post-fix
+rates. Checkpoint completion is distinct from scientific success, and resume must restore
+the observations used by the fresh-run metrics and quality verdict. Incompatible checkpoint
+schemas or protocol/input fingerprints require a separate output namespace.
+
+The Python entropy ranking objective is explicitly selectable: `cf_minus_ts` computes
+`CF - temperature_K * entropy_kcal_per_mol_K`; `legacy_cf_minus_s` is a labelled diagnostic
+compatibility objective. Neither quantity is the ensemble Helmholtz free energy or the
+engine's soft-beta score. Record CF, S, temperature, and objective separately. Nonzero S
+requires a valid temperature. A temperature-dependent ranking-reversal regression and a
+zero-entropy invariance regression gate this correction. Report the emitted generator
+top-1 independently from entropy reranking and the any-pose sampling ceiling.
+
+Experimental `--parallel-dock` regions execute serially inside each process while retaining
+inner evaluator OpenMP and independent MPI ranks. This serializes region managers, not
+unrelated direct callers of `GA()`. Owned region scoring scratch and
+region-specific seeds repair shared mutable state; no historical pose parity or throughput
+claim follows from this repair. Default process-isolated benchmark binaries remain frozen.
+The local repair validation uses one build/test job at a time while the priority benchmark
+runs. Scientific parity and accuracy gates below still apply before a merge or campaign use.
+
+### Receipt tiers
+
 Three tiers, by how a parameter can be recovered after the fact:
 
 | tier | example | recoverable from |

--- a/docs/benchmark-observation-integrity.md
+++ b/docs/benchmark-observation-integrity.md
@@ -1,0 +1,25 @@
+# DatasetRunner scorer identity
+
+The canonical measurement contract is [METHODOLOGY.md](../METHODOLOGY.md).
+
+The corrected default `--ranking-objective cf_minus_ts` computes the explicitly
+named CF-T*S reranking proxy using each pose's emitted temperature. It is
+neither the ensemble free-energy ledger nor a true binding free energy.
+`--ranking-objective legacy_cf_minus_s` is an explicit, dimensionally incorrect
+diagnostic objective for comparison. Nonzero S without an emitted finite,
+positive T refuses the election. Zero S leaves CF unchanged and requires no
+invented temperature.
+
+Pose records preserve CF, raw S, emitted T, T*S, ensemble mean energy, ensemble
+free energy, soft_beta_G, emitted TOTAL_SCORE, generator rank and original
+binding-mode ID separately. Generator rank follows the final numeric output
+filename suffix; cluster identity may disagree after DensityPeak sorting.
+Missing elected output remains a generator miss rather than promoting a later
+rank. The generator_docking_power_top1 endpoint follows that election; the
+entropy_reranked_docking_power_top1 and historical docking_power_top1 keys use
+the declared Python proxy. Synthetic dry runs suppress all docking-power keys.
+
+Regression fixtures establish temperature dependence, a scalar ranking reversal,
+unchanged zero-entropy scores, numeric generator election despite disagreeing
+cluster IDs, and refusal to substitute a later output for missing rank zero.
+These are software checks, not measured molecular-performance changes.

--- a/docs/benchmark-observation-integrity.md
+++ b/docs/benchmark-observation-integrity.md
@@ -1,9 +1,43 @@
-# DatasetRunner scorer identity
+# DatasetRunner observation and scorer identity
 
 The canonical measurement contract is [METHODOLOGY.md](../METHODOLOGY.md).
+These notes describe the BENCH-1/2/3 implementation, not docking-success claims.
+
+`docking_power_top1` and `docking_power_top3` retain their target-level unit.
+Their denominator is the declared target roster, including targets with missing
+inputs, empty output or failed execution. Reports preserve the target/state
+roster and distinguish absent-output observations from engine failures. Mixed
+states for the same target are refused before execution; select one state per
+run with `run_dataset(..., structural_states=[state])` rather than pool states.
+Bootstrap intervals resample declared targets, including empty observations,
+and retain each target's full pose election.
+
+For a frozen denominator use the existing manifest explicitly:
+
+```text
+--expected-target-manifest benchmarks/protocols/astex85_target_manifest.json
+```
+
+The manifest's dataset, N, unique identities and declared sorted-code digest are
+validated. Targets absent from execution remain failures in the denominator.
+Both manifest file-byte SHA256 and sorted-code SHA256 are recorded. The input
+manifest is read without alteration; no second roster is created.
+
+`--resume` restores every schema-2 cached observation, including recorded
+failures, and recomputes metrics and gates over fresh plus restored evidence.
+Early-termination records, failure exit codes and timeouts survive resume.
+Checkpoint compatibility binds the selected roster, dataset configuration,
+engine hash, Python scorer source hashes, temperature, objective, relevant
+runtime environment and input file hashes. Old, malformed or incompatible
+checkpoints fail before dispatch. Baseline changes may reuse compatible
+observations but always recompute the verdict. To retry a previously failed
+observation or change protocols, use a new results namespace; do not erase or
+reinterpret frozen evidence.
+Manifest labels use canonical target IDs; checkpoint discovery retains the
+scheduled ID spelling, including on case-sensitive filesystems.
 
 The corrected default `--ranking-objective cf_minus_ts` computes the explicitly
-named CF-T*S reranking proxy using each pose's emitted temperature. It is
+named **CF-T*S reranking proxy** using each pose's emitted temperature. It is
 neither the ensemble free-energy ledger nor a true binding free energy.
 `--ranking-objective legacy_cf_minus_s` is an explicit, dimensionally incorrect
 diagnostic objective for comparison. Nonzero S without an emitted finite,
@@ -11,15 +45,17 @@ positive T refuses the election. Zero S leaves CF unchanged and requires no
 invented temperature.
 
 Pose records preserve CF, raw S, emitted T, T*S, ensemble mean energy, ensemble
-free energy, soft_beta_G, emitted TOTAL_SCORE, generator rank and original
-binding-mode ID separately. Generator rank follows the final numeric output
-filename suffix; cluster identity may disagree after DensityPeak sorting.
-Missing elected output remains a generator miss rather than promoting a later
-rank. The generator_docking_power_top1 endpoint follows that election; the
-entropy_reranked_docking_power_top1 and historical docking_power_top1 keys use
-the declared Python proxy. Synthetic dry runs suppress all docking-power keys.
+free energy, `soft_beta_G`, any emitted `TOTAL_SCORE`, and generator rank as
+separate fields. Generator rank follows the final numeric output filename
+suffix. `binding_mode` is retained as cluster identity: DensityPeak keeps its
+original IDs after sorting the output election. An absent elected rank remains
+a generator miss, even if a later output is near-native.
+`generator_docking_power_top1` follows the emitted election;
+`entropy_reranked_docking_power_top1` and the historical `docking_power_top1`
+key use the declared Python proxy objective. Synthetic dry runs suppress all
+docking-power endpoints. No RMSD-only endpoint is a validated docking claim.
 
-Regression fixtures establish temperature dependence, a scalar ranking reversal,
-unchanged zero-entropy scores, numeric generator election despite disagreeing
-cluster IDs, and refusal to substitute a later output for missing rank zero.
-These are software checks, not measured molecular-performance changes.
+The repair's regression fixtures establish temperature dependence, a scalar
+ranking reversal, unchanged zero-entropy scores, fixed denominator accounting,
+identical fresh/full/partial-resume verdicts, and refusal of incompatible caches.
+They do not establish a change in real molecular performance.

--- a/python/flexaidds/dataset_runner/cli.py
+++ b/python/flexaidds/dataset_runner/cli.py
@@ -170,6 +170,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Simulation temperature in Kelvin (default: 300).",
     )
     p.add_argument(
+        "--ranking-objective", choices=("cf_minus_ts", "legacy_cf_minus_s"),
+        default="cf_minus_ts",
+        help="Python reranking proxy: CF-T*S using emitted T (default), or legacy dimensionally incorrect CF-S for diagnostics. Generator election is reported separately.",
+    )
+    p.add_argument(
         "--entry-timeout-seconds",
         type=int,
         default=None,
@@ -381,6 +386,7 @@ def main(argv: list[str] | None = None) -> int:
         command_line=full_command,
         default_conc_M=getattr(args, 'default_conc_M', 1.0),
         entry_timeout_seconds=getattr(args, 'entry_timeout_seconds', None),
+        ranking_objective=args.ranking_objective,
     )
     if args.datasets_dir is not None:
         runner_kwargs["datasets_dir"] = args.datasets_dir

--- a/python/flexaidds/dataset_runner/cli.py
+++ b/python/flexaidds/dataset_runner/cli.py
@@ -175,6 +175,10 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Python reranking proxy: CF-T*S using emitted T (default), or legacy dimensionally incorrect CF-S for diagnostics. Generator election is reported separately.",
     )
     p.add_argument(
+        "--expected-target-manifest", default=None, metavar="JSON",
+        help="Pin the declared denominator to an existing dataset/N/targets manifest; absent execution rows count as failures.",
+    )
+    p.add_argument(
         "--entry-timeout-seconds",
         type=int,
         default=None,
@@ -254,17 +258,8 @@ def _benchmark_inconclusive_reasons(datasets) -> list[str]:
     reasons: list[str] = []
     for dr in datasets:
         slug = dr.config.slug
-        # Gates 2-3 judge only a run whose empty output is meaningful. Three
-        # cases (executed = targets run this session, resumed = checkpoints):
-        #   executed > 0             → fresh work; judge it.
-        #   executed == 0, resumed>0 → pure --resume/package-regen; poses live in
-        #                              checkpoints not all_poses, so skip — else
-        #                              a successful resume re-inverts the gate.
-        #   executed == 0, resumed==0→ the run scheduled NOTHING (empty tier, bad
-        #                              filter). Zero poses is meaningful: judge it,
-        #                              so a no-op cannot pass silently.
-        # Liveness still applies unconditionally — a non-zero exit can only have
-        # come from a target that did run.
+        # Resumed observations, metrics and execution evidence are restored.
+        # All scientific gates therefore apply equally to fresh and cached work.
         executed = getattr(dr, "newly_executed", None)
         if executed is None:  # tolerate objects predating the field
             executed = len(dr.targets_completed) + len(dr.targets_failed)
@@ -298,16 +293,13 @@ def _benchmark_inconclusive_reasons(datasets) -> list[str]:
                 f"did not complete successfully (None = no exit code produced: "
                 f"exec failure or timeout) [{codes}]"
             )
-        # 2. Productivity — only a run that executed targets can be faulted for
-        #    producing no poses (a resume/no-op executed nothing this session).
-        if executed > 0 and dr.total_poses == 0 and slug not in allow_empty:
+        # 2. Productivity — a declared run must contain observed poses.
+        if (executed > 0 or resumed > 0) and dr.total_poses == 0 and slug not in allow_empty:
             reasons.append(
-                f"{slug}: productivity — 0 poses across {executed} executed target(s)"
+                f"{slug}: productivity — 0 poses across {executed + resumed} observed target(s)"
             )
-        # 3. Completeness — declared baselines left unmeasured fail, UNLESS this
-        #    was a legitimate resume (executed==0 but resumed>0), where the
-        #    metrics live in checkpoints rather than this session's output.
-        if (executed > 0 or resumed == 0) and dr.inconclusive_metrics:
+        # 3. Completeness — every declared baseline needs a reconstructed metric.
+        if dr.inconclusive_metrics:
             reasons.append(
                 f"{slug}: completeness — baselines never measured: "
                 + ", ".join(dr.inconclusive_metrics)
@@ -387,6 +379,7 @@ def main(argv: list[str] | None = None) -> int:
         default_conc_M=getattr(args, 'default_conc_M', 1.0),
         entry_timeout_seconds=getattr(args, 'entry_timeout_seconds', None),
         ranking_objective=args.ranking_objective,
+        expected_target_manifest=args.expected_target_manifest,
     )
     if args.datasets_dir is not None:
         runner_kwargs["datasets_dir"] = args.datasets_dir

--- a/python/flexaidds/dataset_runner/metrics.py
+++ b/python/flexaidds/dataset_runner/metrics.py
@@ -359,6 +359,8 @@ def docking_power(
             n_success += 1
 
     denom = n_targets if n_targets is not None else len(by_target)
+    if denom < len(by_target):
+        raise ValueError("Docking denominator is smaller than the observed roster")
     return n_success / denom if denom > 0 else 0.0
 
 

--- a/python/flexaidds/dataset_runner/metrics.py
+++ b/python/flexaidds/dataset_runner/metrics.py
@@ -43,7 +43,7 @@ class PoseScore:
         enthalpy_score:     Contact-function score *without* entropy correction (kcal/mol).
                             Lower = better binding.
         entropy_correction: TΔS contribution (kcal/mol, positive = entropy-favoured).
-        total_score:        enthalpy_score − entropy_correction (final ranking score).
+        total_score:        Declared reranking proxy; never a binding free energy.
         is_active:          Whether the compound is a known binder / true positive.
         exp_affinity:       Experimental ΔG (kcal/mol); None if unavailable.
         structural_state:   Receptor source: ``"holo"``, ``"apo"``, or ``"af2"``.
@@ -60,6 +60,14 @@ class PoseScore:
     exp_affinity: Optional[float] = None
     structural_state: str = "holo"
     ensemble_log_Z: Optional[float] = None  # P3 grand canonical: real log_Z from ensemble (for conc-weighted Xi)
+    entropy: Optional[float] = None  # emitted S, score units / K
+    temperature: Optional[float] = None  # emitted temperature, K
+    ensemble_mean_energy: Optional[float] = None
+    ensemble_free_energy: Optional[float] = None
+    generator_score: Optional[float] = None  # emitted soft_beta_G, independent ledger
+    ranking_objective: str = "cf_minus_ts"
+    emitted_total_score: Optional[float] = None
+    binding_mode_id: Optional[int] = None  # cluster identity; not output rank
 
 
 def rmsd_is_success(rmsd: float, threshold: float = 2.0) -> bool:
@@ -306,6 +314,7 @@ def docking_power(
     rmsd_threshold: float = 2.0,
     top_n: int = 1,
     n_targets: Optional[int] = None,
+    ranking: str = "reranked",
 ) -> float:
     """Fraction of targets where the top-N poses contain a near-native pose.
 
@@ -339,7 +348,13 @@ def docking_power(
     for target_poses in by_target.values():
         # Rank over every emitted pose. Filtering the sentinels out first would
         # promote a worse-scoring pose into the top-N and inflate the rate.
-        ranked = sorted(target_poses, key=lambda p: p.total_score)[:top_n]
+        if ranking not in {"reranked", "generator"}:
+            raise ValueError(f"Unknown docking ranking: {ranking}")
+        if ranking == "generator":
+            # A missing elected output is a miss; do not promote a later rank.
+            ranked = [p for p in target_poses if 1 <= p.pose_rank <= top_n]
+        else:
+            ranked = sorted(target_poses, key=lambda p: p.total_score)[:top_n]
         if any(rmsd_is_success(p.rmsd, rmsd_threshold) for p in ranked):
             n_success += 1
 
@@ -491,6 +506,8 @@ def compute_all_metrics(
         "entropy_rescue_rate",
         "docking_power_top1",
         "docking_power_top3",
+        "generator_docking_power_top1",
+        "entropy_reranked_docking_power_top1",
         "mean_rmsd",
         "median_rmsd",
         "ef_1pct",
@@ -515,6 +532,14 @@ def compute_all_metrics(
     if "docking_power_top3" in to_compute:
         results["docking_power_top3"] = docking_power(
             poses, top_n=3, n_targets=n_targets)
+
+    # Keep the emitted election separate from Python's declared proxy objective.
+    if "generator_docking_power_top1" in to_compute or "docking_power_top1" in to_compute:
+        results["generator_docking_power_top1"] = docking_power(
+            poses, top_n=1, n_targets=n_targets, ranking="generator")
+    if "entropy_reranked_docking_power_top1" in to_compute or "docking_power_top1" in to_compute:
+        results["entropy_reranked_docking_power_top1"] = docking_power(
+            poses, top_n=1, n_targets=n_targets)
 
     # Pose-accuracy aggregates: per-target best-pose RMSD, then mean/median
     # across targets — mirrors benchmark.BenchmarkSummary's median-of-best-pose

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -128,7 +128,10 @@ DRY_RUN_METRICS_NOTE: str = (
 
 def _is_docking_power_metric(name: str) -> bool:
     """True for docking_power_* keys (including bootstrap CI suffixes)."""
-    return name.startswith("docking_power_")
+    return "docking_power_" in name
+
+
+RANKING_OBJECTIVES = ("cf_minus_ts", "legacy_cf_minus_s")
 
 
 def _strip_docking_power_metrics(metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -687,6 +690,7 @@ class DatasetResult:
     # a legitimate resume (skip gates 2-3) from a run that scheduled nothing at
     # all (newly==0 AND resumed==0 → still INCONCLUSIVE, not a silent pass).
     resumed: int = 0
+    ranking_objective: str = "cf_minus_ts"
 
     def check_regressions(self) -> Dict[str, bool]:
         """Flag metrics that regressed below baseline − tolerance.
@@ -776,6 +780,7 @@ class DatasetResult:
             "inconclusive_metrics": self.inconclusive_metrics,
             "newly_executed": self.newly_executed,
             "resumed": self.resumed,
+            "ranking_objective": self.ranking_objective,
         }
         if self.metrics_note:
             payload["metrics_note"] = self.metrics_note
@@ -1484,6 +1489,7 @@ class DatasetRunner:
         command_line: Optional[str] = None,
         default_conc_M: float = 1.0,  # P3
         entry_timeout_seconds: Optional[int] = None,
+        ranking_objective: str = "cf_minus_ts",
     ) -> None:
         _default_datasets = Path(__file__).resolve().parent / "datasets"
         self.datasets_dir = Path(datasets_dir) if datasets_dir is not None else _default_datasets
@@ -1498,6 +1504,9 @@ class DatasetRunner:
         # raises and the liveness gate counts it.
         self.binary = self._resolve_binary()
         self.temperature = temperature
+        if ranking_objective not in RANKING_OBJECTIVES:
+            raise ValueError(f"Unknown ranking objective: {ranking_objective}")
+        self.ranking_objective = ranking_objective
         self.n_workers = max(1, int(n_workers))
         # OMP threads per worker: explicit > env > auto (aim for 2 on M3 Pro's 5 P-cores).
         if omp_threads is None:
@@ -1695,7 +1704,7 @@ class DatasetRunner:
             List of :class:`PoseScore` objects.
         """
         if self.dry_run:
-            return self._synthetic_poses(target_id, ligand_paths, structural_state)
+            return self._synthetic_poses(target_id, ligand_paths, structural_state, self.ranking_objective)
 
         try:
             return self._run_flexaid(
@@ -1846,6 +1855,7 @@ class DatasetRunner:
                     structural_state,
                     reference_ligand=ligand_path,
                     mismatches=self._element_mismatches,
+                    ranking_objective=self.ranking_objective,
                 )
                 # Copy the coordinates out BEFORE the with-block closes and
                 # takes them.  Deliberately after the parse, so a preservation
@@ -1976,6 +1986,7 @@ class DatasetRunner:
         structural_state: str,
         reference_ligand: Optional[Path] = None,
         mismatches: Optional[List[str]] = None,
+        ranking_objective: str = "cf_minus_ts",
     ) -> List[PoseScore]:
         """Parse FlexAIDdS result PDB files from a completed docking run.
 
@@ -1983,6 +1994,8 @@ class DatasetRunner:
         ``REMARK CF=`` / ``REMARK <rmsd> RMSD to ref. structure`` output.
         Computes post-hoc RMSD vs the reference ligand when REMARK omits it.
         """
+        if ranking_objective not in RANKING_OBJECTIVES:
+            raise ValueError(f"Unknown ranking objective: {ranking_objective}")
         poses: List[PoseScore] = []
         pdb_files = sorted(
             p for p in work_dir.glob("*.pdb")
@@ -1993,6 +2006,17 @@ class DatasetRunner:
             pdb_files = sorted(
                 p for p in work_dir.glob("*.pdb") if not _is_initial_pose_file(p)
             )
+        # The final numeric filename suffix is the emitted election index.
+        # binding_mode is the original cluster ID in DensityPeak output and
+        # can disagree with the CF-sorted order used to write these files.
+        def output_index(path: Path) -> Optional[int]:
+            match = re.search(r"_(\d+)\.pdb$", path.name, re.IGNORECASE)
+            return int(match.group(1)) if match else None
+
+        pdb_files.sort(key=lambda path: (
+            output_index(path) if output_index(path) is not None else math.inf,
+            path.name,
+        ))
 
         # A contaminated reference is a refusal, not a docking failure, and it
         # must not reach the caller's broad `except Exception` looking like one.
@@ -2017,7 +2041,16 @@ class DatasetRunner:
             rmsd = -1.0
             enthalpy_score = 0.0
             entropy_correction = 0.0
-            total_score = 0.0
+            entropy: Optional[float] = None
+            temperature: Optional[float] = None
+            ensemble_mean_energy: Optional[float] = None
+            ensemble_free_energy: Optional[float] = None
+            generator_score: Optional[float] = None
+            emitted_total_score: Optional[float] = None
+            grand_log_z: Optional[float] = None
+            emitted_index = output_index(pdb_path)
+            generator_rank = emitted_index + 1 if emitted_index is not None else rank
+            binding_mode_id: Optional[int] = None
             is_active = False
             exp_affinity: Optional[float] = None
 
@@ -2031,13 +2064,15 @@ class DatasetRunner:
                     elif "CF_SCORE:" in line:
                         enthalpy_score = _parse_remark_float(line, "CF_SCORE:")
                     elif "ENTROPY:" in line:
-                        entropy_correction = _parse_remark_float(line, "ENTROPY:")
+                        entropy = _parse_remark_float(line, "ENTROPY:")
                     elif "TOTAL_SCORE:" in line:
-                        total_score = _parse_remark_float(line, "TOTAL_SCORE:")
+                        emitted_total_score = _parse_remark_float(line, "TOTAL_SCORE:")
                     elif "EXP_AFFINITY:" in line:
                         exp_affinity = _parse_remark_float(line, "EXP_AFFINITY:")
                     elif "ACTIVE:1" in line:
                         is_active = True
+                    elif re.match(r"REMARK\s+binding_mode\s*=", line):
+                        binding_mode_id = int(line.split("=", 1)[1].strip())
                     elif "ENSEMBLE_LOG_Z:" in line or "GRAND_LOG_Z:" in line:
                         try:
                             grand_log_z = float( line.split(":")[-1].strip() )
@@ -2054,25 +2089,50 @@ class DatasetRunner:
                         if m and enthalpy_score == 0.0:
                             enthalpy_score = float(m.group(1))
                         m = _ENTROPY_REMARK_RE.search(line)
-                        if m and entropy_correction == 0.0:
-                            entropy_correction = float(m.group(1))
+                        if m and entropy is None:
+                            entropy = float(m.group(1))
+                        for label in ("entropy", "temperature", "enthalpy", "proxy_free_energy", "free_energy", "soft_beta_G"):
+                            match = re.match(rf"REMARK\s+{label}\s*=\s*(\S+)", line)
+                            if match:
+                                value = float(match.group(1))
+                                if label == "entropy":
+                                    entropy = value
+                                elif label == "temperature":
+                                    temperature = value
+                                elif label == "enthalpy":
+                                    ensemble_mean_energy = value
+                                elif label in {"free_energy", "proxy_free_energy"}:
+                                    ensemble_free_energy = value
+                                else:
+                                    generator_score = value
 
                 if rmsd < 0.0 and ref_coords is not None:
                     rmsd = _pose_rmsd_vs_reference(
                         pdb_path, ref_coords, ref_elements, mismatches)
 
             except Exception as exc:
-                logger.debug("Error parsing %s: %s", pdb_path, exc)
-                continue
+                raise ValueError(f"Invalid pose metadata in {pdb_path}: {exc}") from exc
 
-            if total_score == 0.0 and enthalpy_score != 0.0:
-                total_score = enthalpy_score - entropy_correction
+            # S is emitted in score units / K. A nonzero S without its own
+            # emitted T has no dimensionally valid correction; never borrow
+            # the CLI default or silently drop that pose from the election.
+            if entropy is not None and not math.isfinite(entropy):
+                raise ValueError(f"Nonfinite entropy in {pdb_path}")
+            if temperature is not None and (not math.isfinite(temperature) or temperature <= 0):
+                raise ValueError(f"Invalid emitted temperature in {pdb_path}")
+            if entropy and temperature is None:
+                raise ValueError(f"Nonzero entropy without emitted temperature in {pdb_path}")
+            entropy_correction = (entropy or 0.0) * (temperature or 0.0)
+            subtraction = (entropy or 0.0) if ranking_objective == "legacy_cf_minus_s" else entropy_correction
+            total_score = enthalpy_score - subtraction
+            if not math.isfinite(total_score):
+                raise ValueError(f"Nonfinite reranking score in {pdb_path}")
 
             poses.append(
                 PoseScore(
                     target_id=target_id,
                     ligand_id=ligand_id,
-                    pose_rank=rank,
+                    pose_rank=generator_rank,
                     rmsd=rmsd,
                     enthalpy_score=enthalpy_score,
                     entropy_correction=entropy_correction,
@@ -2080,6 +2140,15 @@ class DatasetRunner:
                     is_active=is_active,
                     exp_affinity=exp_affinity,
                     structural_state=structural_state,
+                    entropy=entropy,
+                    temperature=temperature,
+                    ensemble_mean_energy=ensemble_mean_energy,
+                    ensemble_free_energy=ensemble_free_energy,
+                    generator_score=generator_score,
+                    emitted_total_score=emitted_total_score,
+                    ensemble_log_Z=grand_log_z,
+                    ranking_objective=ranking_objective,
+                    binding_mode_id=binding_mode_id,
                 )
             )
 
@@ -2090,6 +2159,7 @@ class DatasetRunner:
         target_id: str,
         ligand_paths: List[Path],
         structural_state: str,
+        ranking_objective: str = "cf_minus_ts",
     ) -> List[PoseScore]:
         """Generate synthetic poses for dry-run / framework testing."""
         import random
@@ -2100,7 +2170,7 @@ class DatasetRunner:
             for rank in range(1, 6):
                 enthalpy = rng.uniform(-12, -4)
                 entropy = rng.uniform(0.5, 3.0)
-                total = enthalpy - entropy
+                total = enthalpy - (entropy / 300.0 if ranking_objective == "legacy_cf_minus_s" else entropy)
                 # Synthetic near-native pose at rank 2 sometimes
                 rmsd = rng.uniform(0.5, 1.5) if rank == 2 else rng.uniform(1.0, 5.0)
                 poses.append(
@@ -2116,6 +2186,9 @@ class DatasetRunner:
                         exp_affinity=rng.uniform(-12, -6),
                         ensemble_log_Z = rng.uniform(5, 15),  # synthetic for grand test
                         structural_state=structural_state,
+                        entropy=entropy / 300.0,
+                        temperature=300.0,
+                        ranking_objective=ranking_objective,
                     )
                 )
         return poses
@@ -2191,6 +2264,7 @@ class DatasetRunner:
             full_command=getattr(self, "command_line", None) or " ".join(sys.argv),
             dry_run=bool(self.dry_run),
             metrics_note=DRY_RUN_METRICS_NOTE if self.dry_run else "",
+            ranking_objective=self.ranking_objective,
         )
 
         if not targets:

--- a/python/flexaidds/dataset_runner/runner.py
+++ b/python/flexaidds/dataset_runner/runner.py
@@ -35,6 +35,7 @@ MPI distributed run::
 from __future__ import annotations
 
 import datetime
+import hashlib
 import json
 import csv
 import logging
@@ -51,7 +52,7 @@ import threading
 import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, fields, asdict, replace
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -132,6 +133,18 @@ def _is_docking_power_metric(name: str) -> bool:
 
 
 RANKING_OBJECTIVES = ("cf_minus_ts", "legacy_cf_minus_s")
+CHECKPOINT_SCHEMA_VERSION = 2
+
+
+def _file_sha256(path: Path) -> Optional[str]:
+    """Bounded-memory identity for checkpoint inputs and the engine binary."""
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _strip_docking_power_metrics(metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -567,6 +580,9 @@ class TargetResult:
     # generation budget is indistinguishable in the artifact from a full one.
     early_termination: Dict[str, Any] = field(default_factory=dict)
     early_exit_params: Dict[str, Any] = field(default_factory=dict)
+    entry_exit_codes: Dict[str, Optional[int]] = field(default_factory=dict)
+    entry_timeouts: Dict[str, int] = field(default_factory=dict)
+    provenance: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def success(self) -> bool:
@@ -629,7 +645,7 @@ class DatasetResult:
         metrics:            ``{metric_name: scalar_value}`` computed across all targets.
         ci_95:              ``{metric_name: (lower, upper)}`` bootstrap CIs.
         regression_flags:   ``{metric_name: True}`` when metric regressed vs baseline.
-        targets_attempted:  All target IDs that were scheduled.
+        targets_attempted:  Declared target roster, including expected targets absent from execution.
         targets_completed:  Target IDs that produced at least one pose.
         targets_failed:     Target IDs where docking failed or produced no poses.
         duration_seconds:   Total wall-clock time for this dataset.
@@ -682,15 +698,18 @@ class DatasetResult:
     # they are process-level and identical across entries of a run).
     early_exit_params: Dict[str, Any] = field(default_factory=dict)
     inconclusive_metrics: List[str] = field(default_factory=list)
-    # Targets actually executed this run (excludes --resume checkpoints, whose
-    # poses are not reloaded into all_poses). Gates 2-3 only judge a run that
-    # did fresh work — a pure resume/package-regen run must not false-fail.
+    # Freshly executed observations; resumed observations are restored and
+    # judged by the same quality and completeness gates as fresh observations.
     newly_executed: int = 0
-    # Targets loaded from --resume checkpoints (not re-executed). Distinguishes
-    # a legitimate resume (skip gates 2-3) from a run that scheduled nothing at
-    # all (newly==0 AND resumed==0 → still INCONCLUSIVE, not a silent pass).
+    # Observations loaded from verified --resume checkpoints (not re-executed).
     resumed: int = 0
+    observation_roster: List[Tuple[str, str]] = field(default_factory=list)
+    observations_completed: List[Tuple[str, str]] = field(default_factory=list)
+    observations_failed: List[Tuple[str, str]] = field(default_factory=list)
     ranking_objective: str = "cf_minus_ts"
+    checkpoint_provenance: Dict[str, Any] = field(default_factory=dict)
+    scheduled_observation_roster: List[Tuple[str, str]] = field(default_factory=list)
+    expected_target_manifest: Dict[str, Any] = field(default_factory=dict)
 
     def check_regressions(self) -> Dict[str, bool]:
         """Flag metrics that regressed below baseline − tolerance.
@@ -702,7 +721,7 @@ class DatasetResult:
         tol = self.config.baseline_tolerance
         for metric, baseline in self.config.expected_baselines.items():
             measured = self.metrics.get(metric)
-            if measured is None or np.isnan(measured):
+            if measured is None or not math.isfinite(measured):
                 # Completeness gate (#326): a metric that was never measured is
                 # NOT "no regression" — it is an inconclusive run. Record it so
                 # cli.main can fail the run rather than silently pass it.
@@ -780,7 +799,14 @@ class DatasetResult:
             "inconclusive_metrics": self.inconclusive_metrics,
             "newly_executed": self.newly_executed,
             "resumed": self.resumed,
+            "observation_roster": self.observation_roster,
+            "observations_completed": self.observations_completed,
+            "observations_failed": self.observations_failed,
+            "docking_power_denominator": len(self.targets_attempted),
             "ranking_objective": self.ranking_objective,
+            "checkpoint_provenance": self.checkpoint_provenance,
+            "scheduled_observation_roster": self.scheduled_observation_roster,
+            "expected_target_manifest": self.expected_target_manifest,
         }
         if self.metrics_note:
             payload["metrics_note"] = self.metrics_note
@@ -1490,6 +1516,7 @@ class DatasetRunner:
         default_conc_M: float = 1.0,  # P3
         entry_timeout_seconds: Optional[int] = None,
         ranking_objective: str = "cf_minus_ts",
+        expected_target_manifest: Optional[Union[str, Path]] = None,
     ) -> None:
         _default_datasets = Path(__file__).resolve().parent / "datasets"
         self.datasets_dir = Path(datasets_dir) if datasets_dir is not None else _default_datasets
@@ -1507,6 +1534,7 @@ class DatasetRunner:
         if ranking_objective not in RANKING_OBJECTIVES:
             raise ValueError(f"Unknown ranking objective: {ranking_objective}")
         self.ranking_objective = ranking_objective
+        self.expected_target_manifest = Path(expected_target_manifest).resolve() if expected_target_manifest else None
         self.n_workers = max(1, int(n_workers))
         # OMP threads per worker: explicit > env > auto (aim for 2 on M3 Pro's 5 P-cores).
         if omp_threads is None:
@@ -2214,9 +2242,22 @@ class DatasetRunner:
         A lightweight EntryTaskManager (see below) coordinates the work items.
         """
         t0 = time.monotonic()
-        targets = config.scheduled_targets(tier)
         states = structural_states or config.structural_states
         scheduled_items = config.scheduled_work_items(tier)
+        if not config._uses_crossdock_catalog(tier):
+            scheduled_items = [(tid, st) for tid in config.scheduled_targets(tier) for st in states]
+        if len(set(scheduled_items)) != len(scheduled_items):
+            raise ValueError("Duplicate scheduled observation identities")
+        scheduled_targets = list(dict.fromkeys(tid for tid, _ in scheduled_items))
+        if len(scheduled_items) != len(scheduled_targets):
+            raise ValueError(
+                "Mixed structural states would pool distinct observations in target-level metrics; "
+                "run one structural state at a time via structural_states=[state]"
+            )
+        targets, manifest_identity = self._expected_targets(config, scheduled_targets)
+        canonical_ids = {target.casefold(): target for target in targets}
+        declared_roster = ([(target, states[0]) for target in targets]
+                           if manifest_identity else list(scheduled_items))
         slug = config.slug
         eff_temp = self._effective_temperature(slug)
         if slug in THERMO_DATASETS and eff_temp != self.temperature:
@@ -2264,7 +2305,10 @@ class DatasetRunner:
             full_command=getattr(self, "command_line", None) or " ".join(sys.argv),
             dry_run=bool(self.dry_run),
             metrics_note=DRY_RUN_METRICS_NOTE if self.dry_run else "",
+            observation_roster=declared_roster,
             ranking_objective=self.ranking_objective,
+            scheduled_observation_roster=list(scheduled_items),
+            expected_target_manifest=manifest_identity,
         )
 
         if not targets:
@@ -2273,19 +2317,25 @@ class DatasetRunner:
             return dr
 
         # --- NEW: Per-entry resume + individual processing automation ---
-        already_completed: set[str] = set()
+        self._checkpoint_protocol = self._protocol_provenance(config, tier)
+        self._checkpoint_protocol["observation_roster"] = [list(item) for item in scheduled_items]
+        self._checkpoint_protocol["expected_target_manifest"] = manifest_identity
+        cached_results: Dict[Tuple[str, str], TargetResult] = {}
         if self.resume:
-            already_completed = self._discover_completed_targets(config, tier)
-            if already_completed:
+            for tid, st in scheduled_items:
+                cached = self._load_target_result(config, tier, tid, st)
+                if cached is not None:
+                    cached_results[(tid, st)] = cached
+            if cached_results:
                 logger.info(
-                    "Resume mode: %d/%d targets already have complete per-entry results — skipping them",
-                    len(already_completed), len(targets)
+                    "Resume mode: restoring %d/%d observations and their provenance",
+                    len(cached_results), len(scheduled_items)
                 )
 
         # Build work items from catalog (large-N tier-2) or targets × states
         all_work_items: List[Tuple[str, str]] = []
         for tid, st in scheduled_items:
-            if tid in already_completed:
+            if (tid, st) in cached_results:
                 continue
             all_work_items.append((tid, st))
 
@@ -2333,8 +2383,11 @@ class DatasetRunner:
             cost_hints=cost_hints,
         )
 
+        # Only root contributes cached observations to MPI aggregation. The
+        # cache is shared, so adding it on every rank would multiply evidence.
+        restored = cached_results if self._mpi_root else {}
         all_poses: List[PoseScore] = []
-        completed_targets: set[str] = set(already_completed)
+        completed_targets: set[str] = set()
         failed_targets: set[str] = set()
 
         # #326: reset per-dataset FlexAID crash tally before this run's entries.
@@ -2345,6 +2398,15 @@ class DatasetRunner:
             self._entry_early_termination = {}
             self._entry_early_exit_params = {}
             self._element_mismatches = []
+
+        for (tid, st), cached in restored.items():
+            self._entry_exit_codes.update(cached.entry_exit_codes)
+            self._entry_timeouts.update(cached.entry_timeouts)
+            if cached.early_termination:
+                self._entry_early_termination[f"{tid}/{st}"] = cached.early_termination
+            if cached.early_exit_params:
+                self._entry_early_exit_params[f"{tid}/{st}"] = cached.early_exit_params
+        self._flexaid_crashes = len(self._entry_exit_codes)
 
         def _process_one_item(item: Tuple[str, str]) -> Tuple[str, str, List[PoseScore], float, str]:
             """Process a single (target_id, structural_state) entry.
@@ -2363,11 +2425,9 @@ class DatasetRunner:
                 if config.data_dir and not self.dry_run:
                     receptor, ligands = self._resolve_entry_paths(config, target_id, state)
                     if receptor is None:
-                        error = f"No receptor found for {target_id}/{state}"
-                        return target_id, state, [], time.monotonic() - t_start, error
+                        raise ValueError(f"No receptor found for {target_id}/{state}")
                     if not ligands:
-                        error = f"No ligand found for {target_id}/{state}"
-                        return target_id, state, [], time.monotonic() - t_start, error
+                        raise ValueError(f"No ligand found for {target_id}/{state}")
 
                 # P3: per-ligand conc from config.ligand_concs if present (from yaml)
                 eff_conc = getattr(config, 'default_conc_M', self.default_conc_M)
@@ -2384,6 +2444,8 @@ class DatasetRunner:
 
                 elapsed = time.monotonic() - t_start
                 cost_cpu = elapsed * max(1, self.omp_threads)
+                if not poses:
+                    error = "No poses produced"
 
                 tr = TargetResult(
                     target_id=target_id,
@@ -2421,14 +2483,29 @@ class DatasetRunner:
                     "Unhandled exception for %s/%s: %s", target_id, state, exc,
                     exc_info=True,
                 )
-                return target_id, state, [], elapsed, f"EXCEPTION: {exc}"
+                error = f"EXCEPTION: {exc}"
+                try:
+                    self._save_target_result(TargetResult(
+                        target_id=target_id, structural_state=state, poses=[],
+                        duration_seconds=elapsed, error=error,
+                        **self._early_termination_for(target_id, state),
+                    ), config, tier, cost_cpu=elapsed * max(1, self.omp_threads))
+                except Exception as save_exc:
+                    logger.warning("Could not persist failed observation %s/%s: %s", target_id, state, save_exc)
+                return target_id, state, [], elapsed, error
 
         # Dispatch via the EntryTaskManager (local ThreadPool or sequential)
         results = entry_manager.run(_process_one_item)
+        newly = len(results)
+        fresh_results = list(results)
+        results = list(results) + [
+            (tid, st, tr.poses, tr.duration_seconds, tr.error)
+            for (tid, st), tr in restored.items()
+        ]
 
         for target_id, state, poses, elapsed, error in results:
             all_poses.extend(poses)
-            if error:
+            if error or not poses:
                 failed_targets.add(target_id)
                 logger.warning("Failed %s/%s: %s", target_id, state, error)
             else:
@@ -2464,7 +2541,7 @@ class DatasetRunner:
             dr.grand_summary = grand_summary
             logger.info("P3: emitted grand summary for %d ligands", len(grand_summary))
 
-        completed = sorted(completed_targets)
+        completed = sorted(completed_targets - failed_targets)
         failed = sorted(failed_targets)
 
         # #326: snapshot this rank's FlexAID crash tally + count of targets
@@ -2482,8 +2559,7 @@ class DatasetRunner:
             early_params = next(
                 (dict(v) for v in self._entry_early_exit_params.values()), {}
             )
-        newly = len(results)
-        resumed = len(already_completed)
+        resumed = len(cached_results)
 
         # Element-order refusals are scored as misses, so they must be visible
         # or a correspondence bug reads as bad docking.
@@ -2560,6 +2636,11 @@ class DatasetRunner:
 
         # Root finalizes
         if self._mpi_root:
+            all_poses = [replace(pose, target_id=canonical_ids[pose.target_id.casefold()])
+                         for pose in all_poses]
+            completed = [canonical_ids[target.casefold()] for target in completed]
+            failed = [canonical_ids[target.casefold()] for target in failed]
+            failed.extend(target for target in targets if target.casefold() not in {tid.casefold() for tid in scheduled_targets})
             dr.targets_completed = completed
             dr.targets_failed = failed
             dr.flexaid_crashes = crashes
@@ -2570,16 +2651,25 @@ class DatasetRunner:
             dr.total_poses = len(all_poses)
             dr.newly_executed = newly
             dr.resumed = resumed
+            observed = {(p.target_id, p.structural_state) for p in all_poses}
+            if not observed.issubset(set(declared_roster)):
+                raise ValueError("Observed poses outside the declared observation roster")
+            dr.observations_completed = [item for item in declared_roster if item in observed]
+            dr.observations_failed = [item for item in declared_roster if item not in observed]
+            dr.checkpoint_provenance = dict(self._checkpoint_protocol)
+            dr.targets_completed = sorted(set(completed) - set(failed))
+            dr.targets_failed = sorted(set(failed))
 
-            if all_poses:
-                metrics = compute_all_metrics(all_poses, requested=requested_metrics)
+            if declared_roster:
+                metrics = compute_all_metrics(
+                    all_poses, requested=requested_metrics, n_targets=len(targets))
                 if self.dry_run:
                     # Safety net: never surface docking_power_* from synthetic poses.
                     metrics = _strip_docking_power_metrics(metrics)
                 dr.metrics = metrics
 
                 if self.do_bootstrap:
-                    cis = self._compute_bootstrap_cis(all_poses, requested_metrics)
+                    cis = self._compute_bootstrap_cis(all_poses, requested_metrics, declared_roster)
                     if self.dry_run:
                         cis = _strip_docking_power_metrics(cis)
                     dr.ci_95 = cis
@@ -2593,13 +2683,15 @@ class DatasetRunner:
                 )
 
             # Also write a small per-dataset manifest of individual entry status (for audit + reproducibility)
-            self._write_entry_manifest(config, tier, completed, failed)
+            self._write_entry_manifest(config, tier, dr.targets_completed, dr.targets_failed,
+                                       observation_roster=declared_roster,
+                                       scheduled_observation_roster=scheduled_items)
 
             # Update persistent cost history (CostHistory + EMA)
             if cost_history is not None:
                 try:
                     observed_costs = {}
-                    for target_id, state, poses, elapsed, error in results:
+                    for target_id, state, poses, elapsed, error in fresh_results:
                         if not error and elapsed > 0:
                             key = f"{target_id}_{state}"
                             observed_costs[key] = elapsed * max(1, self.omp_threads)
@@ -2616,15 +2708,31 @@ class DatasetRunner:
         self,
         poses: List[PoseScore],
         requested: Optional[List[str]],
+        observation_roster: Optional[List[Tuple[str, str]]] = None,
     ) -> Dict[str, Tuple[float, float]]:
-        """Compute bootstrap CIs for scalar pose-level metrics."""
+        """Resample declared targets, including missing-output targets.
+
+        Each draw gets a distinct ID so repeated draws are not collapsed by
+        metric grouping. Resampling poses would change both election and N.
+        """
         cis: Dict[str, Tuple[float, float]] = {}
+        roster = observation_roster or list(dict.fromkeys((p.target_id, p.structural_state) for p in poses))
+        if not roster:
+            return cis
+        grouped = {item: [] for item in roster}
+        for pose in poses:
+            grouped[(pose.target_id, pose.structural_state)].append(pose)
+        observations = list(grouped.values())
+
+        def _flatten(sample):
+            return [replace(pose, target_id=f"draw_{index}")
+                    for index, bucket in enumerate(sample) for pose in bucket]
 
         def _rescue_fn(sample):
-            return entropy_rescue_rate(sample)
+            return entropy_rescue_rate(_flatten(sample))
 
         def _dock_fn(sample):
-            return docking_power(sample, top_n=1)
+            return docking_power(_flatten(sample), top_n=1, n_targets=len(sample))
 
         fns = {
             "entropy_rescue_rate": _rescue_fn,
@@ -2635,7 +2743,7 @@ class DatasetRunner:
             if self.dry_run and _is_docking_power_metric(name):
                 continue
             if requested is None or name in requested:
-                lo, hi = bootstrap_ci(fn, poses, n_resamples=self.n_bootstrap)
+                lo, hi = bootstrap_ci(fn, observations, n_resamples=self.n_bootstrap)
                 cis[name] = (lo, hi)
 
         return cis
@@ -2752,11 +2860,86 @@ class DatasetRunner:
         safe_id = target_id.replace("/", "_")
         return self._entry_results_dir(config, tier) / f"{safe_id}_{structural_state}.json"
 
+    def _protocol_provenance(self, config: DatasetConfig, tier: int) -> Dict[str, Any]:
+        """Identity of the observation/scorer protocol, separate from verdicts.
+
+        Baselines may be re-evaluated without redocking. Changed inputs, engine,
+        scoring objective or runtime knobs require a new result namespace.
+        """
+        spec = asdict(config)
+        for key in ("expected_baselines", "published_baselines", "published_source", "baseline_tolerance", "metrics"):
+            spec.pop(key, None)
+        environment = {key: value for key, value in os.environ.items()
+                       if key.startswith(("FLEXAID", "OMP_", "CUDA_"))}
+        return {
+            "schema_version": CHECKPOINT_SCHEMA_VERSION,
+            "dataset": config.slug,
+            "tier": tier,
+            "observation_roster": [list(item) for item in config.scheduled_work_items(tier)],
+            "dataset_spec_sha256": hashlib.sha256(json.dumps(spec, sort_keys=True, default=str).encode()).hexdigest(),
+            "runtime_environment_sha256": hashlib.sha256(json.dumps(environment, sort_keys=True).encode()).hexdigest(),
+            "git_sha": _git_sha(self.repo_root),
+            "binary": self._resolve_binary(),
+            "binary_sha256": _file_sha256(Path(self._resolve_binary())),
+            "temperature": self._effective_temperature(config.slug),
+            "ranking_objective": self.ranking_objective,
+            "omp_threads": self.omp_threads,
+            "scorer_source_sha256": {
+                name: _file_sha256(Path(__file__).with_name(name))
+                for name in ("runner.py", "metrics.py", "data_paths.py")
+            },
+            "entry_timeout_seconds": self.entry_timeout_seconds,
+            "dry_run": self.dry_run,
+            "expected_target_manifest": self._expected_targets(config, config.scheduled_targets(tier))[1],
+        }
+
+    def _expected_targets(self, config: DatasetConfig, scheduled: List[str]) -> Tuple[List[str], Dict[str, Any]]:
+        """Use an explicitly pinned manifest as N even if execution omitted rows."""
+        path = self.expected_target_manifest
+        if path is None:
+            return list(scheduled), {}
+        data = json.loads(path.read_text())
+        targets = data.get("targets")
+        if data.get("dataset") != config.slug or not isinstance(targets, list) or not targets:
+            raise ValueError("Expected-target manifest has the wrong dataset or no target roster")
+        if any(not isinstance(target, str) or not target.strip() for target in targets):
+            raise ValueError("Expected-target manifest contains invalid target identities")
+        normalized = {target.casefold() for target in targets}
+        if len(normalized) != len(targets) or data.get("N") != len(targets):
+            raise ValueError("Expected-target manifest has duplicate identities or inconsistent N")
+        if len({target.casefold() for target in scheduled}) != len(scheduled):
+            raise ValueError("Scheduled target identities are not unique")
+        if not {target.casefold() for target in scheduled}.issubset(normalized):
+            raise ValueError("Scheduled targets are outside the expected-target manifest")
+        if len(config.structural_states) != 1:
+            raise ValueError("A pinned target manifest requires a single declared structural state")
+        codes_digest = hashlib.sha256(",".join(sorted(targets)).encode("utf-8")).hexdigest()
+        if data.get("sha256_of_sorted_codes") is not None and data["sha256_of_sorted_codes"] != codes_digest:
+            raise ValueError("Expected-target manifest sorted-code digest mismatch")
+        return list(targets), {"path": str(path), "sha256": _file_sha256(path),
+                               "sha256_of_sorted_codes": codes_digest,
+                               "schema": data.get("schema"), "dataset": config.slug, "N": len(targets)}
+
+    def _input_provenance(self, config: DatasetConfig, target_id: str, state: str) -> List[Dict[str, Any]]:
+        if self.dry_run or not config.data_dir:
+            return []
+        receptor, ligands = self._resolve_entry_paths(config, target_id, state)
+        paths = ([receptor] if receptor else []) + list(ligands)
+        return [{"path": str(path.resolve()), "sha256": _file_sha256(path)} for path in paths]
+
     def _save_target_result(self, tr: TargetResult, config: DatasetConfig, tier: int, cost_cpu: float = 0.0) -> Path:
         """Atomic write of one TargetResult (crash-safe). Includes simple cost tracking."""
         path = self._target_result_path(config, tier, tr.target_id, tr.structural_state)
         tmp = path.with_suffix(".json.tmp")
+        with self._crash_lock:
+            exit_codes = {k: v for k, v in self._entry_exit_codes.items() if k.startswith(f"{tr.target_id}/")}
+            timeouts = {k: v for k, v in self._entry_timeouts.items() if k.startswith(f"{tr.target_id}/")}
         payload = {
+            "schema_version": CHECKPOINT_SCHEMA_VERSION,
+            "provenance": {
+                "protocol": getattr(self, "_checkpoint_protocol", None) or self._protocol_provenance(config, tier),
+                "inputs": self._input_provenance(config, tr.target_id, tr.structural_state),
+            },
             "target_id": tr.target_id,
             "structural_state": tr.structural_state,
             "duration_seconds": tr.duration_seconds,
@@ -2771,6 +2954,8 @@ class DatasetRunner:
             # truncated run cannot be mistaken for a complete one.
             "early_termination": getattr(tr, 'early_termination', {}) or {},
             "early_exit_params": getattr(tr, 'early_exit_params', {}) or {},
+            "entry_exit_codes": exit_codes,
+            "entry_timeouts": timeouts,
             "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
         }
         tmp.write_text(json.dumps(payload, indent=2))
@@ -2785,16 +2970,48 @@ class DatasetRunner:
             return None
         try:
             data = json.loads(path.read_text())
-            poses = []
-            for p in data.get("poses", []):
-                if isinstance(p, dict):
-                    # Best-effort reconstruction; fall back to storing raw dict if fields mismatch
-                    try:
-                        poses.append(PoseScore(**p))  # type: ignore[call-arg]
-                    except Exception:
-                        poses.append(p)  # type: ignore[arg-type]
-                else:
-                    poses.append(p)
+            expected = {
+                "protocol": getattr(self, "_checkpoint_protocol", None) or self._protocol_provenance(config, tier),
+                "inputs": self._input_provenance(config, target_id, structural_state),
+            }
+            if data.get("schema_version") != CHECKPOINT_SCHEMA_VERSION or data.get("provenance") != expected:
+                raise ValueError("checkpoint schema or input/scorer protocol differs; use a new results directory")
+            if (data.get("target_id"), data.get("structural_state")) != (target_id, structural_state):
+                raise ValueError("checkpoint observation identity differs from its scheduled identity")
+            if not isinstance(data.get("poses"), list) or not isinstance(data.get("error"), str):
+                raise ValueError("checkpoint lacks a typed observation result")
+            pose_fields = {entry.name for entry in fields(PoseScore)}
+            if any(not isinstance(p, dict) or set(p) != pose_fields for p in data["poses"]):
+                raise ValueError("checkpoint pose schema is incomplete or incompatible")
+            poses = [PoseScore(**p) for p in data["poses"]]
+            identities = set()
+            for pose in poses:
+                if (pose.target_id, pose.structural_state) != (target_id, structural_state):
+                    raise ValueError("cached pose belongs to a different observation")
+                if pose.ranking_objective != self.ranking_objective:
+                    raise ValueError("cached pose uses a different scoring objective")
+                if not isinstance(pose.pose_rank, int) or pose.pose_rank < 1:
+                    raise ValueError("invalid cached generator rank")
+                identity = (pose.ligand_id, pose.pose_rank)
+                if identity in identities:
+                    raise ValueError("duplicate cached pose identity")
+                identities.add(identity)
+                if not all(math.isfinite(value) for value in (pose.rmsd, pose.enthalpy_score, pose.entropy_correction, pose.total_score)):
+                    raise ValueError("cached pose contains a nonfinite score or RMSD")
+                if pose.entropy is not None:
+                    if not math.isfinite(pose.entropy) or (pose.entropy and pose.temperature is None):
+                        raise ValueError("cached entropy lacks valid temperature provenance")
+                    if pose.temperature is not None and (not math.isfinite(pose.temperature) or pose.temperature <= 0):
+                        raise ValueError("cached pose has invalid temperature")
+                    correction = pose.entropy * (pose.temperature or 0.0)
+                    if not math.isclose(pose.entropy_correction, correction, rel_tol=1e-12, abs_tol=1e-12):
+                        raise ValueError("cached T*S disagrees with emitted S and T")
+                subtraction = (pose.entropy or 0.0) if self.ranking_objective == "legacy_cf_minus_s" else pose.entropy_correction
+                if not math.isclose(pose.total_score, pose.enthalpy_score - subtraction, rel_tol=1e-12, abs_tol=1e-12):
+                    raise ValueError("cached score disagrees with declared ranking objective")
+            for evidence_key in ("early_termination", "early_exit_params", "entry_exit_codes", "entry_timeouts"):
+                if not isinstance(data.get(evidence_key), dict):
+                    raise ValueError(f"checkpoint lacks {evidence_key} provenance")
             return TargetResult(
                 target_id=data["target_id"],
                 structural_state=data["structural_state"],
@@ -2810,16 +3027,18 @@ class DatasetRunner:
                 # to prevent.
                 early_termination=data.get("early_termination") or {},
                 early_exit_params=data.get("early_exit_params") or {},
+                entry_exit_codes=data["entry_exit_codes"],
+                entry_timeouts=data["entry_timeouts"],
+                provenance=data["provenance"],
             )
         except Exception as e:
-            logger.warning("Corrupt target result %s — will re-run: %s", path, e)
-            return None
+            raise ValueError(f"Refusing unverified resume checkpoint {path}: {e}") from e
 
     def _discover_completed_targets(self, config: DatasetConfig, tier: int) -> set[str]:
         """Return set of target_ids that have at least one successful result for every requested state."""
         states = config.structural_states
         completed = set()
-        for target_id in config.targets:
+        for target_id in config.scheduled_targets(tier):
             all_states_ok = True
             for st in states:
                 tr = self._load_target_result(config, tier, target_id, st)
@@ -2837,6 +3056,8 @@ class DatasetRunner:
         completed: List[str],
         failed: List[str],
         raw_results: Optional[List[Tuple[str, str, List[PoseScore], float, str]]] = None,
+        observation_roster: Optional[List[Tuple[str, str]]] = None,
+        scheduled_observation_roster: Optional[List[Tuple[str, str]]] = None,
     ) -> None:
         """Write rich per-entry manifest with timing and cost tracking.
 
@@ -2851,13 +3072,22 @@ class DatasetRunner:
         per_entry: Dict[str, float] = {}
         per_entry_cost: Dict[str, float] = {}
         durations: List[float] = []
+        checkpoint_files: Dict[str, str] = {}
 
-        for jf in sorted(entry_dir.glob("*_*.json")):
-            if jf.name.startswith("_"):
+        roster = observation_roster if observation_roster is not None else config.scheduled_work_items(tier)
+        scheduled = scheduled_observation_roster if scheduled_observation_roster is not None else config.scheduled_work_items(tier)
+        checkpoint_ids = {(tid.casefold(), st): tid for tid, st in scheduled}
+        for tid, st in roster:
+            checkpoint_id = checkpoint_ids.get((tid.casefold(), st))
+            if checkpoint_id is None:
+                continue
+            jf = self._target_result_path(config, tier, checkpoint_id, st)
+            if not jf.is_file():
                 continue
             try:
                 data = json.loads(jf.read_text())
-                key = f"{data.get('target_id')}_{data.get('structural_state')}"
+                key = f"{tid}_{st}"
+                checkpoint_files[key] = jf.name
                 dur = float(data.get("duration_seconds", 0.0))
                 cost = float(data.get("cost_cpu_seconds", dur * max(1, self.omp_threads)))
                 per_entry[key] = round(dur, 2)
@@ -2883,7 +3113,9 @@ class DatasetRunner:
             "n_workers_used": self.n_workers,
             "completed": completed,
             "failed": failed,
-            "total_attempted": len(completed) + len(failed),
+            "total_attempted": len({tid for tid, _ in roster}),
+            "observation_roster": roster,
+            "checkpoint_files": checkpoint_files,
             # --- NEW: per-target timing + cost tracking (user priority #2 first) ---
             "timings": {
                 "per_entry_wall_seconds": per_entry,

--- a/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
+++ b/python/flexaidds/dataset_runner/tests/test_benchmark_gate.py
@@ -86,10 +86,9 @@ def test_no_attempts_is_not_flagged_productivity():
     assert _benchmark_inconclusive_reasons([dr]) == []
 
 
-def test_fully_resumed_run_is_not_inconclusive():
-    # Regression for the review finding (Bumble + Honey): a pure --resume run
-    # executes no fresh targets — its poses come from checkpoints, not all_poses
-    # — so 0 poses + unmeasured metrics must NOT read as a dead binary.
+def test_resume_without_reconstructed_metrics_is_inconclusive():
+    # A resume must reconstruct cached observations and remeasure its quality.
+    # Skipping work cannot exempt absent metrics from the completeness gate.
     dr = _dr(
         "astex_diverse",
         completed=["a", "b", "c"],   # all seeded from already_completed
@@ -98,7 +97,9 @@ def test_fully_resumed_run_is_not_inconclusive():
         total_poses=0,               # checkpoint poses not reloaded
         missing_metrics=["docking_power_top1", "mean_rmsd"],
     )
-    assert _benchmark_inconclusive_reasons([dr]) == []
+    reasons = _benchmark_inconclusive_reasons([dr])
+    assert any("completeness" in reason for reason in reasons)
+    assert any("productivity" in reason for reason in reasons)
 
 
 def test_run_that_scheduled_nothing_is_inconclusive():

--- a/python/tests/test_pose_pdb_preservation.py
+++ b/python/tests/test_pose_pdb_preservation.py
@@ -28,6 +28,7 @@ PDB_BODY = (
     "REMARK CF=-5.08119\n"
     "REMARK enthalpy = -5.079114\n"
     "REMARK entropy = 0.00000780\n"
+    "REMARK temperature = 300.00\n"
     "ATOM      1  C   LIG A   1       0.000   0.000   0.000  1.00  0.00\n"
     "END\n"
 )

--- a/python/tests/test_runner_entropy_remark_parse.py
+++ b/python/tests/test_runner_entropy_remark_parse.py
@@ -13,8 +13,10 @@ mismatch cannot silently return.
 """
 
 from pathlib import Path
+import pytest
 
 from flexaidds.dataset_runner.runner import DatasetRunner
+from flexaidds.dataset_runner.metrics import docking_power, entropy_rescue_rate
 
 
 def _write_pose(work_dir: Path, name: str, body: str) -> None:
@@ -30,6 +32,7 @@ def test_entropy_remark_written_spelling_is_captured(tmp_path: Path) -> None:
         "REMARK CF=-5.07911\n"
         "REMARK enthalpy = -5.079114\n"
         "REMARK entropy = 0.00000780\n"
+        "REMARK temperature = 300.00\n"
         "REMARK 3.15582 RMSD to ref. structure\n",
     )
 
@@ -40,11 +43,14 @@ def test_entropy_remark_written_spelling_is_captured(tmp_path: Path) -> None:
     assert len(poses) == 1
     pose = poses[0]
     # The defect: this used to be 0.0 because nothing read `entropy = `.
-    assert pose.entropy_correction == 0.00000780
+    assert pose.entropy == 0.00000780
+    assert pose.temperature == 300.0
+    assert pose.entropy_correction == 300.0 * 0.00000780
     # enthalpy_score stays sourced from CF= (unchanged), not the enthalpy line.
     assert pose.enthalpy_score == -5.07911
-    # total_score = enthalpy_score - entropy_correction, now with a real ΔS.
-    assert pose.total_score == -5.07911 - 0.00000780
+    # The separate reranking proxy is CF - T*S, using the emitted temperature.
+    assert pose.total_score == -5.07911 - 300.0 * 0.00000780
+    assert pose.ensemble_mean_energy == -5.079114
 
 
 def test_entropy_defaults_to_zero_when_writer_omits_it(tmp_path: Path) -> None:
@@ -64,8 +70,8 @@ def test_entropy_defaults_to_zero_when_writer_omits_it(tmp_path: Path) -> None:
     assert poses[0].entropy_correction == 0.0
 
 
-def test_legacy_entropy_token_still_parses(tmp_path: Path) -> None:
-    """The explicit ``ENTROPY:`` token remains honoured for back-compat."""
+def test_legacy_entropy_token_requires_emitted_temperature(tmp_path: Path) -> None:
+    """An old spelling supplies S, not permission to guess its temperature."""
     _write_pose(
         tmp_path,
         "flexaid_0.pdb",
@@ -73,9 +79,90 @@ def test_legacy_entropy_token_still_parses(tmp_path: Path) -> None:
         "REMARK ENTROPY: 0.0123\n",
     )
 
-    poses = DatasetRunner._parse_flexaid_output(
-        tmp_path, target_id="1G9V", ligand_id="lig", structural_state="holo"
-    )
+    with pytest.raises(ValueError, match="without emitted temperature"):
+        DatasetRunner._parse_flexaid_output(
+            tmp_path, target_id="1G9V", ligand_id="lig", structural_state="holo")
 
-    assert len(poses) == 1
-    assert poses[0].entropy_correction == 0.0123
+
+def _parse(path, objective="cf_minus_ts"):
+    return DatasetRunner._parse_flexaid_output(
+        path, "target", "lig", "holo", ranking_objective=objective)
+
+
+@pytest.mark.parametrize("temperature", [100.0, 300.0, 600.0])
+def test_correction_depends_on_emitted_temperature(tmp_path, temperature):
+    _write_pose(tmp_path, "flexaid_0.pdb",
+                f"REMARK CF=-10\nREMARK entropy = 0.01\nREMARK temperature = {temperature}\n")
+    pose = _parse(tmp_path)[0]
+    assert pose.entropy_correction == temperature * 0.01
+    assert pose.total_score == -10 - temperature * 0.01
+
+
+def test_dimensional_counterexample_reverses_ranking_but_not_generator(tmp_path):
+    # Arbitrary scalar counterexample, not a molecular accuracy claim.
+    _write_pose(tmp_path, "flexaid_0.pdb",
+                "REMARK CF=-11\nREMARK entropy = 0.001\nREMARK temperature = 300.00\n"
+                "REMARK enthalpy = -11\nREMARK free_energy = -11.3\n"
+                "REMARK soft_beta_G = -15\nREMARK binding_mode = 0\nREMARK RMSD: 5\n")
+    _write_pose(tmp_path, "flexaid_1.pdb",
+                "REMARK CF=-10\nREMARK entropy = 0.010\nREMARK temperature = 300.00\n"
+                "REMARK enthalpy = -10\nREMARK free_energy = -13\n"
+                "REMARK soft_beta_G = -14\nREMARK binding_mode = 1\nREMARK RMSD: 1\n")
+    corrected, legacy = _parse(tmp_path), _parse(tmp_path, "legacy_cf_minus_s")
+    assert docking_power(corrected) == 1.0
+    assert docking_power(legacy) == 0.0
+    assert entropy_rescue_rate(corrected, rank_threshold=1) == 1.0
+    assert entropy_rescue_rate(legacy, rank_threshold=1) == 0.0
+    assert docking_power(corrected, ranking="generator") == 0.0
+    assert docking_power(legacy, ranking="generator") == 0.0
+    assert corrected[1].ensemble_free_energy == -13
+    assert corrected[1].enthalpy_score == -10
+    assert corrected[1].generator_score == -14
+    assert corrected[1].pose_rank == 2
+
+
+def test_zero_entropy_is_score_identical_without_assumed_temperature(tmp_path):
+    _write_pose(tmp_path, "flexaid_0.pdb", "REMARK CF=-10\nREMARK entropy = 0.00000000\n")
+    corrected, legacy = _parse(tmp_path)[0], _parse(tmp_path, "legacy_cf_minus_s")[0]
+    assert corrected.entropy_correction == legacy.entropy_correction == 0.0
+    assert corrected.total_score == legacy.total_score == -10.0
+    assert corrected.temperature is None
+
+
+@pytest.mark.parametrize("temperature", ["0", "-1", "nan", "inf"])
+def test_invalid_temperature_refuses_entire_election(tmp_path, temperature):
+    _write_pose(tmp_path, "flexaid_0.pdb",
+                f"REMARK CF=-10\nREMARK entropy = 0.01\nREMARK temperature = {temperature}\n")
+    with pytest.raises(ValueError, match="Invalid emitted temperature"):
+        _parse(tmp_path)
+
+
+def test_explicit_zero_score_is_preserved_as_emitted_metadata(tmp_path):
+    _write_pose(tmp_path, "flexaid_0.pdb",
+                "REMARK CF=-10\nREMARK entropy = 0.01\nREMARK temperature = 300\n"
+                "REMARK TOTAL_SCORE: 0\nREMARK free_energy = -80\nREMARK enthalpy = -77\n")
+    pose = _parse(tmp_path)[0]
+    assert pose.total_score == -13
+    assert pose.emitted_total_score == 0
+    assert pose.ensemble_mean_energy == -77
+    assert pose.ensemble_free_energy == -80
+
+
+def test_generator_election_uses_numeric_filename_not_cluster_identity(tmp_path):
+    # DensityPeak sorts clusters before writing _i.pdb but retains original IDs.
+    for output_index, cluster_id, rmsd in [(10, 0, 5), (0, 9, 1), (2, 1, 5)]:
+        _write_pose(tmp_path, f"flexaid_{output_index}.pdb",
+                    f"REMARK CF=-10\nREMARK binding_mode = {cluster_id}\nREMARK RMSD: {rmsd}\n")
+    poses = _parse(tmp_path)
+    assert [pose.pose_rank for pose in poses] == [1, 3, 11]
+    assert [pose.binding_mode_id for pose in poses] == [9, 1, 0]
+    assert docking_power(poses, ranking="generator") == 1.0
+
+
+def test_missing_generator_top1_is_not_replaced_by_later_output(tmp_path):
+    _write_pose(tmp_path, "flexaid_1.pdb",
+                "REMARK CF=-10\nREMARK binding_mode = 0\nREMARK RMSD: 1\n")
+    poses = _parse(tmp_path)
+    assert poses[0].pose_rank == 2
+    assert docking_power(poses, ranking="generator") == 0.0
+    assert docking_power(poses, ranking="generator", top_n=3) == 1.0

--- a/python/tests/test_runner_observation_integrity.py
+++ b/python/tests/test_runner_observation_integrity.py
@@ -1,0 +1,259 @@
+"""Runner-level regressions for fixed N and scientifically equivalent resume.
+
+All docking is replaced with scalar synthetic observations. These tests never
+run the engine, PoseBusters or tENCoM and make no molecular accuracy claims.
+"""
+
+import json
+
+import pytest
+
+from flexaidds.dataset_runner.cli import _benchmark_inconclusive_reasons
+from flexaidds.dataset_runner.metrics import PoseScore
+from flexaidds.dataset_runner.runner import DatasetConfig, DatasetRunner
+
+
+def _config():
+    return DatasetConfig(
+        slug="integrity", name="Synthetic integrity fixture", description="",
+        targets=["a", "b"], metrics=["docking_power_top1"],
+        expected_baselines={"docking_power_top1": 0.75}, baseline_tolerance=0.0,
+    )
+
+
+def _runner(tmp_path, **kwargs):
+    return DatasetRunner(
+        results_dir=tmp_path, binary="not-executed-test-engine",
+        n_workers=1, omp_threads=1, **kwargs,
+    )
+
+
+def _pose(target, rmsd, state="holo"):
+    return PoseScore(target, "lig", 1, rmsd, -10.0, 0.0, -10.0, False,
+                     structural_state=state)
+
+
+def _stub(runner, rmsds, calls):
+    def dock(target, *args, structural_state="holo", **kwargs):
+        calls.append(target)
+        value = rmsds[target]
+        return [] if value is None else [_pose(target, value, structural_state)]
+    runner._dock_target = dock
+
+
+def _verdict(result):
+    return result.metrics, result.regression_flags, _benchmark_inconclusive_reasons([result])
+
+
+def test_one_success_one_empty_keeps_fixed_denominator(tmp_path):
+    runner = _runner(tmp_path)
+    _stub(runner, {"a": 1.0, "b": None}, [])
+    result = runner.run_dataset(_config())
+    assert result.metrics["docking_power_top1"] == 0.5
+    assert result.regression_flags["docking_power_top1"] is True
+    assert result.targets_completed == ["a"]
+    assert result.targets_failed == ["b"]
+    assert result.flexaid_crashes == 0  # absent output is not an engine crash
+    assert result.to_dict()["docking_power_denominator"] == 2
+    assert result.observation_roster == [("a", "holo"), ("b", "holo")]
+    assert result.observations_failed == [("b", "holo")]
+
+
+def test_missing_input_is_an_observation_failure(tmp_path, monkeypatch):
+    cfg = _config()
+    cfg.data_dir = tmp_path / "inputs"
+    runner = _runner(tmp_path / "results")
+    monkeypatch.setattr(runner, "_resolve_entry_paths", lambda c, t, s: (
+        (tmp_path / "receptor.pdb", [tmp_path / "lig.mol2"]) if t == "a" else (None, [])))
+    calls = []
+    _stub(runner, {"a": 1.0}, calls)
+    result = runner.run_dataset(cfg)
+    assert calls == ["a"]
+    assert result.metrics["docking_power_top1"] == 0.5
+    assert result.targets_failed == ["b"]
+    assert result.flexaid_crashes == 0
+
+
+@pytest.mark.parametrize("rmsds", [{"a": 5.0, "b": 5.0}, {"a": 1.0, "b": None}, {"a": None, "b": None}, {"a": 1.0, "b": 1.0}])
+def test_full_resume_reconstructs_exact_quality_verdict(tmp_path, rmsds):
+    runner = _runner(tmp_path)
+    calls = []
+    _stub(runner, rmsds, calls)
+    fresh = runner.run_dataset(_config())
+    runner.resume = True
+    calls.clear()
+    resumed = runner.run_dataset(_config())
+    assert calls == []
+    assert resumed.newly_executed == 0
+    assert resumed.resumed == 2
+    assert resumed.total_poses == fresh.total_poses
+    assert resumed.targets_failed == fresh.targets_failed
+    assert _verdict(resumed) == _verdict(fresh)
+
+
+def test_partial_resume_includes_cached_miss(tmp_path):
+    runner = _runner(tmp_path)
+    _stub(runner, {"a": 5.0, "b": 1.0}, [])
+    fresh = runner.run_dataset(_config())
+    runner._target_result_path(_config(), 2, "b", "holo").unlink()
+    runner.resume = True
+    calls = []
+    _stub(runner, {"b": 1.0}, calls)
+    resumed = runner.run_dataset(_config())
+    assert calls == ["b"]
+    assert resumed.resumed == 1
+    assert resumed.newly_executed == 1
+    assert resumed.metrics["docking_power_top1"] == 0.5
+    assert _verdict(resumed) == _verdict(fresh)
+
+
+def test_resume_preserves_execution_and_termination_evidence(tmp_path):
+    runner = _runner(tmp_path)
+    def dock(target, *args, **kwargs):
+        if target == "a":
+            runner._entry_exit_codes["a/lig"] = -6
+            runner._flexaid_crashes += 1
+            runner._entry_early_termination["a/holo"] = {"terminated_early": True, "reason": "test", "generation": 10}
+            return []
+        return [_pose(target, 1.0)]
+    runner._dock_target = dock
+    fresh = runner.run_dataset(_config())
+    runner.resume = True
+    resumed = runner.run_dataset(_config())
+    assert resumed.entry_exit_codes == fresh.entry_exit_codes == {"a/lig": -6}
+    assert resumed.early_terminations == fresh.early_terminations
+    assert resumed.flexaid_crashes == fresh.flexaid_crashes == 1
+    assert _verdict(resumed) == _verdict(fresh)
+
+
+@pytest.mark.parametrize("mutation", ["old_schema", "wrong_target", "missing_pose_field", "nonfinite", "wrong_score", "wrong_protocol"])
+def test_incompatible_cache_fails_before_any_work(tmp_path, mutation):
+    runner = _runner(tmp_path)
+    _stub(runner, {"a": 1.0, "b": 1.0}, [])
+    runner.run_dataset(_config())
+    path = runner._target_result_path(_config(), 2, "a", "holo")
+    data = json.loads(path.read_text())
+    if mutation == "old_schema":
+        data.pop("schema_version")
+    elif mutation == "wrong_target":
+        data["poses"][0]["target_id"] = "other"
+    elif mutation == "missing_pose_field":
+        data["poses"][0].pop("entropy")
+    elif mutation == "nonfinite":
+        data["poses"][0]["rmsd"] = float("nan")
+    elif mutation == "wrong_score":
+        data["poses"][0]["total_score"] = -100.0
+    else:
+        data["provenance"]["protocol"]["temperature"] = 500.0
+    path.write_text(json.dumps(data))
+    calls = []
+    runner.resume = True
+    _stub(runner, {}, calls)
+    with pytest.raises(ValueError, match="Refusing unverified resume"):
+        runner.run_dataset(_config())
+    assert calls == []
+
+
+def test_changed_ranking_objective_rejects_cache(tmp_path):
+    runner = _runner(tmp_path)
+    _stub(runner, {"a": 1.0, "b": 1.0}, [])
+    runner.run_dataset(_config())
+    legacy = _runner(tmp_path, resume=True, ranking_objective="legacy_cf_minus_s")
+    with pytest.raises(ValueError, match="protocol differs"):
+        legacy.run_dataset(_config())
+
+
+def test_mixed_state_pool_refused_and_explicit_single_state_honored(tmp_path):
+    cfg = _config()
+    cfg.structural_states = ["holo", "apo"]
+    runner = _runner(tmp_path)
+    calls = []
+    _stub(runner, {"a": 1.0, "b": None}, calls)
+    with pytest.raises(ValueError, match="Mixed structural states"):
+        runner.run_dataset(cfg)
+    assert calls == []
+    result = runner.run_dataset(cfg, structural_states=["apo"])
+    assert result.observation_roster == [("a", "apo"), ("b", "apo")]
+    assert result.metrics["docking_power_top1"] == 0.5
+
+
+def test_bootstrap_samples_full_roster_including_empty_target(tmp_path, monkeypatch):
+    runner = _runner(tmp_path, bootstrap_ci=True, n_bootstrap=20)
+    samples = []
+    def bootstrap(fn, data, **kwargs):
+        samples.append(data)
+        assert len(data) == 2
+        assert sorted(len(bucket) for bucket in data) == [0, 1]
+        value = fn(data)
+        assert value == 0.5
+        # Duplicate draws must count twice, not collapse into one target.
+        assert fn([data[0], data[0]]) == 1.0
+        return value, value
+    monkeypatch.setattr("flexaidds.dataset_runner.runner.bootstrap_ci", bootstrap)
+    _stub(runner, {"a": 1.0, "b": None}, [])
+    result = runner.run_dataset(_config())
+    assert samples
+    assert result.ci_95["docking_power_top1"] == (0.5, 0.5)
+
+
+def test_frozen_85_manifest_keeps_omitted_target_in_denominator(tmp_path):
+    from pathlib import Path
+    manifest = Path(__file__).resolve().parents[2] / "benchmarks/protocols/astex85_target_manifest.json"
+    frozen = json.loads(manifest.read_text())
+    assert frozen["N"] == 85
+    scheduled = [target for target in frozen["targets"] if target != "2HR7"]
+    assert len(scheduled) == 84
+    cfg = DatasetConfig(slug="astex_diverse", name="Scalar frozen-roster fixture", description="",
+                        targets=scheduled, metrics=["docking_power_top1"])
+    runner = _runner(tmp_path, expected_target_manifest=manifest)
+    calls = []
+    _stub(runner, {target: 1.0 for target in scheduled}, calls)
+    result = runner.run_dataset(cfg)
+    assert len(calls) == 84
+    assert result.to_dict()["docking_power_denominator"] == 85
+    assert result.metrics["docking_power_top1"] == 84 / 85
+    assert result.targets_failed == ["2HR7"]
+    assert result.observations_failed == [("2HR7", "holo")]
+    assert result.expected_target_manifest["sha256"] == "d207666a414422b2eea9f92ebe67a72aad9f3ac87ad029ed56609870aa414326"
+    assert result.expected_target_manifest["sha256_of_sorted_codes"] == "da89650afd791e27924afbe403efdae5c63400ffce3b4c52a4c42351f4102afc"
+    runner.resume = True
+    calls.clear()
+    resumed = runner.run_dataset(cfg)
+    assert calls == []
+    assert _verdict(resumed) == _verdict(result)
+
+
+def test_changed_baseline_reuses_evidence_but_recomputes_verdict(tmp_path):
+    cfg = _config()
+    runner = _runner(tmp_path)
+    _stub(runner, {"a": 1.0, "b": None}, [])
+    fresh = runner.run_dataset(cfg)
+    assert fresh.regression_flags["docking_power_top1"] is True
+    cfg.expected_baselines["docking_power_top1"] = 0.25
+    runner.resume = True
+    resumed = runner.run_dataset(cfg)
+    assert resumed.metrics == fresh.metrics
+    assert resumed.regression_flags["docking_power_top1"] is False
+
+
+def test_canonical_manifest_keeps_scheduled_checkpoint_case(tmp_path, monkeypatch):
+    from pathlib import Path
+    manifest = Path(__file__).resolve().parents[2] / "benchmarks/protocols/astex85_target_manifest.json"
+    cfg = DatasetConfig(slug="astex_diverse", name="Case-sensitive fixture", description="",
+                        targets=["1g9v"], metrics=["docking_power_top1"])
+    runner = _runner(tmp_path, expected_target_manifest=manifest)
+    _stub(runner, {"1g9v": 1.0}, [])
+    actual_path = runner._target_result_path
+    def case_sensitive_path(config, tier, target_id, state):
+        # This assertion catches the Linux failure even on case-insensitive APFS.
+        assert target_id == "1g9v", "canonical claim label was used as checkpoint filename"
+        return actual_path(config, tier, target_id, state)
+    monkeypatch.setattr(runner, "_target_result_path", case_sensitive_path)
+    result = runner.run_dataset(cfg)
+    assert result.targets_completed == ["1G9V"]
+    saved_manifest = json.loads((tmp_path / "astex_diverse/tier2/_entry_manifest.json").read_text())
+    assert "1G9V_holo" in saved_manifest["timings"]["per_entry_wall_seconds"]
+    assert saved_manifest["checkpoint_files"] == {"1G9V_holo": "1g9v_holo.json"}
+    runner.resume = True
+    resumed = runner.run_dataset(cfg)
+    assert resumed.metrics == result.metrics

--- a/tests/test_ccbm.cpp
+++ b/tests/test_ccbm.cpp
@@ -44,10 +44,6 @@ protected:
 
     void SetUp() override {
         mock_fa = new FA_Global();
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnontrivial-memcall"
-        std::memset(mock_fa, 0, sizeof(FA_Global));
-#pragma clang diagnostic pop
         mock_fa->temperature = static_cast<uint>(TEMP);
         mock_fa->multi_model = false;
         mock_fa->n_models = 1;
@@ -63,7 +59,7 @@ protected:
         mock_vc = new VC_Global();
         std::memset(mock_vc, 0, sizeof(VC_Global));
 
-        mock_chroms = new chromosome[N_CHROMS];
+        mock_chroms = new chromosome[N_CHROMS]();
         for (int i = 0; i < N_CHROMS; ++i) {
             mock_chroms[i].genes = new gene[N_GENES];
             std::memset(mock_chroms[i].genes, 0, sizeof(gene) * N_GENES);
@@ -120,6 +116,65 @@ protected:
 // ===========================================================================
 // POSE total_energy() TESTS
 // ===========================================================================
+
+TEST_F(CCBMTest, ProductionPoseConversionRetainsReceptorModelIdentity) {
+    mock_fa->multi_model = true;
+    mock_fa->n_models = 2;
+    mock_fa->model_gene_index = N_GENES - 1;
+    mock_fa->model_strain = {0.0, 3.0};
+    BindingMode mode(test_population);
+    for (int i = 0; i < 2; ++i) {
+        mock_chroms[i].genes[N_GENES - 1].to_ic = i;
+        // These evaluated scores already include any model strain.
+        mock_chroms[i].app_evalue = -10.0;
+        Pose p = Pose::from_chromosome(&mock_chroms[i], i, i, 0.5f,
+            static_cast<uint>(TEMP), {1.0f, 2.0f}, *mock_fa, N_GENES);
+        EXPECT_EQ(p.model_index, i);
+        EXPECT_EQ(p.chrom, &mock_chroms[i]);
+        EXPECT_EQ(p.chrom_index, i);
+        EXPECT_EQ(p.order, i);
+        EXPECT_EQ(p.vPose, (std::vector<float>{1.0f, 2.0f}));
+        EXPECT_DOUBLE_EQ(p.CF, -10.0);
+        EXPECT_DOUBLE_EQ(p.total_energy(), -10.0);
+        EXPECT_DOUBLE_EQ(p.receptor_strain, 0.0);
+        mode.add_Pose(p);
+    }
+    const auto populations = mode.conformer_populations();
+    ASSERT_EQ(populations.size(), 2u);
+    EXPECT_NEAR(populations[0], 0.5, EPS);
+    EXPECT_NEAR(populations[1], 0.5, EPS);
+    EXPECT_NEAR(mode.receptor_conformational_entropy(), kB * std::log(2.0), EPS);
+}
+
+TEST_F(CCBMTest, ProductionModelDecoderMatchesRoundedClampedEvaluatorGene) {
+    mock_fa->multi_model = true;
+    mock_fa->n_models = 3;
+    mock_fa->model_gene_index = N_GENES - 1;
+    for (const auto& sample : std::vector<std::pair<double, int>>{
+             {-1.0e30, 0}, {0.49, 0}, {0.5, 1}, {1.49, 1}, {1.5, 2}, {1.0e30, 2}}) {
+        mock_chroms[0].genes[N_GENES - 1].to_ic = sample.first;
+        EXPECT_EQ(chromosome_model_index(mock_chroms[0], *mock_fa, N_GENES), sample.second);
+    }
+    mock_chroms[0].genes[N_GENES - 1].to_ic = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_THROW(chromosome_model_index(mock_chroms[0], *mock_fa, N_GENES), std::invalid_argument);
+    mock_fa->model_gene_index = N_GENES;
+    EXPECT_THROW(chromosome_model_index(mock_chroms[0], *mock_fa, N_GENES), std::invalid_argument);
+    mock_fa->model_gene_index = -1;
+    EXPECT_THROW(chromosome_model_index(mock_chroms[0], *mock_fa, N_GENES), std::invalid_argument);
+}
+
+TEST_F(CCBMTest, ProductionPoseConversionPreservesSingleModelBehavior) {
+    mock_chroms[0].app_evalue = -7.5;
+    const Pose old_pose(&mock_chroms[0], 0, 2, 0.25f, static_cast<uint>(TEMP), {});
+    const Pose pose = Pose::from_chromosome(&mock_chroms[0], 0, 2, 0.25f,
+        static_cast<uint>(TEMP), {}, *mock_fa, N_GENES);
+    EXPECT_EQ(pose.model_index, 0);
+    EXPECT_DOUBLE_EQ(pose.CF, old_pose.CF);
+    EXPECT_DOUBLE_EQ(pose.boltzmann_weight, old_pose.boltzmann_weight);
+    EXPECT_DOUBLE_EQ(pose.total_energy(), old_pose.total_energy());
+    EXPECT_THROW(Pose::from_chromosome(nullptr, 0, 0, 0.0f,
+        static_cast<uint>(TEMP), {}, *mock_fa, N_GENES), std::invalid_argument);
+}
 
 TEST_F(CCBMTest, TotalEnergyIncludesStrain) {
     Pose p = make_ccbm_pose(-10.0, 1, 2.5, 0);

--- a/tests/test_gaboom.cpp
+++ b/tests/test_gaboom.cpp
@@ -9,6 +9,7 @@
 // flexaid.h defines E as a macro which conflicts with GoogleTest templates.
 // Include gtest first, then our headers.
 #include "../LIB/gaboom.h"
+#include "../LIB/GaEliteBuffer.h"
 
 #include <cmath>
 #include <cstdlib>
@@ -219,6 +220,73 @@ TEST(CopyChrom, CopiesAllFields) {
         EXPECT_EQ(dst.genes[i].to_int32, src.genes[i].to_int32);
         EXPECT_DOUBLE_EQ(dst.genes[i].to_ic, src.genes[i].to_ic);
     }
+}
+
+TEST(GaElitism, RestoresCachedScoreWithOwnedGenesAndEveryRingField) {
+    ChromArray population(3, 2);
+    auto full_state_score = [](const chromosome& c) {
+        return c.genes[0].to_ic + 2.0 * c.genes[1].to_ic +
+               c.ring_phases[0] + 10.0 * c.ring_six[0] + 100.0 * c.ring_five[0];
+    };
+    for (int i = 0; i < 3; ++i) {
+        auto& c = population[i];
+        c.genes[0] = {i + 10, static_cast<double>(i)};
+        c.genes[1] = {i + 20, static_cast<double>(i + 1)};
+        c.ring_phases[0] = 20.0f + 100.0f * i;
+        c.ring_six[0] = i + 1;
+        c.ring_five[0] = i + 1;
+        c.ring_phases[MAX_RING_FLEX - 1] = 71.0f + i;
+        c.ring_six[MAX_RING_FLEX - 1] = i + 2;
+        c.ring_five[MAX_RING_FLEX - 1] = i + 3;
+        c.evalue = c.cf.com = full_state_score(c);
+        c.app_evalue = c.evalue - 1.0;
+        c.status = 'n';
+    }
+    const chromosome elite = population[0];
+    const gene elite_genes[] = {population[0].genes[0], population[0].genes[1]};
+    gene* const destination_storage = population[2].genes;
+    flexaids::GaEliteBuffer saved(1, 2);
+    saved.capture(population.data(), 3);
+    // Reproduction destroys the original elite's storage and leaves the worst
+    // destination with a different pucker. The actual GA restore must own both.
+    population[0].genes[0].to_ic = 999.0;
+    population[0].ring_phases[0] = 359.0f;
+    population[2].fitnes = population[2].free_energy = population[2].boltzmann_weight = 9.0;
+    saved.restore(population.data(), 3);
+    const auto& restored = population[2];
+    EXPECT_EQ(restored.genes, destination_storage);
+    EXPECT_NE(restored.genes, population[0].genes);
+    EXPECT_EQ(restored.genes[0].to_int32, elite_genes[0].to_int32);
+    EXPECT_DOUBLE_EQ(restored.genes[0].to_ic, elite_genes[0].to_ic);
+    EXPECT_DOUBLE_EQ(restored.genes[1].to_ic, elite_genes[1].to_ic);
+    EXPECT_EQ(std::memcmp(restored.ring_phases, elite.ring_phases, sizeof(elite.ring_phases)), 0);
+    EXPECT_EQ(std::memcmp(restored.ring_six, elite.ring_six, sizeof(elite.ring_six)), 0);
+    EXPECT_EQ(std::memcmp(restored.ring_five, elite.ring_five, sizeof(elite.ring_five)), 0);
+    EXPECT_DOUBLE_EQ(restored.evalue, full_state_score(restored));
+    EXPECT_DOUBLE_EQ(restored.cf.com, restored.evalue);
+    EXPECT_DOUBLE_EQ(restored.app_evalue, elite.app_evalue);
+    EXPECT_EQ(restored.status, 'n');
+    EXPECT_DOUBLE_EQ(restored.fitnes, 0.0);
+    EXPECT_DOUBLE_EQ(restored.free_energy, 0.0);
+    EXPECT_DOUBLE_EQ(restored.boltzmann_weight, 0.0);
+}
+
+TEST(GaElitism, MultipleElitesKeepRankAndDoNotCertifyUnscoredChromosomes) {
+    ChromArray population(3, 1);
+    for (int i = 0; i < 3; ++i) {
+        population[i].evalue = i + 1;
+        population[i].genes[0].to_ic = i + 1;
+        population[i].status = i == 0 ? 'o' : 'n';
+    }
+    flexaids::GaEliteBuffer saved(2, 1);
+    saved.capture(population.data(), 3);
+    for (int i = 0; i < 3; ++i) population[i].evalue = 10 + i;
+    saved.restore(population.data(), 3);
+    EXPECT_DOUBLE_EQ(population[2].evalue, 1.0);
+    EXPECT_DOUBLE_EQ(population[1].evalue, 2.0);
+    EXPECT_EQ(population[2].status, 'o');
+    EXPECT_EQ(population[1].status, 'n');
+    EXPECT_DOUBLE_EQ(population[0].evalue, 10.0);
 }
 
 TEST(SwapChrom, SwapsContents) {

--- a/tests/test_gaboom.cpp
+++ b/tests/test_gaboom.cpp
@@ -10,6 +10,10 @@
 // Include gtest first, then our headers.
 #include "../LIB/gaboom.h"
 #include "../LIB/GaEliteBuffer.h"
+#include "../LIB/GaEvaluationPolicy.h"
+#include "../LIB/GaPopulationReceipt.h"
+#include "../LIB/RngSeed.h"
+#include "../LIB/GAContext.h"
 
 #include <cmath>
 #include <cstdlib>
@@ -19,6 +23,8 @@
 #include <algorithm>
 #include <numeric>
 #include <string>
+#include <atomic>
+#include <memory>
 
 // ===========================================================================
 // HELPERS
@@ -287,6 +293,126 @@ TEST(GaElitism, MultipleElitesKeepRankAndDoNotCertifyUnscoredChromosomes) {
     EXPECT_EQ(population[2].status, 'o');
     EXPECT_EQ(population[1].status, 'n');
     EXPECT_DOUBLE_EQ(population[0].evalue, 10.0);
+}
+
+namespace {
+class GaScopedEnvironment {
+public:
+    GaScopedEnvironment(const char* name, const char* value) : name_(name) {
+        const char* previous = std::getenv(name);
+        existed_ = previous != nullptr;
+        if (previous) previous_ = previous;
+        set(value);
+    }
+    ~GaScopedEnvironment() { set(existed_ ? previous_.c_str() : nullptr); }
+private:
+    void set(const char* value) {
+#ifdef _WIN32
+        _putenv_s(name_.c_str(), value ? value : "");
+#else
+        if (value) setenv(name_.c_str(), value, 1);
+        else unsetenv(name_.c_str());
+#endif
+    }
+    std::string name_, previous_;
+    bool existed_;
+};
+
+std::atomic<int> population_target_calls{0};
+
+cfstr population_scheduling_target(FA_Global*, VC_Global*, atom*, resid*,
+                                  gridpoint*, int, double* values) {
+    ++population_target_calls;
+    // Actual production RNG stream: a worker assignment changes this score.
+    auto& rng = flexaids_rng::lazy_thread_rng(0x0C0A11ULL);
+    cfstr result{};
+    result.com = values[0] + std::uniform_real_distribution<double>(0.0, 0.1)(rng);
+    return result;
+}
+}  // namespace
+
+TEST(GaEvaluation, DeterministicGenerationZeroUsesOneActualWorkerAndStableScores) {
+    GaScopedEnvironment deterministic("FLEXAID_DETERMINISTIC", "1");
+    GaScopedEnvironment cpu("FLEXAIDDS_FORCE_CPU", "1");
+    GaScopedEnvironment receipt("FLEXAIDDS_GEN0_RECEIPT", "observer-only-no-file-written");
+#ifdef _OPENMP
+    const int previous_threads = omp_get_max_threads();
+    const int previous_dynamic = omp_get_dynamic();
+    omp_set_dynamic(0);
+#endif
+    std::vector<std::pair<int32_t, double>> baseline;
+    for (int requested : {1, 4, 4}) {
+#ifdef _OPENMP
+        omp_set_num_threads(requested);
+#endif
+        auto fa = std::make_unique<FA_Global>();
+        auto gb = std::make_unique<GB_Global>();
+        VC_Global vc{};
+        atom atoms[2]{};
+        resid residues[2]{};
+        OptRes optres[1]{};
+        optmap map[1]{};
+        map[0].atm = 1;
+        fa->atm_cnt = fa->atm_cnt_real = fa->res_cnt = fa->num_optres = fa->ntypes = fa->npar = 1;
+        fa->optres = optres;
+        fa->map_par = map;
+        fa->temperature = 300.0;
+        atoms[1].optres = optres;
+        gb->num_chrom = 8;
+        gb->num_genes = 1;
+        gb->duplicates = 1;
+        std::strcpy(gb->fitness_model, "LINEAR");
+        genlim limits{};
+        limits.min = 0.0;
+        limits.max = 63.0;
+        limits.del = 1.0;
+        limits.nbin = 64.0;
+        limits.bin = 1.0 / 64.0;
+        ChromArray population(gb->num_chrom, 1);
+        int draw = 0;
+        std::function<int32_t()> dice = [&] { return ictogene(&limits, ++draw); };
+        std::unordered_map<size_t, int> duplicates;
+        char method[] = "RANDOM";
+        char file[] = "";
+        population_target_calls = 0;
+        flexaids_rng::set_master_seed(12345);
+        flexaids::GaPopulationObservation observation;
+        populate_chromosomes(fa.get(), gb.get(), &vc, population.data(), &limits,
+                             atoms, residues, nullptr, method, population_scheduling_target,
+                             file, 0, 0, 0, dice, duplicates);
+        EXPECT_EQ(population_target_calls.load(), gb->num_chrom);
+        ASSERT_EQ(observation.batches.size(), 1u);
+        const auto& batch = observation.batches[0];
+        EXPECT_EQ(batch.region, "populate_chromosomes");
+        ASSERT_EQ(batch.workers.size(), 1u);
+        EXPECT_EQ(batch.workers[0].team_size, 1);
+        EXPECT_EQ(batch.workers[0].evaluated_chromosomes, 8u);
+        std::vector<std::pair<int32_t, double>> scores;
+        for (const auto& c : population.chroms) {
+            EXPECT_EQ(c.status, 'n');
+            scores.emplace_back(c.genes[0].to_int32, c.evalue);
+        }
+        if (baseline.empty()) baseline = scores;
+        else EXPECT_EQ(scores, baseline) << "requested workers=" << requested;
+        for (auto& c : population.chroms) c.status = 'o';
+        flexaids_rng::set_master_seed(12345);
+        GAContext context;
+        calculate_fitness(fa.get(), gb.get(), &vc, population.data(), &limits,
+                          atoms, residues, nullptr, gb->fitness_model, gb->num_chrom,
+                          0, population_scheduling_target, context);
+        EXPECT_EQ(population_target_calls.load(), 2 * gb->num_chrom);
+        ASSERT_EQ(observation.batches.size(), 2u);
+        EXPECT_EQ(observation.batches[1].region, "calculate_fitness");
+        ASSERT_EQ(observation.batches[1].workers.size(), 1u);
+        EXPECT_EQ(observation.batches[1].workers[0].team_size, 1);
+        EXPECT_EQ(observation.batches[1].workers[0].evaluated_chromosomes, 8u);
+        for (int i = 0; i < gb->num_chrom; ++i)
+            EXPECT_DOUBLE_EQ(population[i].evalue, baseline[i].second);
+    }
+#ifdef _OPENMP
+    omp_set_num_threads(previous_threads);
+    omp_set_dynamic(previous_dynamic);
+#endif
 }
 
 TEST(SwapChrom, SwapsContents) {

--- a/tests/test_parallel_dock.cpp
+++ b/tests/test_parallel_dock.cpp
@@ -6,10 +6,17 @@
 #include <set>
 #include <numeric>
 #include <latch>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
 #include <thread>
 #include <vector>
 #include <barrier>
 #include "../LIB/AtomCopyExtent.h"
+#include "../LIB/SerialRegionExecution.h"
+#include "../LIB/RegionScoringWorkspace.h"
 #include "../LIB/GridDecomposer.h"
 #include "../LIB/SharedPosePool.h"
 #include "../LIB/statmech.h"
@@ -377,45 +384,145 @@ TEST(ParallelDockWorkspace, AtomCopyIncludesLastOneBasedAtom) {
 }
 
 // ============================================================================
-// thread_local workspace isolation (gaboom ParEvalWS under --parallel-dock)
+// Production region scheduling and scratch ownership
 // ============================================================================
-// Not a race test: two threads write distinct sentinels and publish addresses
-// after join. A process-wide static would share one object; thread_local must
-// not. Production: thread_local ParEvalWS in gaboom.cpp calculate_fitness.
-//
-// Both threads must be ALIVE when they publish &ws. Without a rendezvous t0
-// can run to completion before t1 is scheduled, and the runtime may hand t1
-// the thread-local block t0 just released: p0 == p1 with no sharing at all.
-// Observed on macOS under `ctest -j4` (2 of 4 runs); never in isolation.
 
-TEST(ParEvalWSIsolation, ThreadLocalWorkspacesDoNotShare) {
-    struct WS { int sentinel = 0; };
-    thread_local WS ws;
+namespace {
+void set_region_test_seed_env(const char* value) {
+#ifdef _WIN32
+    _putenv_s("FLEXAID_SEED", value ? value : "");
+#else
+    if (value) setenv("FLEXAID_SEED", value, 1);
+    else unsetenv("FLEXAID_SEED");
+#endif
+}
 
-    WS* p0 = nullptr;
-    WS* p1 = nullptr;
-    int v0 = -1;
-    int v1 = -1;
-    std::latch both_published(2);
+struct RegionSeedStateGuard {
+    const bool had_env = std::getenv("FLEXAID_SEED") != nullptr;
+    const std::string env = had_env ? std::getenv("FLEXAID_SEED") : "";
+    const bool had_master = flexaids_rng::has_master_seed();
+    const std::uint64_t master = flexaids_rng::master_seed();
 
-    std::thread t0([&] {
-        ws.sentinel = 7;
-        p0 = &ws;
-        v0 = ws.sentinel;
-        both_published.arrive_and_wait();
+    ~RegionSeedStateGuard() {
+        set_region_test_seed_env(had_env ? env.c_str() : nullptr);
+        flexaids_rng::set_master_seed(master);
+        flexaids_rng::g_has_master_seed.store(had_master);
+    }
+};
+}  // namespace
+
+TEST(SerialRegionExecution, ExplicitParentSeedSurvivesPriorRegionEpochs) {
+    RegionSeedStateGuard restore;
+    set_region_test_seed_env("12345");
+    std::uint64_t first = 0, repeated = 0;
+    flexaids_rng::set_master_seed(98765);
+    EXPECT_TRUE(flexaids::resolve_region_parent_seed(0, first));
+    EXPECT_EQ(first, 12345u);
+
+    // Exercise the same mutation each actual region GA performs.
+    flexaids_rng::set_master_seed(flexaids::region_seed(first, 3));
+    EXPECT_TRUE(flexaids::resolve_region_parent_seed(0, repeated));
+    EXPECT_EQ(repeated, first);
+    EXPECT_EQ(flexaids::region_seed(repeated, 0), flexaids::region_seed(first, 0));
+
+    // A configured GB seed still wins; a master seed is only a fallback.
+    EXPECT_TRUE(flexaids::resolve_region_parent_seed(444, repeated));
+    EXPECT_EQ(repeated, 444u);
+    set_region_test_seed_env(nullptr);
+    flexaids_rng::set_master_seed(777);
+    EXPECT_TRUE(flexaids::resolve_region_parent_seed(0, repeated));
+    EXPECT_EQ(repeated, 777u);
+}
+
+TEST(SerialRegionExecution, ConcurrentDispatchersCannotOverlapRegionCallbacks) {
+    // Same dispatcher as ParallelDockManager::run; no stand-in thread_local.
+    std::atomic<int> active{0}, peak{0}, completed{0};
+    std::latch ready(2);
+    auto dispatch = [&] {
+        ready.arrive_and_wait();
+        flexaids::for_each_serial_region(0, 3, 1, [&](int region) {
+            const int now = ++active;
+            int prior = peak.load();
+            while (prior < now && !peak.compare_exchange_weak(prior, now)) {}
+            flexaids_rng::set_master_seed(flexaids::region_seed(12345, region));
+            const auto epoch = flexaids_rng::g_seed_epoch.load();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            EXPECT_EQ(flexaids_rng::g_seed_epoch.load(), epoch);
+            --active;
+            ++completed;
+        });
+    };
+    std::thread first(dispatch), second(dispatch);
+    first.join();
+    second.join();
+    EXPECT_EQ(completed.load(), 6);
+    EXPECT_EQ(peak.load(), 1);
+}
+
+TEST(SerialRegionExecution, RegionSeedsFollowGlobalIndexAcrossRankAssignments) {
+    std::vector<int> local(8), distributed(8);
+    flexaids::for_each_serial_region(0, 8, 1, [&](int region) {
+        local[region] = flexaids::region_seed(12345, region);
+        EXPECT_GT(local[region], 0);
     });
-    std::thread t1([&] {
-        ws.sentinel = 9;
-        p1 = &ws;
-        v1 = ws.sentinel;
-        both_published.arrive_and_wait();
-    });
-    t0.join();
-    t1.join();
+    for (int rank = 0; rank < 3; ++rank)
+        flexaids::for_each_serial_region(rank, 8, 3, [&](int region) {
+            distributed[region] = flexaids::region_seed(12345, region);
+        });
+    EXPECT_EQ(distributed, local);
+    EXPECT_EQ(std::set<int>(local.begin(), local.end()).size(), local.size());
+    EXPECT_NE(flexaids::region_seed(98765, 0), local[0]);
+}
 
-    ASSERT_NE(p0, nullptr);
-    ASSERT_NE(p1, nullptr);
-    EXPECT_NE(p0, p1);
-    EXPECT_EQ(v0, 7);
-    EXPECT_EQ(v1, 9);
+TEST(RegionScoringWorkspace, OwnsScratchRebindsOptresAndSupportsContactReallocation) {
+    auto fa = std::make_unique<FA_Global>();
+    GB_Global gb{};
+    VC_Global vc{};
+    atom atoms[3]{};
+    resid residues[2]{};
+    OptRes optres[1]{};
+    fa->atm_cnt = fa->atm_cnt_real = 2;
+    fa->res_cnt = fa->num_optres = fa->ntypes = 1;
+    fa->optres = optres;
+    atoms[2].optres = &optres[0];
+    atoms[2].coor[0] = 17.0f;
+    optres[0].cf.com = 42.0;
+    ca_struct parent_contact{};
+    parent_contact.area = 8.5;
+    vc.ca_rec = &parent_contact; // deliberately non-heap: must never free/realloc parent
+    vc.ca_recsize = 100;
+    auto first = std::make_unique<flexaids::RegionScoringWorkspace>(*fa, gb, vc, atoms, residues);
+    auto second = std::make_unique<flexaids::RegionScoringWorkspace>(*fa, gb, vc, atoms, residues);
+    EXPECT_EQ(first->atoms_copy[2].optres, &first->optres[0]);
+    EXPECT_EQ(second->atoms_copy[2].optres, &second->optres[0]);
+    EXPECT_EQ(first->atoms_copy[1].optres, nullptr);
+    EXPECT_NE(first->fa.optres, fa->optres);
+    EXPECT_NE(first->fa.contacts, second->fa.contacts);
+    EXPECT_NE(first->fa.contributions, second->fa.contributions);
+    EXPECT_NE(first->vc.Calc, second->vc.Calc);
+    EXPECT_NE(first->vc.Calclist, second->vc.Calclist);
+    EXPECT_NE(first->vc.ca_rec, vc.ca_rec);
+    EXPECT_NE(first->vc.ca_index, second->vc.ca_index);
+    EXPECT_NE(first->vc.seed, second->vc.seed);
+    EXPECT_NE(first->vc.contlist, second->vc.contlist);
+    EXPECT_NE(first->vc.ptorder, second->vc.ptorder);
+    EXPECT_NE(first->vc.centerpt, second->vc.centerpt);
+    EXPECT_NE(first->vc.poly, second->vc.poly);
+    EXPECT_NE(first->vc.cont, second->vc.cont);
+    EXPECT_NE(first->vc.vedge, second->vc.vedge);
+    EXPECT_NE(first->vc.scorable_list, second->vc.scorable_list);
+    first->atoms_copy[2].optres->cf.com = -5.0;
+    first->vc.Calc[0].atom = &first->atoms_copy[2];
+    EXPECT_DOUBLE_EQ(optres[0].cf.com, 42.0);
+    EXPECT_DOUBLE_EQ(second->optres[0].cf.com, 42.0);
+    // save_areas() is permitted to realloc this exact allocation. Using a
+    // vector's data() here is an allocator mismatch, even without concurrency.
+    auto* grown = static_cast<ca_struct*>(std::realloc(first->vc.ca_rec, 10100 * sizeof(ca_struct)));
+    ASSERT_NE(grown, nullptr);
+    first->vc.ca_rec = grown;
+    first->vc.ca_recsize = 10100;
+    first.reset();
+    EXPECT_FLOAT_EQ(parent_contact.area, 8.5f);
+    EXPECT_EQ(atoms[2].optres, optres);
+    EXPECT_FLOAT_EQ(atoms[2].coor[0], 17.0f);
 }

--- a/tests/test_rigid_fastpath.cpp
+++ b/tests/test_rigid_fastpath.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <map>
 #include <string>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 
@@ -414,7 +415,9 @@ protected:
     void free_vc_box()
     {
         if (vc_.box) {
-            std::free(vc_.box);
+            // vindex boxes belong to Vcontacts' TLS map and remain available
+            // to subsequent calls/workspaces on this thread.
+            if (!fa_.vindex) std::free(vc_.box);
             vc_.box = nullptr;
         }
     }
@@ -654,6 +657,148 @@ TEST_F(RigidFastpathBitIdentity, FastpathActiveOnStableSecondOnEval)
     if (off.fastpath_used >= 0) {
         EXPECT_EQ(off.fastpath_used, 0);
     }
+}
+
+// A region can be destroyed/recreated on the same thread, including reuse of
+// every heap address. Fresh Calc storage must never inherit the old region's
+// TLS rigid snapshot or its per-atom hoisted box assignments.
+TEST_F(RigidFastpathBitIdentity, FreshWorkspaceInvalidatesWarmThreadCache)
+{
+    for (int cache_boxes : {0, 1}) {
+        SCOPED_TRACE(cache_boxes);
+        fa_.vindex = cache_boxes;
+        for (bool fastpath : {false, true}) {
+            SCOPED_TRACE(fastpath);
+            clear_fastpath_env();
+            const PoseRecord gold = eval_vcontacts(0);
+            ASSERT_EQ(gold.vcontacts_rc, 0);
+
+            // Exercise both the full rigid fastpath and HOIST on its own.
+            if (fastpath) set_rigid_fastpath(true);
+            else ASSERT_EQ(setenv("FLEXAIDDS_HOIST_RECEPTOR_INDEX", "1", 1), 0);
+            (void)eval_vcontacts(0);
+            const PoseRecord warm = eval_vcontacts(0);
+            expect_pose_eq(gold, warm, "warm workspace vs baseline");
+            if (fastpath) ASSERT_EQ(warm.fastpath_used, 1);
+
+            // Deliberately preserve storage addresses and semantic identity;
+            // pointer/count comparisons alone cannot detect this reset.
+            std::fill(calc_.begin(), calc_.end(), atomsas{});
+            std::fill(calclist_.begin(), calclist_.end(), -1);
+            std::fill(ca_index_.begin(), ca_index_.end(), -1);
+            std::fill(seed_.begin(), seed_.end(), -1);
+            vc_.calc_count = 0;
+            vc_.numcarec = 0;
+            vc_.n_scorable = 0;
+            vc_.fastpath_used = 0;
+
+            const PoseRecord fresh = eval_vcontacts(0);
+            ASSERT_EQ(fresh.vcontacts_rc, 0);
+            ASSERT_EQ(fresh.calc_count, kNAtoms);
+            EXPECT_EQ(fresh.fastpath_used, 0);
+            expect_pose_eq(gold, fresh, "fresh workspace vs baseline");
+            for (int i = 0; i < kNAtoms; ++i) {
+                EXPECT_EQ(calc_[static_cast<size_t>(i)].atom,
+                          &atoms_[static_cast<size_t>(i)]) << "atom " << i;
+                EXPECT_EQ(calc_[static_cast<size_t>(i)].residue,
+                          &residues_[i < kNRec ? 1 : 2]) << "atom " << i;
+            }
+
+            // Invalidating a fresh workspace must not disable subsequent reuse.
+            const PoseRecord second = eval_vcontacts(0);
+            expect_pose_eq(gold, second, "rewarmed workspace vs baseline");
+            if (fastpath) EXPECT_EQ(second.fastpath_used, 1);
+        }
+    }
+}
+
+// Both workspaces already have valid Calc arrays. Switching back to A must
+// discard B's TLS rigid snapshot even though A's calc_count remains nonzero.
+TEST_F(RigidFastpathBitIdentity, SwitchingBetweenWarmWorkspacesRebuildsSnapshot)
+{
+    for (int cache_boxes : {0, 1}) {
+        SCOPED_TRACE(cache_boxes);
+        fa_.vindex = cache_boxes;
+        clear_fastpath_env();
+        const PoseRecord gold_a = eval_vcontacts(0);
+        ASSERT_EQ(gold_a.vcontacts_rc, 0);
+
+        std::vector<atom> other_atoms = atoms_;
+        for (int i = 0; i < kNRec; ++i) other_atoms[i].coor[0] += CELLSIZE;
+        std::vector<atomsas> other_calc(kNAtoms);
+        std::vector<int> other_calclist(kNAtoms, -1), other_ca_index(kNAtoms, -1);
+        std::vector<int> other_seed(3 * kNAtoms, -1), other_scorable(kNAtoms);
+        VC_Global other_vc = vc_;
+        other_vc.Calc = other_calc.data();
+        other_vc.Calclist = other_calclist.data();
+        other_vc.ca_index = other_ca_index.data();
+        other_vc.seed = other_seed.data();
+        other_vc.scorable_list = other_scorable.data();
+        other_vc.calc_count = 0;
+        other_vc.numcarec = 0;
+        other_vc.n_scorable = 0;
+        other_vc.fastpath_used = 0;
+        other_vc.box = nullptr;
+        // Sequential calls can share transient hull/contact scratch. The two
+        // workspaces retain independent atoms, Calc, Calclist, seeds and counts.
+        auto switch_workspace = [&] {
+            atoms_.swap(other_atoms);
+            calc_.swap(other_calc);
+            calclist_.swap(other_calclist);
+            ca_index_.swap(other_ca_index);
+            seed_.swap(other_seed);
+            scorable_buf_.swap(other_scorable);
+            std::swap(vc_, other_vc);
+        };
+
+        switch_workspace();
+        const PoseRecord gold_b = eval_vcontacts(0);
+        ASSERT_EQ(gold_b.vcontacts_rc, 0);
+        ASSERT_NE(gold_a.boxnum, gold_b.boxnum)
+            << "rigid box assignments must distinguish these workspaces";
+        switch_workspace();
+
+        set_rigid_fastpath(true);
+        (void)eval_vcontacts(0);
+        const PoseRecord warm_a = eval_vcontacts(0);
+        ASSERT_EQ(warm_a.fastpath_used, 1);
+        expect_pose_eq(gold_a, warm_a, "warm A vs baseline A");
+
+        switch_workspace();
+        ASSERT_GT(vc_.calc_count, 0);
+        const PoseRecord switched_b = eval_vcontacts(0);
+        EXPECT_EQ(switched_b.fastpath_used, 0);
+        expect_pose_eq(gold_b, switched_b, "A->B switch vs baseline B");
+        const PoseRecord warm_b = eval_vcontacts(0);
+        ASSERT_EQ(warm_b.fastpath_used, 1);
+
+        switch_workspace();
+        ASSERT_GT(vc_.calc_count, 0);
+        const PoseRecord switched_a = eval_vcontacts(0);
+        EXPECT_EQ(switched_a.fastpath_used, 0);
+        expect_pose_eq(gold_a, switched_a, "B->A switch vs baseline A");
+        EXPECT_EQ(eval_vcontacts(0).fastpath_used, 1);
+    }
+}
+
+// Run cached indexing on a disposable worker: its cache must survive scoring
+// reuse, then its TLS destructor owns cleanup at join. ASan/LSan CI checks the
+// actual allocation lifetime; the fixture never manually frees cached boxes.
+TEST_F(RigidFastpathBitIdentity, CachedBoxesSurviveWorkerReuseAndThreadExit)
+{
+    fa_.vindex = 1;
+    set_rigid_fastpath(true);
+    PoseRecord first, second;
+    std::thread worker([&] {
+        first = eval_vcontacts(0);
+        second = eval_vcontacts(1);
+    });
+    worker.join();
+    EXPECT_EQ(first.vcontacts_rc, 0);
+    EXPECT_EQ(second.vcontacts_rc, 0);
+    EXPECT_EQ(first.fastpath_used, 0);
+    EXPECT_EQ(second.fastpath_used, 1);
+    EXPECT_EQ(vc_.box, nullptr);
 }
 
 // Default-OFF: never leave the flag set (TearDown also unsets).

--- a/tests/test_vcontacts_failsafe.cpp
+++ b/tests/test_vcontacts_failsafe.cpp
@@ -1,0 +1,253 @@
+// CORE-2 / CORE-6: exercise the production voronoi_poly2 retry and exit paths.
+// The test-only hook raises the edge-limit trigger on a small bounded hull;
+// plane generation, jitter, RESTART, successful completion and error return are
+// the actual LIB/Vcontacts.cpp implementation, not a mirror of its guard logic.
+// Apache-2.0
+
+#include <gtest/gtest.h>
+#include "Vcontacts.h"
+#include "RngSeed.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#ifndef FLEXAIDS_VCONTACTS_TEST_HOOKS
+#error "This regression must link production Vcontacts.cpp with its test hook enabled"
+#endif
+
+namespace {
+
+class ScopedEnv {
+public:
+    ScopedEnv(const char* name, const char* value) : name_(name) {
+        const char* previous = std::getenv(name);
+        had_previous_ = previous != nullptr;
+        if (previous) previous_ = previous;
+        set(value);
+    }
+    ~ScopedEnv() { set(had_previous_ ? previous_.c_str() : nullptr); }
+    ScopedEnv(const ScopedEnv&) = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+    void set(const char* value) {
+#ifdef _WIN32
+        _putenv_s(name_.c_str(), value ? value : "");
+#else
+        if (value) setenv(name_.c_str(), value, 1);
+        else unsetenv(name_.c_str());
+#endif
+    }
+private:
+    std::string name_;
+    std::string previous_;
+    bool had_previous_ = false;
+};
+
+struct Hull {
+    static constexpr int contact_count = 6;
+    std::array<atom, 7> atoms{};
+    std::array<atomsas, 7> calc{};
+    std::array<contactlist, contact_count> contacts{};
+    std::array<plane, contact_count + 4> planes{};
+    std::array<vertex, contact_count> centers{};
+    std::vector<vertex> poly = std::vector<vertex>(MAX_POLY);
+    std::vector<edgevector> edges = std::vector<edgevector>(MAX_POLY);
+    std::array<int, 21> seeds{};
+    std::array<std::array<float, 3>, 7> pristine{};
+    VC_Global vc{};
+
+    Hull() {
+        // Deliberately away from zero: the old restore-to-origin defect cannot
+        // pass accidentally. Six neighbours bound a cube with half-width 1.
+        const float origin[3] = {17.25f, -9.5f, 31.75f};
+        const float offsets[7][3] = {
+            {0, 0, 0}, {2, 0, 0}, {-2, 0, 0}, {0, 2, 0},
+            {0, -2, 0}, {0, 0, 2}, {0, 0, -2}
+        };
+        for (int i = 0; i < 7; ++i) {
+            atoms[i].number = 90000 + i;
+            atoms[i].radius = 1.0f;
+            calc[i].atom = &atoms[i];
+            for (int axis = 0; axis < 3; ++axis) {
+                atoms[i].coor[axis] = origin[axis] + offsets[i][axis];
+                pristine[i][axis] = atoms[i].coor[axis];
+            }
+        }
+        for (int i = 0; i < contact_count; ++i) {
+            contacts[i].index = i + 1;
+            contacts[i].dist = 2.0;
+        }
+        seeds.fill(-1);
+        vc.Calc = calc.data();
+        vc.poly = poly.data();
+        vc.vedge = edges.data();
+        vc.centerpt = centers.data();
+        vc.seed = seeds.data();
+        vc.planedef = 'B';
+        vc.recalc = 1;
+    }
+
+    int run(int forced_failures, bool allow_retry = true) {
+        auto& trace = flexaids_vct_test::trace();
+        trace = {};
+        trace.force_failsafe_passes = forced_failures;
+        vc.recalc = allow_retry ? 1 : 0;
+        return voronoi_poly2(&vc, 0, planes.data(), 2.0f,
+                             contact_count, contacts.data());
+    }
+
+    void expect_input_preserved() const {
+        for (int i = 0; i < 7; ++i) {
+            EXPECT_EQ(std::memcmp(atoms[i].coor, pristine[i].data(),
+                                  sizeof(atoms[i].coor)), 0) << "atom " << i;
+        }
+    }
+};
+
+using Gates = std::tuple<bool, bool, bool>;  // local, eager guard, keyed jitter
+class VcontactsFailsafe : public ::testing::TestWithParam<Gates> {
+protected:
+    ScopedEnv local{"FLEXAIDDS_VCT_LOCAL_PERTURB", "0"};
+    ScopedEnv guard{"FLEXAIDDS_VCT_COORD_GUARD", "0"};
+    ScopedEnv diag{"FLEXAIDDS_VCT_FAILSAFE_DIAG", "0"};
+    ScopedEnv keyed{"FLEXAIDDS_VORONOI_KEYED_JITTER", "0"};
+    ScopedEnv stream_fix{"FLEXAIDDS_RNG_STREAM_FIX", "0"};
+
+    void SetUp() override {
+        local.set(std::get<0>(GetParam()) ? "1" : "0");
+        guard.set(std::get<1>(GetParam()) ? "1" : "0");
+        keyed.set(std::get<2>(GetParam()) ? "1" : "0");
+        flexaids_rng::set_master_seed(12345);
+    }
+
+    void expect_real_perturbation(const Hull& hull) {
+        const auto& trace = flexaids_vct_test::trace();
+        EXPECT_EQ(trace.local_mode, std::get<0>(GetParam()));
+        EXPECT_EQ(trace.coord_guard_requested, std::get<1>(GetParam()));
+        EXPECT_NE(std::memcmp(trace.working_after_perturb,
+                              hull.pristine[0].data(), 3 * sizeof(float)), 0);
+        if (std::get<0>(GetParam())) {
+            // Check inside the failsafe as well as after return: local mode
+            // must not rely on an eventual guard to undo an illegal write.
+            EXPECT_EQ(std::memcmp(trace.input_after_perturb,
+                                  hull.pristine[0].data(), 3 * sizeof(float)), 0);
+        } else {
+            EXPECT_EQ(std::memcmp(trace.input_after_perturb,
+                                  trace.working_after_perturb, 3 * sizeof(float)), 0);
+        }
+    }
+};
+
+TEST_P(VcontactsFailsafe, PristineCoordinatesAfterOneAndRepeatedRetries) {
+    for (int failures : {1, 3}) {
+        SCOPED_TRACE(failures);
+        Hull hull;
+        ASSERT_GT(hull.run(failures), 0);
+        const auto& trace = flexaids_vct_test::trace();
+        EXPECT_EQ(trace.force_failsafe_passes, 0);
+        EXPECT_EQ(trace.failsafe_entries, failures);
+        EXPECT_EQ(trace.hull_passes, failures + 1);
+        EXPECT_EQ(trace.success_exits, 1);
+        EXPECT_EQ(trace.error_exits, 0);
+        expect_real_perturbation(hull);
+        hull.expect_input_preserved();
+    }
+}
+
+TEST_P(VcontactsFailsafe, PristineCoordinatesOnFailsafeErrorExit) {
+    Hull hull;
+    ASSERT_EQ(hull.run(1, false), -1);
+    const auto& trace = flexaids_vct_test::trace();
+    EXPECT_EQ(trace.force_failsafe_passes, 0);
+    EXPECT_EQ(trace.failsafe_entries, 1);
+    EXPECT_EQ(trace.hull_passes, 1);
+    EXPECT_EQ(trace.success_exits, 0);
+    EXPECT_EQ(trace.error_exits, 1);
+    expect_real_perturbation(hull);
+    hull.expect_input_preserved();
+}
+
+TEST_P(VcontactsFailsafe, ValidHullHasAnalyticalCubeVerticesWithoutRetries) {
+    Hull hull;
+    ASSERT_EQ(hull.run(0), 8);
+    EXPECT_EQ(flexaids_vct_test::trace().failsafe_entries, 0);
+    EXPECT_EQ(flexaids_vct_test::trace().hull_passes, 1);
+    unsigned corners = 0;
+    for (int i = 0; i < 8; ++i) {
+        int corner = 0;
+        for (int axis = 0; axis < 3; ++axis) {
+            EXPECT_DOUBLE_EQ(std::abs(hull.poly[i].xi[axis]), 1.0);
+            if (hull.poly[i].xi[axis] > 0.0) corner |= 1 << axis;
+        }
+        corners |= 1u << corner;
+    }
+    EXPECT_EQ(corners, 0xffu);
+    hull.expect_input_preserved();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllGateCombinations, VcontactsFailsafe,
+                        ::testing::Combine(::testing::Bool(), ::testing::Bool(),
+                                           ::testing::Bool()));
+
+TEST(VcontactsFailsafeFlags, CanonicalTrueFalseAndFallbackSpellingsReachProduction) {
+    ScopedEnv local("FLEXAIDDS_VCT_LOCAL_PERTURB", nullptr);
+    ScopedEnv guard("FLEXAIDDS_VCT_COORD_GUARD", nullptr);
+    ScopedEnv diag("FLEXAIDDS_VCT_FAILSAFE_DIAG", nullptr);
+    ScopedEnv keyed("FLEXAIDDS_VORONOI_KEYED_JITTER", "1");
+    const std::pair<const char*, bool> values[] = {
+        {"1", true}, {"true", true}, {"yes", true}, {"on", true},
+        {"TRUE", true}, {"YeS", true}, {"ON", true}, {"  true  ", true},
+        {"0", false}, {"false", false}, {"no", false}, {"off", false},
+        {"FALSE", false}, {"No", false}, {"OFF", false}, {"  off  ", false},
+        {nullptr, false}, {"", false}, {"  ", false}, {"garbage", false},
+        {"2", false}
+    };
+    for (const auto& value : values) {
+        SCOPED_TRACE(value.first ? value.first : "unset");
+        local.set(value.first);
+        guard.set(value.first);
+        diag.set(value.first);
+        flexaids_rng::set_master_seed(12345);
+        Hull hull;
+        ::testing::internal::CaptureStderr();
+        const int result = hull.run(1, false);
+        const auto output = ::testing::internal::GetCapturedStderr();
+        ASSERT_EQ(result, -1);
+        const auto& trace = flexaids_vct_test::trace();
+        EXPECT_EQ(trace.local_mode, value.second);
+        EXPECT_EQ(trace.coord_guard_requested, value.second);
+        EXPECT_EQ(trace.diagnostics_enabled, value.second);
+        EXPECT_EQ(output.find("[VCT-FAILSAFE]") != std::string::npos, value.second);
+        hull.expect_input_preserved();
+    }
+}
+
+TEST(VcontactsFailsafeFlags, LocalDiagnosticsReportWorkingCopyDisplacement) {
+    ScopedEnv local("FLEXAIDDS_VCT_LOCAL_PERTURB", "on");
+    ScopedEnv guard("FLEXAIDDS_VCT_COORD_GUARD", "off");
+    ScopedEnv diag("FLEXAIDDS_VCT_FAILSAFE_DIAG", "yes");
+    ScopedEnv keyed("FLEXAIDDS_VORONOI_KEYED_JITTER", "1");
+    flexaids_rng::set_master_seed(12345);
+    Hull hull;
+    ::testing::internal::CaptureStderr();
+    const int result = hull.run(1, false);
+    const auto output = ::testing::internal::GetCapturedStderr();
+    ASSERT_EQ(result, -1);
+    const auto& trace = flexaids_vct_test::trace();
+    char expected[128];
+    std::snprintf(expected, sizeof(expected), "d=(%.6f,%.6f,%.6f)",
+                  trace.working_after_perturb[0] - hull.pristine[0][0],
+                  trace.working_after_perturb[1] - hull.pristine[0][1],
+                  trace.working_after_perturb[2] - hull.pristine[0][2]);
+    EXPECT_NE(output.find(expected), std::string::npos);
+    EXPECT_EQ(output.find("d=(0.000000,0.000000,0.000000)"), std::string::npos);
+    hull.expect_input_preserved();
+}
+
+}  // namespace


### PR DESCRIPTION
This repairs BENCH-1/2/3, CORE-2 through CORE-6, and SCI-1 from the main audit. Missing or empty targets previously disappeared from success-rate denominators; resumed runs lost quality/provenance evidence; Python reranking subtracted entropy without multiplying by temperature. The core fixes restore coordinate/state ownership, consistent evaluator scheduling and model identity.

- **BENCH-1/2:** use declared unique-target denominators, preserve absent/failed targets, and restore typed checkpoint observations and execution status before recomputing metrics/verdicts. Reject incompatible schema, protocol/input/scorer identities and mixed-state target pooling. Case-sensitive checkpoint discovery maps canonical manifest labels to scheduled paths.
- **BENCH-3:** expose `cf_minus_ts` and diagnostic `legacy_cf_minus_s`, retain emitted CF/S/T and other ledgers separately, and fail closed for nonzero entropy without valid temperature. Numeric output filename rank identifies generator election; an original cluster ID does not. Tests cover temperature dependence, ranking reversal, zero entropy and missing elected output.
- **CORE-2/6:** save pristine Voronoi coordinates before mutation and restore on every exit/retry; use the common boolean parser for the three optimization switches. Tests execute the real retry/error paths through compile-time test hooks.
- **CORE-3/5:** preserve complete elite ring state and use the same deterministic evaluator allocation/scheduling from generation zero onward.
- **CORE-4:** serialize region managers within each process while retaining inner OpenMP/MPI distribution; own region scratch and invalidate thread-local contact caches across region/lifetime changes. Explicit parent seeds survive prior region epochs.
- **SCI-1:** construct production poses through one chromosome factory, preserving decoded model identity without double-counting strain energy. Multi-model population tests use that production factory.

Validation of the combined implementation: fresh isolated macOS configure with `BUILD_TESTING=ON`, OpenMP on, a full serial build, **103/103 CTest checks passed** (1,894 GoogleTest cases started across 101 invocations; remaining checks include CLI probes), and **199 affected Python tests passed, one optional module skipped**. Strict source registration validation passed. Independent scoped reviews covered the core ownership, parser/checkpoint behavior and model propagation. Intermediate commits were inspected for dependency coherence; these counts describe the combined tree, not separate executions of every intermediate commit.

This branch includes the separate CI repair in #466: cached-epoch test correction, reservation-fixture cleanup and Windows release build wiring. The fixture cleanup and Windows compiler branch were added after the local full test pass and require hosted CI evidence. Further local compilation stopped because the active benchmark has RAM priority. Implementation/review: Codex (GPT-6), with independent scoped agent review.

**Scientific acceptance remains pending:** per METHODOLOGY §§1–3 and §5, OPS owns parity/determinism and any applicable accuracy gates before merge/campaign use. This PR makes no benchmark performance or pose-parity claim. No existing benchmark/result/cache, frozen binary, active driver, or live checkout changed.

Rescoring handoff: pin the existing `benchmarks/protocols/astex85_target_manifest.json` (85 targets, sorted roster SHA beginning `da89650a`). The current 84-target execution roster omits **2HR7**; the exclusion reason is unverified. Claude Science will score both comparison arms together with this scorer and the same explicit frozen denominator. No arms were rescored here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches GA elitism, parallel-dock concurrency, Voronoi failsafe coordinate paths, and benchmark scoring denominators—any of which can change docking trajectories or reported success rates without obvious runtime errors.
> 
> **Overview**
> Repairs audit findings across **DatasetRunner** benchmarks and the **C++ GA / parallel-dock / Vcontacts** stack so declared target rosters, resume checkpoints, and reranking scores stay honest and reproducible.
> 
> **Benchmark observation (BENCH-1/2/3):** Docking-power denominators can be pinned to an **expected-target manifest** (e.g. Astex 85) so absent or empty targets count as failures. **Resume** loads schema-2 checkpoints with strict protocol/input/scorer fingerprints and reapplies the same productivity/completeness gates as fresh runs. Reranking defaults to **`cf_minus_ts`** (`CF − T×S` from emitted REMARKs); **`legacy_cf_minus_s`** remains diagnostic. Parser and metrics keep generator rank (numeric PDB suffix), cluster `binding_mode`, and separate thermodynamic ledgers. CLI adds manifest and ranking flags; CI runs runner/metrics regression tests.
> 
> **Core engine:** **`ParallelDock`** runs region GAs **serially per process** (mutex + deterministic **`region_seed`**) while keeping inner OpenMP/MPI; **`RegionScoringWorkspace`** owns per-region scoring scratch. **`GaEliteBuffer`** and shared **`ga_evaluation_threads()`** unify elitism and deterministic eval thread policy from generation zero. **`Pose::from_chromosome`** / **`chromosome_model_index`** centralize multi-model identity for OPTICS/CCBM. **Vcontacts** adds pristine-coordinate **`AtomCoordGuard`** on hull failsafe paths, thread-local **indexed box cache** with workspace invalidation, env parsing via **`env_bool`**, and optional **test hooks** (`test_vcontacts_failsafe`). **`calculate_fitness`** now takes **`GAContext&`**; parallel-dock best-chromosome copy includes **`ring_five`**.
> 
> Documentation updates in **METHODOLOGY.md** and **benchmark-observation-integrity.md** record the audit contract; extensive C++ and Python tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf30b74ca510375cd0f485fe1ef86647cdaf76d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->