### PR TITLE
[fix] Complete Windows engine portability and reader temp-file handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,23 @@ jobs:
             -DFLEXAIDS_USE_CUDA=OFF ^
             -DFLEXAIDS_USE_METAL=OFF ^
             -DBUILD_PYTHON_BINDINGS=OFF ^
-            -DBUILD_TESTING=OFF
+            -DBUILD_TESTING=ON
 
-      - name: Build
+      - name: Build (Unix)
+        if: runner.os != 'Windows'
         run: cmake --build build --parallel 2
+
+      - name: Build shipping executables and portability tests (Windows)
+        if: runner.os == 'Windows'
+        run: >
+          cmake --build build --parallel 2 --target
+          FlexAID FlexAIDdS tENCoM test_mol2_sdf_reader test_flexaidds_flags
+
+      - name: Verify reader and environment behavior (Windows)
+        if: runner.os == 'Windows'
+        run: >
+          ctest --test-dir build --output-on-failure --parallel 1
+          --no-tests=error -R "^(Mol2SdfReaderTests|FlexaiddsFlagsTests)$"
 
       - name: Smoke test shipping executables (Unix)
         if: runner.os != 'Windows'

--- a/LIB/CifReader.cpp
+++ b/LIB/CifReader.cpp
@@ -39,10 +39,84 @@
 #include <sstream>
 #include <algorithm>
 #ifdef _WIN32
+#  include <fcntl.h>
+#  include <filesystem>
 #  include <io.h>
-#  define mkstemp(t) _mktemp_s(t, strlen(t)+1)
+#  include <share.h>
+#  include <sys/stat.h>
 #else
 #  include <unistd.h>
+#endif
+
+#ifdef _WIN32
+namespace {
+// _mktemp_s generates a name only. Open it exclusively before passing a real
+// descriptor to _fdopen, and retain the file until read_pdb has reopened it.
+struct WindowsTempPdb {
+    char path[MAX_PATH__]{};
+    FILE* stream = nullptr;
+
+    explicit WindowsTempPdb(const char* pattern) {
+        std::error_code error;
+        const auto directory = std::filesystem::temp_directory_path(error);
+        if (error) {
+            errno = ENOENT;
+            return;
+        }
+        const std::string candidate = (directory / pattern).string();
+        if (candidate.size() >= sizeof(path)) {
+            errno = ENAMETOOLONG;
+            return;
+        }
+
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            std::memcpy(path, candidate.c_str(), candidate.size() + 1);
+            const errno_t name_error = _mktemp_s(path, sizeof(path));
+            if (name_error != 0) {
+                path[0] = '\0';
+                errno = name_error;
+                return;
+            }
+            int fd = -1;
+            const errno_t open_error = _sopen_s(
+                &fd, path, _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY | _O_NOINHERIT,
+                _SH_DENYRW, _S_IREAD | _S_IWRITE);
+            if (open_error != 0) {
+                // Never remove a candidate that another process created.
+                path[0] = '\0';
+                if (open_error == EEXIST) continue;
+                errno = open_error;
+                return;
+            }
+            stream = _fdopen(fd, "wb");
+            if (!stream) {
+                const int stream_error = errno;
+                _close(fd);
+                std::remove(path);
+                path[0] = '\0';
+                errno = stream_error;
+            }
+            return;
+        }
+        errno = EEXIST;
+    }
+
+    WindowsTempPdb(const WindowsTempPdb&) = delete;
+    WindowsTempPdb& operator=(const WindowsTempPdb&) = delete;
+
+    void close() {
+        if (stream) {
+            std::fclose(stream);
+            stream = nullptr;
+        }
+    }
+
+    ~WindowsTempPdb() {
+        close();
+        if (path[0] != '\0') std::remove(path);
+    }
+};
+} // namespace
 #endif
 
 // Column indices in the _atom_site loop (set to -1 if not present)
@@ -406,7 +480,17 @@ static int parse_cif_atom_site(
     printf("CIF: parsed %zu atoms from %s\n", cif_atoms.size(), cif_file);
 
     // Phase 3: Convert to PDB-style temp file and let read_pdb handle it.
-    // Uses mkstemp for a race-free unique filename (no random_device dependency).
+    // Create a unique opened file without a random_device dependency.
+#ifdef _WIN32
+    WindowsTempPdb temp_pdb("flexaid_cif_XXXXXX");
+    char* tmp_pdb = temp_pdb.path;
+    FILE* out = temp_pdb.stream;
+    if (!out) {
+        fprintf(stderr, "ERROR: Cannot create temp file for CIF conversion: %s\n",
+                strerror(errno));
+        return 0;
+    }
+#else
     char tmp_pdb[MAX_PATH__];
     strncpy(tmp_pdb, "/tmp/flexaid_cif_XXXXXX", MAX_PATH__ - 1);
     tmp_pdb[MAX_PATH__ - 1] = '\0';
@@ -423,6 +507,7 @@ static int parse_cif_atom_site(
         fprintf(stderr, "ERROR: fdopen failed for CIF temp file: %s\n", strerror(errno));
         return 0;
     }
+#endif
 
     for (const auto& a : cif_atoms) {
         // Format as PDB ATOM/HETATM record (fixed-width 80 chars)
@@ -466,7 +551,11 @@ static int parse_cif_atom_site(
                 a.element.c_str());
     }
     fprintf(out, "END\n");
+#ifdef _WIN32
+    temp_pdb.close();
+#else
     fclose(out);
+#endif
 
     // Now use the existing PDB reader on the temp file
     int result;
@@ -481,7 +570,9 @@ static int parse_cif_atom_site(
         result = (FA->atm_cnt > 0) ? 1 : 0;
     }
 
+#ifndef _WIN32
     remove(tmp_pdb);
+#endif
 
     // Phase 4: Restore formal charges that were lost in the PDB round-trip
     // The CIF file carried pdbx_formal_charge for metal ions and other charged
@@ -595,6 +686,16 @@ int read_multi_model_pdb(FA_Global* FA, atom** atoms, resid** residue,
 
     // Phase 2: Load first model via standard read_pdb for full topology
     // Create a temp PDB with only the first model's atoms
+#ifdef _WIN32
+    WindowsTempPdb temp_pdb("flexaid_mm_XXXXXX");
+    char* tmp_pdb = temp_pdb.path;
+    FILE* out = temp_pdb.stream;
+    if (!out) {
+        fprintf(stderr, "ERROR: Cannot create temp file for multi-model PDB: %s\n",
+                strerror(errno));
+        return 0;
+    }
+#else
     char tmp_pdb[MAX_PATH__];
     strncpy(tmp_pdb, "/tmp/flexaid_mm_XXXXXX", MAX_PATH__ - 1);
     tmp_pdb[MAX_PATH__ - 1] = '\0';
@@ -611,10 +712,16 @@ int read_multi_model_pdb(FA_Global* FA, atom** atoms, resid** residue,
         fprintf(stderr, "ERROR: fdopen failed for multi-model temp: %s\n", strerror(errno));
         return 0;
     }
+#endif
 
     // Re-read and write only the first model
     fp = fopen(pdb_file, "r");
-    if (!fp) { fclose(out); return 0; }
+    if (!fp) {
+#ifndef _WIN32
+        fclose(out);
+#endif
+        return 0;
+    }
 
     int write_model = -1;
     bool writing = !has_model_records;  // if no MODEL records, write everything
@@ -642,11 +749,17 @@ int read_multi_model_pdb(FA_Global* FA, atom** atoms, resid** residue,
     }
     fprintf(out, "END\n");
     fclose(fp);
+#ifdef _WIN32
+    temp_pdb.close();
+#else
     fclose(out);
+#endif
 
     // Load the first model with full FlexAID infrastructure
     read_pdb(FA, atoms, residue, tmp_pdb);
+#ifndef _WIN32
     remove(tmp_pdb);
+#endif
 
     // Phase 3: Build model_coords arrays
     int n_atoms_ref = static_cast<int>(models[0].coords.size());

--- a/LIB/ClusterRepMode.h
+++ b/LIB/ClusterRepMode.h
@@ -28,20 +28,33 @@
 
 #include <cstdlib>
 #include <cstdio>
+#ifdef _WIN32
+#include <cstring>     // _stricmp
+#else
 #include <strings.h>   // strcasecmp
+#endif
 
 namespace flexaids {
 
 enum class ClusterRepMode { LOWCF, MEDOID, BMEDOID, CENTER };
 
+inline bool cluster_rep_name_matches(const char* value, const char* name)
+{
+#ifdef _WIN32
+	return ::_stricmp(value, name) == 0;
+#else
+	return ::strcasecmp(value, name) == 0;
+#endif
+}
+
 inline ClusterRepMode cluster_rep_mode()
 {
 	const char* v = std::getenv("FLEXAIDDS_CLUSTER_REP");
 	if (v && *v) {
-		if (!strcasecmp(v, "lowcf"))   return ClusterRepMode::LOWCF;
-		if (!strcasecmp(v, "medoid"))  return ClusterRepMode::MEDOID;
-		if (!strcasecmp(v, "bmedoid")) return ClusterRepMode::BMEDOID;
-		if (!strcasecmp(v, "center"))  return ClusterRepMode::CENTER;
+		if (cluster_rep_name_matches(v, "lowcf"))   return ClusterRepMode::LOWCF;
+		if (cluster_rep_name_matches(v, "medoid"))  return ClusterRepMode::MEDOID;
+		if (cluster_rep_name_matches(v, "bmedoid")) return ClusterRepMode::BMEDOID;
+		if (cluster_rep_name_matches(v, "center"))  return ClusterRepMode::CENTER;
 		fprintf(stderr,
 		        "WARNING: FLEXAIDDS_CLUSTER_REP='%s' unrecognized "
 		        "(expected lowcf|medoid|bmedoid|center); using default 'lowcf'.\n",

--- a/LIB/SharedPosePool.cpp
+++ b/LIB/SharedPosePool.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <cmath>
 #include <algorithm>
+#include <string>
 
 SharedPosePool::SharedPosePool(int pool_size)
     : capacity_(pool_size), used_(0)

--- a/LIB/flexaidds_flags.cpp
+++ b/LIB/flexaidds_flags.cpp
@@ -633,14 +633,23 @@ void apply_to_environ() {
                 // Do not overwrite a caller-supplied non-empty value.
                 if (!env_raw(g.name) || env_raw(g.name)[0] == '\0') {
                     const char* v = g.value.empty() ? "1" : g.value.c_str();
+#ifdef _WIN32
+                    // Match setenv(..., 0): even an existing empty value wins.
+                    if (!env_raw(g.name)) _putenv_s(g.name, v);
+#else
                     setenv(g.name, v, 0);
+#endif
                 }
             }
         } else if (g.requested && (g.kind == Kind::Bool || g.kind == Kind::Enum)) {
             // Mutual-exclusion loser or superseded gate: hide from getenv()
             // so legacy call sites follow the winner. The flag stays in the
             // registry (requested() remains true).
+#ifdef _WIN32
+            _putenv_s(g.name, "");
+#else
             unsetenv(g.name);
+#endif
         }
     }
 }

--- a/LIB/rescore_pool.cpp
+++ b/LIB/rescore_pool.cpp
@@ -17,39 +17,63 @@
 
 #include <algorithm>
 #include <cstdlib>
+#ifdef _WIN32
+#include <filesystem>
+#include <system_error>
+#else
 #include <dirent.h>
-#include <string>
 #include <sys/stat.h>
+#endif
+#include <string>
 #include <vector>
 
 namespace {
 
 std::string basename_of(const std::string& path)
 {
+#ifdef _WIN32
+    return std::filesystem::path(path).filename().string();
+#else
     const auto pos = path.find_last_of('/');
     return pos == std::string::npos ? path : path.substr(pos + 1);
+#endif
 }
 
 bool dir_exists(const std::string& p)
 {
+#ifdef _WIN32
+    std::error_code ec;
+    return std::filesystem::is_directory(p, ec);
+#else
     struct stat st {};
     return ::stat(p.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+#endif
 }
 
 std::vector<std::string> list_pose_pdbs(const std::string& dir)
 {
     std::vector<std::string> out;
+#ifdef _WIN32
+    // Nonthrowing directory access matches opendir/readdir failure handling.
+    std::error_code ec;
+    std::filesystem::directory_iterator it(dir, ec), end;
+    for (; !ec && it != end; it.increment(ec)) {
+        const std::string n = it->path().filename().string();
+#else
     DIR* d = ::opendir(dir.c_str());
     if (!d) return out;
     while (const dirent* e = ::readdir(d)) {
         const std::string n = e->d_name;
+#endif
         if (n.size() <= 4 || n.substr(n.size() - 4) != ".pdb") continue;
         if (n.find("elected_pose") != std::string::npos) continue;  // §10.1 duplicate
         if (n.find("_INI") != std::string::npos) continue;          // blinded seed
         if (n.find("_rmsd") != std::string::npos) continue;         // member copies
         out.push_back(dir + "/" + n);
     }
+#ifndef _WIN32
     ::closedir(d);
+#endif
     std::sort(out.begin(), out.end());
     return out;
 }

--- a/LIB/top.cpp
+++ b/LIB/top.cpp
@@ -63,8 +63,8 @@
 #include <vector>
 #include <filesystem>
 #include <system_error>
-#include <unistd.h>
 #ifndef _WIN32
+#include <unistd.h>
 #include <sys/wait.h>
 #endif
 

--- a/tests/test_mol2_sdf_reader.cpp
+++ b/tests/test_mol2_sdf_reader.cpp
@@ -17,6 +17,9 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#ifdef _WIN32
+#include <process.h>
+#endif
 
 void assign_radii_types(FA_Global* FA, atom* atoms, resid* residue);
 
@@ -25,10 +28,8 @@ void assign_radii_types(FA_Global* FA, atom* atoms, resid* residue);
 // ===========================================================================
 
 static void init_fa_for_reader(FA_Global* FA, atom** atoms, resid** residue) {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wnontrivial-memcall"
-    std::memset(FA, 0, sizeof(FA_Global));
-    #pragma clang diagnostic pop
+    // Callers value-initialize FA_Global. Byte-zeroing its std::vector members
+    // violates their lifetime invariants (including the Windows debug CRT).
     FA->MIN_NUM_ATOM     = 100;
     FA->MIN_NUM_RESIDUE  = 10;
     FA->MIN_FLEX_BONDS   = 5;
@@ -157,7 +158,7 @@ TEST_F(Mol2ReaderTest, ReadsSimpleMolecule) {
         "2 1 3 1\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -226,7 +227,7 @@ TEST_F(Mol2ReaderTest, ReadsDrugLikeMolecule) {
         "4 1 5 1\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -250,7 +251,7 @@ TEST_F(Mol2ReaderTest, ReadsDrugLikeMolecule) {
 }
 
 TEST_F(Mol2ReaderTest, FailsOnMissingFile) {
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -274,7 +275,7 @@ TEST_F(Mol2ReaderTest, FailsOnEmptyAtomBlock) {
         "@<TRIPOS>BOND\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -299,7 +300,7 @@ TEST_F(Mol2ReaderTest, HandlesUnknownAtomType) {
         "1 X1   1.0  2.0  3.0 Du    1 UNK  0.0\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -328,7 +329,7 @@ TEST_F(Mol2ReaderTest, PDBNumbersStartAt90001) {
         "1 1 2 1\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -402,7 +403,7 @@ TEST_F(SdfReaderTest, ReadsSimpleMolecule) {
         "$$$$\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -457,7 +458,7 @@ TEST_F(SdfReaderTest, ReadsHalogens) {
         "M  END\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -520,7 +521,7 @@ TEST_F(SdfReaderTest, MapsBareSdfElementsToCanonicalTypes) {
         std::string sdf = write_sdf(std::string("bare_") + tc.elem + ".sdf",
                                     make_single_atom_sdf("bare", tc.elem));
 
-        FA_Global FA;
+        FA_Global FA{};
         atom* atoms = nullptr;
         resid* residue = nullptr;
         init_fa_for_reader(&FA, &atoms, &residue);
@@ -549,7 +550,7 @@ TEST_F(SdfReaderTest, BareNitrogenMapsToActiveScoringType) {
         "M  END\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -565,7 +566,7 @@ TEST_F(SdfReaderTest, BareNitrogenMapsToActiveScoringType) {
 }
 
 TEST_F(SdfReaderTest, FailsOnMissingFile) {
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -587,7 +588,7 @@ TEST_F(SdfReaderTest, FailsOnInvalidAtomCount) {
         "M  END\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -611,7 +612,7 @@ TEST_F(SdfReaderTest, MoleculeNameExtracted) {
         "M  END\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -640,7 +641,7 @@ TEST_F(SdfReaderTest, BondOutOfRangeIgnored) {
         "M  END\n"
     );
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -689,7 +690,7 @@ TEST_F(SdfReaderTest, TopologyDerivedFrameAndTorsionPreserveLocalGeometry) {
         " 11 12  1  0\n"
         "M  END\n$$$$\n");
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -803,7 +804,7 @@ TEST_F(SdfReaderTest, AlkylAmineCNRemainsRuntimeRotor) {
         "  4  5  1  0\n"
         "M  END\n$$$$\n");
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -857,7 +858,7 @@ TEST_F(SdfReaderTest, AmideBondNotRuntimeRotor) {
         "  4  5  1  0\n"
         "M  END\n$$$$\n");
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -910,7 +911,7 @@ TEST_F(SdfReaderTest, Real1M2Z_SdfReadBuildlistBuildccGeometryPreserved) {
         GTEST_SKIP() << "1M2Z_ligand.sdf not present in worktree";
     }
 
-    FA_Global FA;
+    FA_Global FA{};
     atom* atoms = nullptr;
     resid* residue = nullptr;
     init_fa_for_reader(&FA, &atoms, &residue);
@@ -971,6 +972,55 @@ TEST_F(SdfReaderTest, Real1M2Z_SdfReadBuildlistBuildccGeometryPreserved) {
 // CIF READER — Cartn must not silently become the origin
 // ===========================================================================
 
+#ifdef _WIN32
+// Keep conversion files in a private directory with spaces in its path. This
+// catches hardcoded /tmp use and lets us observe ownership cleanup directly.
+class WindowsReaderTempDirectory {
+public:
+    WindowsReaderTempDirectory() {
+        if (const char* value = std::getenv("TMP")) old_tmp_ = value;
+        if (const char* value = std::getenv("TEMP")) old_temp_ = value;
+        const auto parent = std::filesystem::temp_directory_path();
+        for (int attempt = 0; attempt < 100; ++attempt) {
+            directory_ = parent / ("flexaids reader temp " +
+                std::to_string(_getpid()) + " " + std::to_string(attempt));
+            std::error_code error;
+            if (std::filesystem::create_directory(directory_, error)) {
+                owns_directory_ = true;
+                break;
+            }
+            if (error) return;
+        }
+        if (!owns_directory_) return;
+        ready_ = _putenv_s("TMP", directory_.string().c_str()) == 0 &&
+                 _putenv_s("TEMP", directory_.string().c_str()) == 0;
+    }
+
+    WindowsReaderTempDirectory(const WindowsReaderTempDirectory&) = delete;
+    WindowsReaderTempDirectory& operator=(const WindowsReaderTempDirectory&) = delete;
+
+    ~WindowsReaderTempDirectory() {
+        _putenv_s("TMP", old_tmp_.c_str());
+        _putenv_s("TEMP", old_temp_.c_str());
+        if (owns_directory_) {
+            // Remove only an empty directory; retain leaked files as evidence.
+            std::error_code ignored;
+            std::filesystem::remove(directory_, ignored);
+        }
+    }
+
+    bool ready() const { return ready_; }
+    const std::filesystem::path& path() const { return directory_; }
+
+private:
+    std::filesystem::path directory_;
+    std::string old_tmp_;
+    std::string old_temp_;
+    bool owns_directory_ = false;
+    bool ready_ = false;
+};
+#endif
+
 static const char* kMinimalCifHeader =
     "data_test\n"
     "loop_\n"
@@ -1007,7 +1057,14 @@ TEST(CifReaderTest, ReadsFiniteCoordinates) {
     atom* atoms = nullptr;
     resid* residue = nullptr;
 
+#ifdef _WIN32
+    WindowsReaderTempDirectory conversion_directory;
+    ASSERT_TRUE(conversion_directory.ready());
+#endif
     EXPECT_EQ(read_cif_receptor(&FA, &atoms, &residue, path.c_str()), 1);
+#ifdef _WIN32
+    EXPECT_TRUE(std::filesystem::is_empty(conversion_directory.path()));
+#endif
     ASSERT_GE(FA.atm_cnt, 1);
     EXPECT_NEAR(atoms[1].coor[0], 1.0f, 1e-4f);
     EXPECT_NEAR(atoms[1].coor[1], 2.0f, 1e-4f);
@@ -1023,6 +1080,93 @@ TEST(CifReaderTest, ReadsFiniteCoordinates) {
     free(residue);
     std::filesystem::remove(path);
 }
+
+TEST(PdbMultiModelReaderTest, LoadsFirstModelTopologyAndAllCoordinates) {
+    const auto path = std::filesystem::temp_directory_path() / "flexaids_models.pdb";
+    {
+        std::ofstream out(path);
+        ASSERT_TRUE(out.good());
+        out << "MODEL        1\n"
+            << "ATOM      1  CA  ALA A   1       1.000   2.000   3.000  1.00 10.00           C  \n"
+            << "ENDMDL\n"
+            << "MODEL        2\n"
+            << "ATOM      1  CA  ALA A   1       4.000   5.000   6.000  1.00 10.00           C  \n"
+            << "ENDMDL\nEND\n";
+    }
+
+    FA_Global FA{};
+    FA.MIN_NUM_ATOM = 32;
+    FA.MIN_NUM_RESIDUE = 8;
+    FA.MIN_ROTAMER = 1;
+    FA.MIN_FLEX_BONDS = 5;
+    FA.ntypes = 40;
+    atom* atoms = nullptr;
+    resid* residue = nullptr;
+
+#ifdef _WIN32
+    WindowsReaderTempDirectory conversion_directory;
+    ASSERT_TRUE(conversion_directory.ready());
+#endif
+    EXPECT_EQ(read_multi_model_pdb(&FA, &atoms, &residue, path.string().c_str()), 2);
+#ifdef _WIN32
+    EXPECT_TRUE(std::filesystem::is_empty(conversion_directory.path()));
+#endif
+    ASSERT_EQ(FA.atm_cnt, 1);
+    EXPECT_FLOAT_EQ(atoms[1].coor[0], 1.0f);
+    EXPECT_FLOAT_EQ(atoms[1].coor[1], 2.0f);
+    EXPECT_FLOAT_EQ(atoms[1].coor[2], 3.0f);
+    EXPECT_EQ(FA.n_models, 2);
+    ASSERT_EQ(FA.model_coords.size(), 2u);
+    EXPECT_EQ(FA.model_coords[0], (std::vector<float>{1.0f, 2.0f, 3.0f}));
+    EXPECT_EQ(FA.model_coords[1], (std::vector<float>{4.0f, 5.0f, 6.0f}));
+    EXPECT_EQ(FA.model_strain, (std::vector<double>{0.0, 0.0}));
+
+    for (int r = 0; r <= FA.res_cnt; ++r) {
+        free(residue[r].fatm);
+        free(residue[r].latm);
+        free(residue[r].bond);
+    }
+    free(FA.num_atm);
+    free(atoms);
+    free(residue);
+    std::filesystem::remove(path);
+}
+
+#ifdef _WIN32
+TEST(CifReaderTest, UnavailableTemporaryDirectoryFailsWithoutAllocatingTopology) {
+    const auto parent = std::filesystem::temp_directory_path();
+    const auto cif = parent / "flexaids_unavailable_temp.cif";
+    const auto pdb = parent / "flexaids_unavailable_temp.pdb";
+    {
+        std::ofstream out(cif);
+        ASSERT_TRUE(out.good());
+        out << kMinimalCifHeader
+            << "ATOM 1 C CA . ALA A 1 1.000 2.000 3.000 1.00 20.00\n";
+    }
+    {
+        std::ofstream out(pdb);
+        ASSERT_TRUE(out.good());
+        out << "MODEL        1\n"
+            << "ATOM      1  CA  ALA A   1       1.000   2.000   3.000  1.00 10.00           C  \n"
+            << "ENDMDL\nEND\n";
+    }
+
+    WindowsReaderTempDirectory conversion_directory;
+    ASSERT_TRUE(conversion_directory.ready());
+    ASSERT_TRUE(std::filesystem::remove(conversion_directory.path()));
+    FA_Global FA{};
+    atom* atoms = nullptr;
+    resid* residue = nullptr;
+    EXPECT_EQ(read_cif_receptor(&FA, &atoms, &residue, cif.string().c_str()), 0);
+    EXPECT_EQ(read_multi_model_pdb(&FA, &atoms, &residue, pdb.string().c_str()), 0);
+    EXPECT_EQ(atoms, nullptr);
+    EXPECT_EQ(residue, nullptr);
+    EXPECT_EQ(FA.num_atm, nullptr);
+    EXPECT_FALSE(std::filesystem::exists(conversion_directory.path()));
+    std::filesystem::remove(cif);
+    std::filesystem::remove(pdb);
+}
+#endif
 
 TEST(CifReaderTest, MissingCartnDoesNotOriginFill) {
     const std::string path =


### PR DESCRIPTION
The first hosted clang-cl release build passed configuration and failed in `top.cpp` on an unconditional Unix header. Inspection found the same portability gap in pool directory access, environment publishing and cluster-name comparison. It also found that Windows CIF/multi-model readers treated `_mktemp_s`’s status code as an open file descriptor and used `/tmp`.

This follow-up to #466/#467 guards Unix APIs and uses the existing Windows CRT or filesystem equivalents. The Windows readers now create a real exclusive temporary file in the system temp directory, close it before the PDB reader reopens it, and remove only owned files on every exit. Unix `mkstemp` operations and scoring behavior remain unchanged.

The Windows release job now explicitly builds shipping executables plus `test_mol2_sdf_reader` and `test_flexaidds_flags`, then runs both CTest entries with `--no-tests=error`. Reader regressions cover nonzero CIF coordinates, both PDB model coordinate sets, temp paths containing spaces, successful cleanup, and unavailable-directory failure before topology allocation. The reader fixture now value-initializes `FA_Global` rather than overwriting its C++ members.

Validation pending: no local compilation/tests were started, preserving RAM for the active priority benchmark. YAML parsing and diff checks passed; independent source review checked the platform branches and temporary-file ownership. Hosted Windows compile/link/test and Linux/macOS regression evidence are required before calling this repair validated. This PR does not publish release artifacts externally beyond GitHub Actions uploads and does not modify benchmark results, caches, frozen binaries, drivers or the live checkout.

Base: current main `d337045287e38011f9fc7d75b11055ef0baa5088`. Implementation/review: Codex (GPT-6), with independent scoped agent review. No scientific parity/performance claim is made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch file I/O temp lifecycle and environment publishing on Windows plus reader paths used before scoring; Unix behavior is largely preserved but CI now exercises more code on Windows.
> 
> **Overview**
> Fixes **Windows clang-cl release builds** by guarding Unix-only headers/APIs and aligning CRT behavior with existing Unix paths.
> 
> **CIF and multi-model PDB readers** no longer misuse `_mktemp_s` or hardcoded `/tmp`. On Windows they use a `WindowsTempPdb` helper that creates an **exclusive** temp file under the system temp directory, closes it before `read_pdb` reopens it, and **deletes only owned files** on all exit paths. Unix still uses `mkstemp`.
> 
> **Portability elsewhere:** `FLEXAIDDS_CLUSTER_REP` parsing uses `_stricmp` on Windows; flag overlay publishing uses `_putenv_s` (matching `setenv(..., 0)` semantics); **rescore pool** directory scans use `std::filesystem` on Windows; **`top.cpp`** includes `unistd.h` only on non-Windows.
> 
> **CI:** The Windows release job turns **`BUILD_TESTING=ON`**, builds shipping binaries plus `test_mol2_sdf_reader` and `test_flexaidds_flags`, and runs the matching **CTest** suites. Reader tests now **value-initialize** `FA_Global` (no `memset` on C++ members) and add Windows-focused coverage for temp paths with spaces, cleanup, multi-model coordinates, and failure when temp dir is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10baddc3a3126827902d81d67e9e46938155e050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->