### PR TITLE
Add experimental pose→helix ΔH/ΔS rewrite and Zhao JCP 2011 lineage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1224,6 +1224,7 @@ if(ENABLE_DUAL_ASSEMBLY_TOOL)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/ShannonThermoStack/ShannonThermoStack.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/statmech.cpp
@@ -1798,6 +1799,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -1856,6 +1858,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2133,6 +2136,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2190,6 +2194,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2244,6 +2249,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2301,6 +2307,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2355,6 +2362,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2411,6 +2419,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2468,6 +2477,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2523,6 +2533,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2682,6 +2693,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -2897,6 +2909,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
@@ -3180,6 +3193,7 @@ flexaids_add_unit_test(test_protocol_config
             LIB/NATURaL/RibosomeElongation.cpp
             LIB/NATURaL/TransloconInsertion.cpp
             LIB/NATURaL/NucleationDetector.cpp
+            LIB/NATURaL/PoseHelixThermoRewrite.cpp
             LIB/NATURaL/NATURaLDualAssembly.cpp
             LIB/statmech.cpp
             LIB/TurboQuant.cpp
@@ -3210,6 +3224,14 @@ flexaids_add_unit_test(test_protocol_config
         add_test(NAME NATURaLTests COMMAND test_natural)
     endif()
 
+    # Experimental 2014 NATURAL pose→helix ΔH/ΔS rewrite (pure function; no GA).
+    flexaids_add_unit_test(test_pose_helix_thermo_rewrite
+        SOURCES
+            tests/test_pose_helix_thermo_rewrite.cpp
+            LIB/NATURaL/PoseHelixThermoRewrite.cpp
+        TEST_NAME PoseHelixThermoRewriteTests
+    )
+
     # test_nascent_chain_scheduler — cotranslational DualAssembly suite
     add_executable(test_nascent_chain_scheduler
         tests/test_nascent_chain_scheduler.cpp
@@ -3220,6 +3242,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/ShannonThermoStack/ShannonThermoStack.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/statmech.cpp
@@ -3491,6 +3514,7 @@ if(BUILD_SWIFT_BRIDGE)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NATURaLDualAssembly.cpp
         LIB/statmech.cpp
         LIB/TurboQuant.cpp
@@ -3556,6 +3580,7 @@ if(BUILD_SWIFT_BRIDGE)
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
         LIB/NATURaL/NucleationDetector.cpp
+        LIB/NATURaL/PoseHelixThermoRewrite.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -133,6 +133,7 @@ set(FLEXAID_CORE_SOURCES
     NATURaL/RibosomeElongation.cpp
     NATURaL/TransloconInsertion.cpp
     NATURaL/NucleationDetector.cpp
+    NATURaL/PoseHelixThermoRewrite.cpp
     NATURaL/NascentChainScheduler.cpp
     NATURaL/FibrilGrowthOracle.cpp
     NATURaL/DualAssemblyRunner.cpp

--- a/LIB/NATURaL/DualAssemblyRunner.h
+++ b/LIB/NATURaL/DualAssemblyRunner.h
@@ -40,6 +40,11 @@ struct DualAssemblyConfig {
     std::string output_csv                  = "cotranslational_trajectory.csv";
     std::string nascent_pdb_dir             = ".";
     double      acceptance_threshold        = 0.5;
+    // Experimental 2014 NATURAL pose→helix ΔH/ΔS rewrite. Default OFF.
+    // DualAssemblyRunner does not invoke PoseHelixThermoRewrite (GA callbacks
+    // currently supply pose RMSDs, not atom coords). Follow-up: wire when a
+    // real-GA backend emits ReceptorNtCoord / LigandPose snapshots.
+    bool        enable_pose_helix_rewrite   = false;
 };
 
 // ─── GA-backend callback signatures ──────────────────────────────────────────

--- a/LIB/NATURaL/NATURaLDualAssembly.cpp
+++ b/LIB/NATURaL/NATURaLDualAssembly.cpp
@@ -1,20 +1,24 @@
 // NATURaLDualAssembly.cpp — co-translational / co-transcriptional folding
 //
-// The same Zhao 2011 master-equation rationale applies to both polypeptide
-// and nucleotide chains:
+// Distinct Zhao 2011 papers (do not conflate):
+//   • Zhao et al., J. Phys. Chem. B 115, 3987 (2011) — ribosome master equation
+//     for protein cotranslation. The ODE below is that JPCB framework, reused
+//     for RNAP nucleotide elongation with different rates (not the JCP paper).
+//   • Zhao, Zhang, Chen, J. Chem. Phys. 135, 245101 (2011) — RNA
+//     cotranscriptional folding kinetics (2014 NATURAL seminar lineage). Pose→helix
+//     ΔH/ΔS rewrite lives in PoseHelixThermoRewrite.{h,cpp} and is default OFF.
 //
-//   Polypeptide (ribosome):
+//   Polypeptide (ribosome; JPCB 2011):
 //     dP_n/dt = k_{n-1} · P_{n-1} − k_n · P_n
 //     k_n  = codon-specific aa elongation rate (s⁻¹)  [Dong 1996 / Ingolia 2011]
 //     Tunnel: 34 aa occluded (Goldman 2010 Cell 143:92)
 //
-//   Nucleotide chain (RNA polymerase):
-//     Same master equation, k_n = nucleotide-specific NTP incorporation rate
+//   Nucleotide chain (RNA polymerase; same ODE, RNAP rates):
 //     k_n  from Uptain 1997 (E. coli RNAP) / Jonkers 2014 (Human RNAP II)
 //     Tunnel: 8 nt (RNAP RNA:DNA hybrid; Nudler 2012 Cell 149:1438)
 //
 // Both modes are handled by the same RibosomeElongation class (same interface,
-// different CodonRateTable) — "same rational for nucleotides than polypeptides".
+// different CodonRateTable).
 //
 // TransloconInsertion (TM helix lateral gating via Sec61 translocon) is also
 // evaluated at each growth step for polypeptide chains, using the Hessa 2007
@@ -873,6 +877,9 @@ std::vector<DualAssemblyEngine::GrowthStep> DualAssemblyEngine::run() {
     }
 
     final_deltaG_ = cumulative_dG;
+    // Pose→helix ΔH/ΔS (PoseHelixThermoRewrite) is intentionally not applied
+    // here: CF + Shannon instantaneous ΔG is not the 2014 seminar ligand
+    // coupling. Call compute_pose_helix_rewrite() as a sidecar when enabled.
 
     // Optional: validate master equation against analytic solution
     if (n_residues_ >= 20) {
@@ -928,6 +935,23 @@ double DualAssemblyEngine::compute_growth_entropy(
     const std::vector<double>& cf_trajectory) const
 {
     return growth_entropy_nats(cf_trajectory);
+}
+
+PoseHelixRewriteResult DualAssemblyEngine::compute_pose_helix_rewrite(
+    const std::vector<ReceptorNtCoord>& rna_nts,
+    const std::vector<LigandPose>& poses) const
+{
+    PoseHelixRewriteResult empty;
+    empty.applied = false;
+    if (!config_.enable_pose_helix_rewrite) return empty;
+    if (!is_rna_receptor_) return empty;
+    if (config_.decision_helices.empty()) return empty;
+    PoseHelixRewriteConfig cfg = config_.pose_helix;
+    cfg.T_K = config_.temperature_K;
+    PoseHelixRewriteResult r = rewrite_helices_from_poses(
+        config_.decision_helices, rna_nts, poses, cfg);
+    r.applied = true;
+    return r;
 }
 
 #endif // FLEXAIDS_OMIT_DUAL_ASSEMBLY_ENGINE

--- a/LIB/NATURaL/NATURaLDualAssembly.h
+++ b/LIB/NATURaL/NATURaLDualAssembly.h
@@ -1,23 +1,41 @@
-// NATURaLDualAssembly.h — Native Assembly of co-Transcriptionally/co-Translationally
-//                          Unified Receptor–Ligand (NATURaL) module
+// NATURaLDualAssembly.h — DualAssembly co-transcriptional / co-translational engine
+//
+// Two acronyms (do not conflate):
+//   2014 seminar NATURAL = "Native Assembly of Transcriptionally-Unified RNA
+//     And Ligand" (LP Morency, master’s seminar R2, 2014-07-25). Perl
+//     implementation of Zhao, Zhang, Chen, J. Chem. Phys. 135, 245101 (2011)
+//     doi:10.1063/1.3671644 (RNA cotranscriptional folding kinetics) with
+//     clustering, population inheritance, slower transcription at nucleotide
+//     repeats, and docking poses that rewrite helix ΔH/ΔS
+//     (see PoseHelixThermoRewrite.h).
+//   2026 C++ header NATURaL = "Native Assembly of co-Transcriptionally /
+//     co-Translationally Unified Receptor–Ligand" (this DualAssembly module).
+//
+// Distinct Zhao 2011 papers:
+//   • Zhao, Zhang, Chen, J. Chem. Phys. 135, 245101 (2011) — RNA
+//     cotranscriptional folding kinetics (2014 NATURAL lineage).
+//   • Zhao et al., J. Phys. Chem. B 115, 3987 (2011) — ribosome master
+//     equation / protein cotranslation ONLY (see RibosomeElongation.h).
 //
 // Auto-detects when the ligand is nucleotide/sugar-containing or the receptor
-// is a nucleic acid chain, then activates co-translational DualAssembly mode.
+// is a nucleic acid chain, then activates DualAssembly mode.
 //
-// In DualAssembly, the receptor chain grows residue-by-residue at ribosome speed
-// (Zhao 2011 master equation; see RibosomeElongation.h) while the ligand is
-// present from the start, computing incremental CF and Shannon entropy at each
-// growth step to capture co-translational stereochemical selection.
+// In DualAssembly, the receptor chain grows residue-by-residue. Protein tracks
+// use ribosome speed from the JPCB 2011 master equation (RibosomeElongation.h);
+// RNA tracks reuse the same ODE with RNAP rates. Incremental CF and Shannon
+// entropy are computed at each growth step. That CF+Shannon instantaneous ΔG
+// is not the 2014 seminar ligand coupling (pose→helix ΔH/ΔS rewrite).
 //
 // Also supports transmembrane (TM) domain insertion via the Sec translocon
 // (see TransloconInsertion model below).
 //
 // Fully integrated with:
-//   – RibosomeElongation (Zhao 2011 master equation, codon-dependent rates)
+//   – RibosomeElongation (Zhao et al. 2011 JPCB master equation, codon rates)
 //   – ShannonThermoStack (entropy per growth step, time-weighted)
 //   – SugarPuckerGene (activated for nucleotide ligands)
 //   – AlphaShape Contact Function (incremental ΔSASA)
 //   – TransloconInsertion (TM helix lateral gating, von Heijne 2007)
+//   – PoseHelixThermoRewrite (experimental, default OFF; RNA DualAssembly sidecar)
 #pragma once
 
 #include "../flexaid.h"
@@ -26,6 +44,7 @@
 #include "RibosomeElongation.h"
 #include "TransloconInsertion.h"
 #include "NucleationDetector.h"
+#include "PoseHelixThermoRewrite.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -51,7 +70,7 @@ struct NATURaLConfig {
     double           temperature_K           = 298.15;
     int              max_growth_steps        = -1; // -1 = full sequence length
     ribosome::Organism organism              = ribosome::Organism::EcoliK12;
-    bool             use_ribosome_speed      = true;  // use Zhao 2011 rates
+    bool             use_ribosome_speed      = true;  // Zhao et al. 2011 JPCB rates
     bool             model_tm_insertion      = true;  // model TM translocon
 
     // ── Ion-dependent RNA folding ──────────────────────────────────────────
@@ -81,6 +100,14 @@ struct NATURaLConfig {
     int              min_hairpin_stem_bp     = 4;     // RNA: min stem length (bp)
     double           helix_propensity_thresh = 1.03;  // protein: Chou-Fasman P_α mean
     int              hydrophobic_run_min     = 4;     // protein: min ILVFMW run length
+
+    // ── Experimental pose→helix ΔH/ΔS rewrite (2014 NATURAL seminar) ──
+    // Default OFF. DualAssemblyEngine::run() never folds these patches into CF
+    // or FA->natural_deltaG. Call DualAssemblyEngine::compute_pose_helix_rewrite()
+    // explicitly on an RNA receptor. Not claim-ready; not Astex election.
+    bool                      enable_pose_helix_rewrite = false;
+    PoseHelixRewriteConfig    pose_helix{};
+    std::vector<HelixSegment>  decision_helices;
 };
 
 // Auto-configure from receptor and ligand properties.
@@ -184,6 +211,13 @@ public:
 
     // Whether NATURaL mode was active
     bool is_active() const noexcept { return config_.enabled; }
+
+    // Experimental sidecar (2014 NATURAL pose→helix ΔH/ΔS).
+    // Empty unless enable_pose_helix_rewrite is true AND the receptor is RNA.
+    // Never mutates final_deltaG_ / CF / FA->natural_deltaG.
+    PoseHelixRewriteResult compute_pose_helix_rewrite(
+        const std::vector<ReceptorNtCoord>& rna_nts,
+        const std::vector<LigandPose>& poses) const;
 
 private:
     NATURaLConfig config_;

--- a/LIB/NATURaL/PoseHelixThermoRewrite.cpp
+++ b/LIB/NATURaL/PoseHelixThermoRewrite.cpp
@@ -1,0 +1,330 @@
+// PoseHelixThermoRewrite.cpp — experimental 2014 NATURAL pose→helix ΔH/ΔS glue
+//
+// See PoseHelixThermoRewrite.h and docs/POSE_HELIX_THERMO_REWRITE.md.
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+#include "PoseHelixThermoRewrite.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <unordered_map>
+#include <utility>
+
+namespace natural {
+
+constexpr double kCalPerKcal = 1000.0;
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+bool finite3(double x, double y, double z) {
+    return std::isfinite(x) && std::isfinite(y) && std::isfinite(z);
+}
+
+double dist_A(const ReceptorNtCoord& nt, const LigandAtomCoord& lig) {
+    const double dx = nt.x - lig.x;
+    const double dy = nt.y - lig.y;
+    const double dz = nt.z - lig.z;
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+double vec_norm(double x, double y, double z) {
+    return std::sqrt(x * x + y * y + z * z);
+}
+
+// Angle between ring normals in degrees, folded into [0, 90] so parallel and
+// antiparallel stacks both count. Zero/degenerate normals → 0° (distance only).
+double stack_angle_deg(const ReceptorNtCoord& nt, const LigandAtomCoord& lig) {
+    const double n1 = vec_norm(nt.nx, nt.ny, nt.nz);
+    const double n2 = vec_norm(lig.nx, lig.ny, lig.nz);
+    if (n1 < 1e-12 || n2 < 1e-12) return 0.0;
+    double cosang = (nt.nx * lig.nx + nt.ny * lig.ny + nt.nz * lig.nz) / (n1 * n2);
+    if (cosang > 1.0) cosang = 1.0;
+    if (cosang < -1.0) cosang = -1.0;
+    const double acute = std::fabs(cosang); // parallel or antiparallel
+    return std::acos(acute) * 180.0 / kPi;
+}
+
+bool in_inclusive(int x, int a, int b) {
+    if (a > b) std::swap(a, b);
+    return x >= a && x <= b;
+}
+
+bool nt_in_loop(const HelixSegment& h, int nt) {
+    return in_inclusive(nt, h.loop_begin, h.loop_end);
+}
+
+bool nt_in_stem(const HelixSegment& h, int nt) {
+    return in_inclusive(nt, h.stem_i_begin, h.stem_i_end) ||
+           in_inclusive(nt, h.stem_j_begin, h.stem_j_end);
+}
+
+bool nt_in_helix(const HelixSegment& h, int nt) {
+    return nt_in_loop(h, nt) || nt_in_stem(h, nt);
+}
+
+bool nt_in_any_helix(const std::vector<HelixSegment>& helices, int nt) {
+    for (const auto& h : helices) {
+        if (nt_in_helix(h, nt)) return true;
+    }
+    return false;
+}
+
+bool valid_helix(const HelixSegment& h) {
+    return h.stem_i_end >= h.stem_i_begin ||
+           h.stem_j_end >= h.stem_j_begin ||
+           h.loop_end >= h.loop_begin;
+}
+
+struct HelixContactCount {
+    int n_hbond = 0;
+    int n_stack = 0;
+    std::vector<int> touched;
+};
+
+HelixContactCount count_contacts(const HelixSegment& helix,
+                                 const std::vector<ReceptorNtCoord>& rna_nts,
+                                 const LigandPose& pose,
+                                 const PoseHelixRewriteConfig& cfg) {
+    HelixContactCount out;
+    std::vector<int> hbond_nts;
+    std::vector<int> stack_nts;
+    for (const auto& nt : rna_nts) {
+        if (nt.nt_index < 0) continue;
+        if (!finite3(nt.x, nt.y, nt.z)) continue;
+        const bool in_loop = nt_in_loop(helix, nt.nt_index);
+        const bool in_stem = nt_in_stem(helix, nt.nt_index);
+        if (!in_loop && !in_stem) continue;
+        bool hit = false;
+        for (const auto& lig : pose.atoms) {
+            if (!finite3(lig.x, lig.y, lig.z)) continue;
+            const double d = dist_A(nt, lig);
+            if (in_loop && nt.is_hbond_partner && lig.is_hbond_partner &&
+                d <= cfg.hbond_max_A) {
+                hit = true;
+                if (std::find(hbond_nts.begin(), hbond_nts.end(), nt.nt_index) ==
+                    hbond_nts.end()) {
+                    hbond_nts.push_back(nt.nt_index);
+                }
+            }
+            if (in_stem && nt.is_aromatic && lig.is_aromatic &&
+                d <= cfg.stack_max_A &&
+                stack_angle_deg(nt, lig) <= cfg.stack_angle_max_deg) {
+                hit = true;
+                if (std::find(stack_nts.begin(), stack_nts.end(), nt.nt_index) ==
+                    stack_nts.end()) {
+                    stack_nts.push_back(nt.nt_index);
+                }
+            }
+        }
+        if (hit) out.touched.push_back(nt.nt_index);
+    }
+    out.n_hbond = static_cast<int>(hbond_nts.size());
+    out.n_stack = static_cast<int>(stack_nts.size());
+    std::sort(out.touched.begin(), out.touched.end());
+    return out;
+}
+
+HelixThermoPatch make_patch(const std::string& label,
+                            const HelixContactCount& c,
+                            const PoseHelixRewriteConfig& cfg,
+                            int pose_rank,
+                            double weight) {
+    HelixThermoPatch p;
+    p.helix_label = label;
+    p.delta_H_kcal = static_cast<double>(c.n_stack) * cfg.dH_per_stack_kcal;
+    p.delta_S_cal_per_K = static_cast<double>(c.n_hbond) * cfg.dS_per_hbond_cal_K;
+    p.delta_G_kcal = helix_thermo_delta_g_kcal(p.delta_H_kcal, p.delta_S_cal_per_K, cfg.T_K);
+    p.touched_nt = c.touched;
+    p.pose_rank = pose_rank;
+    p.pose_boltzmann_w = weight;
+    return p;
+}
+
+void add_touched(std::vector<int>& dst, const std::vector<int>& src) {
+    for (int nt : src) {
+        if (std::find(dst.begin(), dst.end(), nt) == dst.end()) dst.push_back(nt);
+    }
+    std::sort(dst.begin(), dst.end());
+}
+
+} // namespace
+
+double helix_thermo_delta_g_kcal(double delta_H_kcal,
+                                 double delta_S_cal_per_K,
+                                 double T_K) {
+    if (!std::isfinite(delta_H_kcal) || !std::isfinite(delta_S_cal_per_K) ||
+        !std::isfinite(T_K)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return delta_H_kcal - T_K * (delta_S_cal_per_K / kCalPerKcal);
+}
+
+std::vector<double> boltzmann_weights_from_scores(const std::vector<double>& scores_kcal,
+                                                   double T_K) {
+    std::vector<double> w(scores_kcal.size(), 0.0);
+    if (scores_kcal.empty()) return w;
+    const double T = (std::isfinite(T_K) && T_K > 1e-12) ? T_K : 298.15;
+    const double kT = kB_pose_helix_kcal * T;
+    if (!(kT > 0.0) || !std::isfinite(kT)) {
+        const double eq = 1.0 / static_cast<double>(scores_kcal.size());
+        std::fill(w.begin(), w.end(), eq);
+        return w;
+    }
+
+    std::vector<double> neg_betaE;
+    neg_betaE.reserve(scores_kcal.size());
+    for (double E : scores_kcal) {
+        if (!std::isfinite(E)) {
+            neg_betaE.push_back(-std::numeric_limits<double>::infinity());
+            continue;
+        }
+        neg_betaE.push_back(-E / kT);
+    }
+
+    double m = -std::numeric_limits<double>::infinity();
+    for (double v : neg_betaE) {
+        if (v > m) m = v;
+    }
+    if (!std::isfinite(m)) {
+        const double eq = 1.0 / static_cast<double>(scores_kcal.size());
+        std::fill(w.begin(), w.end(), eq);
+        return w;
+    }
+
+    double sum = 0.0;
+    std::vector<double> e(neg_betaE.size(), 0.0);
+    for (size_t i = 0; i < neg_betaE.size(); ++i) {
+        if (!std::isfinite(neg_betaE[i])) {
+            e[i] = 0.0;
+            continue;
+        }
+        e[i] = std::exp(neg_betaE[i] - m);
+        sum += e[i];
+    }
+    if (!(sum > 0.0) || !std::isfinite(sum)) {
+        const double eq = 1.0 / static_cast<double>(scores_kcal.size());
+        std::fill(w.begin(), w.end(), eq);
+        return w;
+    }
+    for (size_t i = 0; i < w.size(); ++i) w[i] = e[i] / sum;
+    return w;
+}
+
+PoseHelixRewriteResult rewrite_helices_from_poses(
+    const std::vector<HelixSegment>& helices,
+    const std::vector<ReceptorNtCoord>& rna_nts,
+    const std::vector<LigandPose>& poses,
+    const PoseHelixRewriteConfig& cfg)
+{
+    PoseHelixRewriteResult result;
+    result.applied = true;
+
+    if (helices.empty() || poses.empty() || cfg.top_k_poses <= 0) {
+        return result;
+    }
+
+    std::vector<LigandPose> ranked = poses;
+    std::sort(ranked.begin(), ranked.end(),
+              [](const LigandPose& a, const LigandPose& b) {
+                  if (a.rank != b.rank) return a.rank < b.rank;
+                  return a.score_kcal < b.score_kcal;
+              });
+    const int k = std::min(cfg.top_k_poses, static_cast<int>(ranked.size()));
+    ranked.resize(static_cast<size_t>(k));
+
+    std::vector<double> scores;
+    scores.reserve(ranked.size());
+    for (const auto& p : ranked) scores.push_back(p.score_kcal);
+    const std::vector<double> weights = boltzmann_weights_from_scores(scores, cfg.T_K);
+
+    struct MixAcc {
+        double dH = 0.0;
+        double dS = 0.0;
+        std::vector<int> touched;
+        double w_sum = 0.0;
+    };
+    std::unordered_map<std::string, MixAcc> mix;
+
+    for (size_t pi = 0; pi < ranked.size(); ++pi) {
+        const LigandPose& pose = ranked[pi];
+        const double w = (pi < weights.size()) ? weights[pi] : 0.0;
+
+        for (const auto& helix : helices) {
+            if (!valid_helix(helix)) continue;
+            const HelixContactCount c = count_contacts(helix, rna_nts, pose, cfg);
+            if (c.n_hbond == 0 && c.n_stack == 0) continue;
+            const std::string label = helix.label.empty() ? std::string("helix") : helix.label;
+            HelixThermoPatch patch = make_patch(label, c, cfg, pose.rank, w);
+            result.patches.push_back(patch);
+            MixAcc& acc = mix[label];
+            acc.dH += w * patch.delta_H_kcal;
+            acc.dS += w * patch.delta_S_cal_per_K;
+            acc.w_sum += w;
+            add_touched(acc.touched, patch.touched_nt);
+        }
+
+        if (!cfg.require_decision_helix_only) {
+            HelixContactCount c;
+            std::vector<int> hbond_nts;
+            std::vector<int> stack_nts;
+            for (const auto& nt : rna_nts) {
+                if (nt.nt_index < 0) continue;
+                if (nt_in_any_helix(helices, nt.nt_index)) continue;
+                if (!finite3(nt.x, nt.y, nt.z)) continue;
+                bool hit = false;
+                for (const auto& lig : pose.atoms) {
+                    if (!finite3(lig.x, lig.y, lig.z)) continue;
+                    const double d = dist_A(nt, lig);
+                    if (nt.is_hbond_partner && lig.is_hbond_partner && d <= cfg.hbond_max_A) {
+                        hit = true;
+                        if (std::find(hbond_nts.begin(), hbond_nts.end(), nt.nt_index) ==
+                            hbond_nts.end()) {
+                            hbond_nts.push_back(nt.nt_index);
+                        }
+                    }
+                    if (nt.is_aromatic && lig.is_aromatic && d <= cfg.stack_max_A &&
+                        stack_angle_deg(nt, lig) <= cfg.stack_angle_max_deg) {
+                        hit = true;
+                        if (std::find(stack_nts.begin(), stack_nts.end(), nt.nt_index) ==
+                            stack_nts.end()) {
+                            stack_nts.push_back(nt.nt_index);
+                        }
+                    }
+                }
+                if (hit) c.touched.push_back(nt.nt_index);
+            }
+            c.n_hbond = static_cast<int>(hbond_nts.size());
+            c.n_stack = static_cast<int>(stack_nts.size());
+            if (c.n_hbond > 0 || c.n_stack > 0) {
+                HelixThermoPatch patch = make_patch("non_decision", c, cfg, pose.rank, w);
+                result.patches.push_back(patch);
+                MixAcc& acc = mix["non_decision"];
+                acc.dH += w * patch.delta_H_kcal;
+                acc.dS += w * patch.delta_S_cal_per_K;
+                acc.w_sum += w;
+                add_touched(acc.touched, patch.touched_nt);
+            }
+        }
+    }
+
+    for (auto& kv : mix) {
+        HelixThermoPatch e;
+        e.helix_label = kv.first;
+        e.delta_H_kcal = kv.second.dH;
+        e.delta_S_cal_per_K = kv.second.dS;
+        e.delta_G_kcal = helix_thermo_delta_g_kcal(e.delta_H_kcal, e.delta_S_cal_per_K, cfg.T_K);
+        e.touched_nt = kv.second.touched;
+        e.pose_rank = -1;
+        e.pose_boltzmann_w = kv.second.w_sum;
+        result.ensemble.push_back(e);
+    }
+    std::sort(result.ensemble.begin(), result.ensemble.end(),
+              [](const HelixThermoPatch& a, const HelixThermoPatch& b) {
+                  return a.helix_label < b.helix_label;
+              });
+    return result;
+}
+
+} // namespace natural

--- a/LIB/NATURaL/PoseHelixThermoRewrite.h
+++ b/LIB/NATURaL/PoseHelixThermoRewrite.h
@@ -1,0 +1,117 @@
+// PoseHelixThermoRewrite.h — experimental 2014 NATURAL pose→helix ΔH/ΔS glue
+//
+// 2014 seminar NATURAL = "Native Assembly of Transcriptionally-Unified RNA And
+// Ligand" (LP Morency, master’s seminar R2, 2014-07-25): Perl implementation of
+// Zhao, Zhang, Chen, J. Chem. Phys. 135, 245101 (2011) doi:10.1063/1.3671644
+// (RNA cotranscriptional folding kinetics) with (1) clustering, (2) population
+// inheritance across elongation, (3) slower transcription at nucleotide repeats,
+// and (4) docking poses that rewrite helix ΔH/ΔS.
+//
+// This module is piece (4) only. It is NOT Zhao et al. J. Phys. Chem. B 115,
+// 3987 (2011) (ribosome master equation / protein cotranslation — see
+// RibosomeElongation.h).
+//
+// Physics (seminar):
+//   • Decision-helix patches only (configurable HelixSegment list).
+//   • Ligand H-bond / base-pair-like contacts to loop nts → ΔS < 0
+//     (loop entropy reduction).
+//   • Aromatic stacking on the helix stem → more negative ΔH (stabilizing).
+//   • Mixture over top-k poses with Boltzmann weights from docking scores.
+//   • ΔG = ΔH − T·ΔS with ΔH in kcal, ΔS in cal/K (ΔS/1000 before T·ΔS).
+//
+// Experimental: never elects poses, never mutates CF, never writes
+// FA->natural_deltaG. DualAssemblyEngine::run() does not apply these patches.
+// See docs/POSE_HELIX_THERMO_REWRITE.md.
+//
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace natural {
+
+// Inclusive 0-based nucleotide ranges for one decision helix (hairpin).
+// stem_i / stem_j are the two sides of the stem; loop is the intervening loop.
+struct HelixSegment {
+    int stem_i_begin = 0;
+    int stem_i_end   = -1;
+    int stem_j_begin = 0;
+    int stem_j_end   = -1;
+    int loop_begin   = 0;
+    int loop_end     = -1;
+    std::string label;
+};
+
+// One RNA nucleotide used only for contact geometry (no FlexAID atom_struct).
+struct ReceptorNtCoord {
+    int    nt_index = -1;
+    double x = 0.0, y = 0.0, z = 0.0;
+    bool   is_hbond_partner = false; // N/O donor/acceptor
+    bool   is_aromatic      = false; // nucleobase ring
+    // Ring normal. A zero vector skips the stacking-angle test (distance only).
+    double nx = 0.0, ny = 0.0, nz = 0.0;
+};
+
+struct LigandAtomCoord {
+    double x = 0.0, y = 0.0, z = 0.0;
+    bool   is_hbond_partner = false;
+    bool   is_aromatic      = false;
+    double nx = 0.0, ny = 0.0, nz = 0.0;
+};
+
+// One docking pose. `score_kcal` is the CF/contact-function scoring proxy used
+// only to form Boltzmann mixture weights — it is not a free-energy claim.
+struct LigandPose {
+    int    rank = 0;           // 0 = best
+    double score_kcal = 0.0;  // CF proxy (more negative → higher weight)
+    std::vector<LigandAtomCoord> atoms;
+};
+
+struct HelixThermoPatch {
+    std::string helix_label;
+    double delta_H_kcal = 0.0;
+    double delta_S_cal_per_K = 0.0;
+    double delta_G_kcal = 0.0;
+    std::vector<int> touched_nt;
+    int    pose_rank = -1;
+    double pose_boltzmann_w = 0.0;
+};
+
+struct PoseHelixRewriteConfig {
+    double T_K = 298.15;
+    double hbond_max_A = 3.5;
+    double stack_max_A = 4.5;
+    double stack_angle_max_deg = 40.0;
+    double dH_per_stack_kcal = -1.2;
+    double dS_per_hbond_cal_K = -3.0;
+    int    top_k_poses = 5;
+    bool   require_decision_helix_only = true;
+};
+
+struct PoseHelixRewriteResult {
+    std::vector<HelixThermoPatch> patches;   // per pose × helix
+    std::vector<HelixThermoPatch> ensemble; // Boltzmann mix, one per helix
+    bool applied = true; // false when DualAssembly flag is off
+};
+
+// kcal mol⁻¹ K⁻¹, same truncated value as LIB/statmech.h kB_kcal.
+inline constexpr double kB_pose_helix_kcal = 0.001987206;
+
+// ΔG [kcal] = ΔH[kcal] − T[K] · (ΔS[cal/K] / 1000).
+double helix_thermo_delta_g_kcal(double delta_H_kcal,
+                                 double delta_S_cal_per_K,
+                                 double T_K);
+
+// Log-sum-exp Boltzmann weights from CF scores. Empty input → empty vector.
+std::vector<double> boltzmann_weights_from_scores(const std::vector<double>& scores_kcal,
+                                                   double T_K);
+
+// Pure function: docking poses → helix ΔH/ΔS patches. No GA, no CF election.
+PoseHelixRewriteResult rewrite_helices_from_poses(
+    const std::vector<HelixSegment>& helices,
+    const std::vector<ReceptorNtCoord>& rna_nts,
+    const std::vector<LigandPose>& poses,
+    const PoseHelixRewriteConfig& cfg = {});
+
+} // namespace natural

--- a/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
+++ b/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
@@ -9,6 +9,30 @@ docking trajectory onto human-cell elongation rates. The Aβ42 protofibril (PDB 
 lives under `LIB/NATURaL/` and is exposed through the `dual_assembly` CLI and
 `scripts/run_dual_assembly_cotranslational.sh`.
 
+### Lineage: 2014 NATURAL vs 2026 NATURaL (do not conflate Zhao 2011 papers)
+
+**2014 NATURAL** = "Native Assembly of Transcriptionally-Unified RNA And Ligand"
+(LP Morency, master’s seminar R2, 2014-07-25). That Perl implementation followed
+Zhao, Zhang, Chen, *Cotranscriptional folding kinetics of ribonucleic acid secondary
+structures*, J. Chem. Phys. **135**, 245101 (2011), doi:10.1063/1.3671644, and added
+(1) clustering, (2) population inheritance across elongation, (3) slower transcription
+at nucleotide repeats, and (4) docking poses that rewrite helix ΔH/ΔS (loop entropy ↓
+for ligand contacts; stacking enthalpy more favorable for aromatic stacking on the
+decision helix). The 2026 C++ glue for piece (4) is `LIB/NATURaL/PoseHelixThermoRewrite`
+— experimental, default OFF; see `docs/POSE_HELIX_THERMO_REWRITE.md`.
+
+**2026 C++ NATURaL** is the broader DualAssembly acronym: Native Assembly of
+co-Transcriptionally / co-Translationally Unified Receptor–Ligand.
+
+**Zhao 2011 JPCB is a different paper.** Zhao et al., J. Phys. Chem. B **115**, 3987
+(2011) is the ribosome master equation / protein cotranslation model used by
+`RibosomeElongation.h`. Do not cite it as the RNA cotranscriptional folding-kinetics
+source, and do not cite the JCP paper as the ribosome ODE.
+
+NucleationDetector hairpin ΔG is sequence-only (Turner). DualAssemblyEngine CF +
+Shannon instantaneous ΔG is not the seminar ligand coupling. Optional StatMech
+`G_natural` is not fed by pose→helix patches.
+
 ---
 
 ## 1. Motivation: the Target/Ligand assignment problem
@@ -350,7 +374,11 @@ a long trajectory is partially readable on disk even if the run is interrupted.
   • `LIB/GrandPartitionFunction.h::GrandPartitionFunction` — one instance per oracle. Two
     entries: the empty site (implicit "1") and `"monomer"` updated each Sim C via
     `add_or_overwrite("monomer", log_Z_monomer, c_monomer_M)`.
-  • `LIB/NATURaL/{NATURaLDualAssembly,RibosomeElongation}.{h,cpp}` — unchanged.
+  • `LIB/NATURaL/{NATURaLDualAssembly,RibosomeElongation}.{h,cpp}` — elongation /
+    DualAssemblyEngine CF+Shannon path unchanged by pose→helix rewrite (default OFF).
+  • `LIB/NATURaL/PoseHelixThermoRewrite.{h,cpp}` — experimental sidecar; RNA DualAssembly
+    hook is `NATURaLConfig.enable_pose_helix_rewrite` (false) +
+    `DualAssemblyEngine::compute_pose_helix_rewrite()`. `run()` does not apply patches.
   • `LIB/DatasetRunner.{h,cpp}` — not touched. The cotranslational runner is a separate
     top-level driver to avoid cross-cutting changes.
 
@@ -391,6 +419,9 @@ a long trajectory is partially readable on disk even if the run is interrupted.
 
   • The MVP truncates the nascent chain in extended geometry only. ESMFold integration for
     per-residue secondary-structure-aware truncation is post-MVP.
+  • Pose→helix ΔH/ΔS rewrite is experimental and default OFF. DualAssemblyRunner does not
+    call it (no atom-level poses from the injected GA). DualAssemblyEngine::run() does not
+    add patches to CF or `FA->natural_deltaG`.
   • The transcription tracks do not dock directly against the protofibril
     (`direct_encounter_allowed = false`). Polysome-mode (multiple nascent chains at
     staggered lengths sharing one mRNA against a single protofibril) is a future
@@ -408,8 +439,12 @@ a long trajectory is partially readable on disk even if the run is interrupted.
 
 ## 10. References
 
+  • Zhao, Zhang, Chen, *Cotranscriptional folding kinetics of ribonucleic acid secondary
+    structures*, J. Chem. Phys. **135**, 245101 (2011), doi:10.1063/1.3671644 — RNA
+    cotranscriptional folding kinetics; 2014 NATURAL (LP Morency seminar) lineage.
+  • Zhao et al. 2011 J. Phys. Chem. B **115**, 3987 — ribosome master equation / protein
+    cotranslation ONLY (not the JCP RNA folding-kinetics paper).
   • Hessa et al. 2007 Nature 450:1026 — TM-helix code.
-  • Zhao et al. 2011 J. Phys. Chem. B 115:3987 — ribosome master equation.
   • Wohlgemuth et al. 2008 — E. coli elongation rate.
   • Ingolia et al. 2011 — human elongation rate.
   • Pechmann & Frydman 2013 Nat. Struct. Mol. Biol. 20:237 — translational pausing.

--- a/docs/EXPERIMENTAL_CAPABILITIES.md
+++ b/docs/EXPERIMENTAL_CAPABILITIES.md
@@ -18,6 +18,8 @@ At the current stage, the following should be treated as experimental:
 - TypeScript, PWA, dashboard, and browser-facing viewers
 - Bonhomme Fleet and iCloud-driven distributed execution
 - NATURaL and related co-translational or co-transcriptional workflows
+- PoseHelixThermoRewrite / pose→helix ΔH/ΔS rewrite (2014 NATURAL seminar glue; default OFF; not Astex / not `G_natural`)
+- backend-specific acceleration paths not required by the Core 1.0 support matrix
 - backend-specific acceleration paths not required by the Core 1.0 support matrix
 - benchmark claims not yet backed by a repository reproducibility bundle
 
@@ -38,6 +40,9 @@ The following are intentionally kept experimental (see `docs/thermodynamics.md` 
 - Temperature scan + model-derived ΔCp fitting (explicitly labelled `model_derived` / `experimental`)
 - Cleft annotation and flexible residue selection (preprocessing only)
 - Advanced compensation / enthalpy-entropy diagnostic metrics (for analysis only)
+- PoseHelixThermoRewrite (`LIB/NATURaL/PoseHelixThermoRewrite`) — docking-pose mixture that
+  rewrites RNA decision-helix ΔH/ΔS (loop ΔS, stem stacking ΔH). Experimental; default OFF;
+  DualAssemblyEngine::run() does not apply it. See `docs/POSE_HELIX_THERMO_REWRITE.md`.
 
 These features are fully implemented with tests and JSON exposure but require additional benchmarking or calibration data before promotion to validated status.
 4. an unambiguous ownership in the product boundary defined by `PRODUCT.md`

--- a/docs/POSE_HELIX_THERMO_REWRITE.md
+++ b/docs/POSE_HELIX_THERMO_REWRITE.md
@@ -1,0 +1,80 @@
+# Pose→helix ΔH/ΔS rewrite (experimental)
+
+**Status:** experimental. Not claim-ready. Does not elect poses, does not change
+Astex CF ranking, and does not write `FA->natural_deltaG` or DatasetRunner claim
+metrics.
+
+## What this is
+
+`LIB/NATURaL/PoseHelixThermoRewrite.{h,cpp}` is the 2026 C++ glue for piece (4) of
+the **2014 NATURAL** seminar:
+
+> **NATURAL** = Native Assembly of Transcriptionally-Unified RNA And Ligand
+> (LP Morency, master’s seminar R2, 2014-07-25)
+
+That Perl implementation followed Zhao, Zhang, Chen, *Cotranscriptional folding
+kinetics of ribonucleic acid secondary structures*, J. Chem. Phys. **135**, 245101
+(2011), doi:10.1063/1.3671644, and added:
+
+1. clustering
+2. population inheritance across elongation
+3. slower transcription at nucleotide repeats
+4. **docking poses that rewrite helix ΔH/ΔS** (this module)
+
+The 2026 DualAssembly acronym is broader: Native Assembly of co-Transcriptionally /
+co-Translationally Unified Receptor–Ligand (`NATURaLDualAssembly.h`).
+
+## Distinct Zhao 2011 papers
+
+| Paper | Role |
+|-------|------|
+| Zhao, Zhang, Chen, J. Chem. Phys. **135**, 245101 (2011) doi:10.1063/1.3671644 | RNA cotranscriptional folding kinetics. 2014 NATURAL lineage. |
+| Zhao et al., J. Phys. Chem. B **115**, 3987 (2011) | Ribosome master equation / **protein cotranslation ONLY**. `RibosomeElongation.h`. |
+
+Do not cite JPCB as the RNA folding-kinetics source, and do not cite JCP as the
+ribosome ODE.
+
+## Physics (seminar)
+
+Decision-helix patches only (`HelixSegment` list):
+
+- Ligand H-bond / base-pair-like contacts to **loop** nucleotides → ΔS < 0
+  (loop entropy reduction). Default −3.0 cal K⁻¹ per unique loop nt.
+- Aromatic stacking on the **stem** → more negative ΔH (stabilizing stacks).
+  Default −1.2 kcal per unique stem nt. Ring-normal angle ≤ 40° (parallel or
+  antiparallel); a zero normal skips the angle test.
+- Mixture over top-*k* poses with Boltzmann weights from docking **CF scores**
+  (scoring proxy, not ΔG_bind).
+- ΔG [kcal] = ΔH [kcal] − T · (ΔS [cal/K] / 1000).
+
+`NucleationDetector` hairpin ΔG is sequence-only (Turner). DualAssemblyEngine
+CF + Shannon instantaneous ΔG is **not** this ligand coupling. Optional StatMech
+`G_natural` is not fed by these patches.
+
+## API
+
+Pure function (no GA):
+
+```text
+rewrite_helices_from_poses(helices, rna_nts, poses, cfg)
+```
+
+Coordinate types (`ReceptorNtCoord`, `LigandPose`) are lightweight and independent
+of `atom_struct`, so unit tests do not need a full engine.
+
+## DualAssembly hook (default OFF)
+
+`NATURaLConfig.enable_pose_helix_rewrite` defaults to **false**.
+
+- `DualAssemblyEngine::run()` never applies patches to CF or `final_deltaG_`.
+- `DualAssemblyEngine::compute_pose_helix_rewrite(rna, poses)` is a sidecar: it
+  returns empty unless the flag is on **and** the receptor is nucleic acid.
+- `DualAssemblyRunner` does not call the rewrite (injected GA results currently
+  carry pose RMSDs, not atom coords). Follow-up: wire when a real-GA backend
+  emits snapshots.
+
+## Not claim-ready
+
+Do not use this module for Astex success, PoseBusters gates, or METHODS claim
+contracts. Treat outputs as a helix-parameter diagnostic for RNA DualAssembly
+experiments only.

--- a/tests/test_natural.cpp
+++ b/tests/test_natural.cpp
@@ -403,6 +403,8 @@ TEST(NucleationDetector, PositionBoostMapBaselineOne) {
 TEST(NATURaLConfig, DefaultsAreReasonable) {
     NATURaLConfig cfg;
     EXPECT_FALSE(cfg.enabled);
+    EXPECT_FALSE(cfg.enable_pose_helix_rewrite);
+    EXPECT_TRUE(cfg.decision_helices.empty());
     EXPECT_GT(cfg.temperature_K, 200.0);
     EXPECT_LT(cfg.temperature_K, 400.0);
     EXPECT_GT(cfg.mg_concentration_mM, 0.0);

--- a/tests/test_pose_helix_thermo_rewrite.cpp
+++ b/tests/test_pose_helix_thermo_rewrite.cpp
@@ -1,0 +1,227 @@
+// tests/test_pose_helix_thermo_rewrite.cpp
+// Experimental 2014 NATURAL pose→helix ΔH/ΔS rewrite (not claim-ready).
+// Apache-2.0 © 2026 Le Bonhomme Pharma
+
+#include <gtest/gtest.h>
+
+#include "NATURaL/PoseHelixThermoRewrite.h"
+
+#include <cmath>
+#include <vector>
+
+using namespace natural;
+
+static constexpr double kTol = 1e-9;
+
+static HelixSegment decision_helix() {
+    HelixSegment h;
+    h.stem_i_begin = 0;
+    h.stem_i_end   = 1;
+    h.loop_begin   = 2;
+    h.loop_end     = 3;
+    h.stem_j_begin = 4;
+    h.stem_j_end   = 5;
+    h.label        = "decision";
+    return h;
+}
+
+static ReceptorNtCoord nt_at(int idx, double x, double y, double z,
+                              bool hbond, bool aromatic) {
+    ReceptorNtCoord n;
+    n.nt_index = idx;
+    n.x = x; n.y = y; n.z = z;
+    n.is_hbond_partner = hbond;
+    n.is_aromatic = aromatic;
+    n.nx = 0.0; n.ny = 0.0; n.nz = 1.0;
+    return n;
+}
+
+static LigandAtomCoord atom_at(double x, double y, double z,
+                               bool hbond, bool aromatic) {
+    LigandAtomCoord a;
+    a.x = x; a.y = y; a.z = z;
+    a.is_hbond_partner = hbond;
+    a.is_aromatic = aromatic;
+    a.nx = 0.0; a.ny = 0.0; a.nz = 1.0;
+    return a;
+}
+
+static void expect_finite_result(const PoseHelixRewriteResult& r) {
+    EXPECT_TRUE(r.applied);
+    for (const auto& p : r.patches) {
+        EXPECT_TRUE(std::isfinite(p.delta_H_kcal));
+        EXPECT_TRUE(std::isfinite(p.delta_S_cal_per_K));
+        EXPECT_TRUE(std::isfinite(p.delta_G_kcal));
+        EXPECT_TRUE(std::isfinite(p.pose_boltzmann_w));
+        EXPECT_FALSE(std::isnan(p.delta_H_kcal));
+        EXPECT_FALSE(std::isnan(p.delta_S_cal_per_K));
+        EXPECT_FALSE(std::isnan(p.delta_G_kcal));
+    }
+    for (const auto& p : r.ensemble) {
+        EXPECT_TRUE(std::isfinite(p.delta_H_kcal));
+        EXPECT_TRUE(std::isfinite(p.delta_S_cal_per_K));
+        EXPECT_TRUE(std::isfinite(p.delta_G_kcal));
+        EXPECT_FALSE(std::isnan(p.delta_G_kcal));
+    }
+}
+
+TEST(PoseHelixThermoRewrite, StackingOnStemGivesNegativeDeltaH) {
+    PoseHelixRewriteConfig cfg;
+    LigandPose pose;
+    pose.rank = 0;
+    pose.score_kcal = -1.0;
+    pose.atoms.push_back(atom_at(0.0, 0.0, 3.5, /*hbond=*/false, /*aromatic=*/true));
+
+    std::vector<ReceptorNtCoord> rna = {
+        nt_at(0, 0.0, 0.0, 0.0, /*hbond=*/false, /*aromatic=*/true),
+    };
+
+    auto r = rewrite_helices_from_poses({decision_helix()}, rna, {pose}, cfg);
+    ASSERT_FALSE(r.patches.empty());
+    EXPECT_LT(r.patches[0].delta_H_kcal, 0.0);
+    EXPECT_NEAR(r.patches[0].delta_H_kcal, cfg.dH_per_stack_kcal, kTol);
+    EXPECT_NEAR(r.patches[0].delta_S_cal_per_K, 0.0, kTol);
+    expect_finite_result(r);
+}
+
+TEST(PoseHelixThermoRewrite, HBondIntoLoopGivesNegativeDeltaS) {
+    PoseHelixRewriteConfig cfg;
+    LigandPose pose;
+    pose.rank = 0;
+    pose.score_kcal = -1.0;
+    pose.atoms.push_back(atom_at(10.0, 0.0, 3.0, /*hbond=*/true, /*aromatic=*/false));
+
+    std::vector<ReceptorNtCoord> rna = {
+        nt_at(2, 10.0, 0.0, 0.0, /*hbond=*/true, /*aromatic=*/false),
+    };
+
+    auto r = rewrite_helices_from_poses({decision_helix()}, rna, {pose}, cfg);
+    ASSERT_FALSE(r.patches.empty());
+    EXPECT_LT(r.patches[0].delta_S_cal_per_K, 0.0);
+    EXPECT_NEAR(r.patches[0].delta_S_cal_per_K, cfg.dS_per_hbond_cal_K, kTol);
+    EXPECT_NEAR(r.patches[0].delta_H_kcal, 0.0, kTol);
+    const double expect_dG = helix_thermo_delta_g_kcal(
+        0.0, cfg.dS_per_hbond_cal_K, cfg.T_K);
+    EXPECT_NEAR(r.patches[0].delta_G_kcal, expect_dG, kTol);
+    expect_finite_result(r);
+}
+
+TEST(PoseHelixThermoRewrite, ContactOutsideDecisionHelixNoPatchWhenRequired) {
+    PoseHelixRewriteConfig cfg;
+    cfg.require_decision_helix_only = true;
+
+    LigandPose pose;
+    pose.rank = 0;
+    pose.score_kcal = -2.0;
+    pose.atoms.push_back(atom_at(50.0, 0.0, 3.0, /*hbond=*/true, /*aromatic=*/true));
+
+    std::vector<ReceptorNtCoord> rna = {
+        nt_at(20, 50.0, 0.0, 0.0, /*hbond=*/true, /*aromatic=*/true),
+    };
+
+    auto r = rewrite_helices_from_poses({decision_helix()}, rna, {pose}, cfg);
+    EXPECT_TRUE(r.patches.empty());
+    EXPECT_TRUE(r.ensemble.empty());
+    expect_finite_result(r);
+}
+
+TEST(PoseHelixThermoRewrite, ContactOutsideDecisionHelixPatchesWhenNotRequired) {
+    PoseHelixRewriteConfig cfg;
+    cfg.require_decision_helix_only = false;
+
+    LigandPose pose;
+    pose.rank = 0;
+    pose.score_kcal = -2.0;
+    pose.atoms.push_back(atom_at(50.0, 0.0, 3.0, /*hbond=*/true, /*aromatic=*/false));
+
+    std::vector<ReceptorNtCoord> rna = {
+        nt_at(20, 50.0, 0.0, 0.0, /*hbond=*/true, /*aromatic=*/false),
+    };
+
+    auto r = rewrite_helices_from_poses({decision_helix()}, rna, {pose}, cfg);
+    ASSERT_EQ(r.patches.size(), 1u);
+    EXPECT_EQ(r.patches[0].helix_label, "non_decision");
+    EXPECT_LT(r.patches[0].delta_S_cal_per_K, 0.0);
+    expect_finite_result(r);
+}
+
+TEST(PoseHelixThermoRewrite, TwoPoseMixtureWeights) {
+    PoseHelixRewriteConfig cfg;
+    cfg.T_K = 298.15;
+    cfg.top_k_poses = 5;
+
+    LigandPose p0;
+    p0.rank = 0;
+    p0.score_kcal = -2.0;
+    p0.atoms.push_back(atom_at(0.0, 0.0, 3.5, false, true));
+
+    LigandPose p1;
+    p1.rank = 1;
+    p1.score_kcal = 0.0;
+    p1.atoms.push_back(atom_at(0.0, 0.0, 3.5, false, true));
+
+    std::vector<ReceptorNtCoord> rna = {
+        nt_at(0, 0.0, 0.0, 0.0, false, true),
+    };
+
+    auto r = rewrite_helices_from_poses({decision_helix()}, rna, {p0, p1}, cfg);
+    ASSERT_EQ(r.patches.size(), 2u);
+
+    const auto w = boltzmann_weights_from_scores({-2.0, 0.0}, cfg.T_K);
+    ASSERT_EQ(w.size(), 2u);
+    EXPECT_NEAR(r.patches[0].pose_boltzmann_w, w[0], kTol);
+    EXPECT_NEAR(r.patches[1].pose_boltzmann_w, w[1], kTol);
+    EXPECT_GT(w[0], w[1]); // more negative CF score → higher weight
+    EXPECT_NEAR(w[0] + w[1], 1.0, kTol);
+
+    ASSERT_EQ(r.ensemble.size(), 1u);
+    const double expect_dH = w[0] * cfg.dH_per_stack_kcal + w[1] * cfg.dH_per_stack_kcal;
+    EXPECT_NEAR(r.ensemble[0].delta_H_kcal, expect_dH, 1e-12);
+    expect_finite_result(r);
+}
+
+TEST(PoseHelixThermoRewrite, NoNaNOnEmptyAndMixed) {
+    PoseHelixRewriteConfig cfg;
+    auto empty = rewrite_helices_from_poses({}, {}, {}, cfg);
+    EXPECT_TRUE(empty.patches.empty());
+    EXPECT_TRUE(empty.ensemble.empty());
+    EXPECT_TRUE(empty.applied);
+
+    LigandPose pose;
+    pose.rank = 0;
+    pose.score_kcal = -0.5;
+    pose.atoms.push_back(atom_at(0.0, 0.0, 3.5, false, true));
+    pose.atoms.push_back(atom_at(10.0, 0.0, 3.0, true, false));
+
+    std::vector<ReceptorNtCoord> rna = {
+        nt_at(0, 0.0, 0.0, 0.0, false, true),
+        nt_at(2, 10.0, 0.0, 0.0, true, false),
+    };
+
+    auto r = rewrite_helices_from_poses({decision_helix()}, rna, {pose}, cfg);
+    ASSERT_FALSE(r.patches.empty());
+    EXPECT_LT(r.patches[0].delta_H_kcal, 0.0);
+    EXPECT_LT(r.patches[0].delta_S_cal_per_K, 0.0);
+    expect_finite_result(r);
+
+    const double dG = helix_thermo_delta_g_kcal(
+        r.patches[0].delta_H_kcal, r.patches[0].delta_S_cal_per_K, cfg.T_K);
+    EXPECT_NEAR(r.patches[0].delta_G_kcal, dG, kTol);
+}
+
+TEST(PoseHelixThermoRewrite, EqualScoresGiveEqualWeights) {
+    const auto w = boltzmann_weights_from_scores({-1.0, -1.0, -1.0}, 298.15);
+    ASSERT_EQ(w.size(), 3u);
+    EXPECT_NEAR(w[0], 1.0 / 3.0, kTol);
+    EXPECT_NEAR(w[1], 1.0 / 3.0, kTol);
+    EXPECT_NEAR(w[2], 1.0 / 3.0, kTol);
+}
+
+TEST(PoseHelixThermoRewrite, UnitsDeltaGMatchesDeltaHMinusTDeltaS) {
+    const double dH = -1.2;
+    const double dS = -3.0; // cal/K
+    const double T = 298.15;
+    const double dG = helix_thermo_delta_g_kcal(dH, dS, T);
+    EXPECT_NEAR(dG, dH - T * (dS / 1000.0), 1e-12);
+    EXPECT_TRUE(std::isfinite(dG));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Experimental; not claim-ready.** This PR does not change Astex CF election, DatasetRunner claim metrics, or METHODS claim contracts.

It (1) documents two distinct Zhao 2011 papers and the 2014 NATURAL seminar acronym, and (2) implements the missing docking-pose → helix ΔH/ΔS rewrite from that seminar as a tested, default-OFF DualAssembly sidecar.

### Citations (do not conflate)

- **ADD:** Zhao, Zhang, Chen, *Cotranscriptional folding kinetics of ribonucleic acid secondary structures*, J. Chem. Phys. **135**, 245101 (2011), doi:10.1063/1.3671644 — RNA cotranscriptional folding kinetics; 2014 NATURAL lineage.
- **KEEP and LABEL:** Zhao et al. 2011 J. Phys. Chem. B **115**, 3987 — ribosome master equation / protein cotranslation **ONLY** (`RibosomeElongation.h`).

### 2014 NATURAL lineage

**2014 NATURAL** = "Native Assembly of Transcriptionally-Unified RNA And Ligand" (LP Morency, master’s seminar R2, 2014-07-25): Perl implementation of Zhao–Zhang–Chen JCP with (1) clustering, (2) population inheritance across elongation, (3) slower transcription at nucleotide repeats, (4) docking poses that rewrite helix ΔH/ΔS (loop entropy ↓ for ligand contacts; stacking enthalpy more favorable for aromatic stacking on the decision helix).

**2026 C++ NATURaL** is the broader DualAssembly acronym: co-Transcriptionally / co-Translationally Unified Receptor–Ligand.

### Seminar ΔH/ΔS rewrite

`LIB/NATURaL/PoseHelixThermoRewrite` is a pure function (no GA):

- Decision-helix patches only (`HelixSegment` list).
- Loop H-bonds → ΔS < 0 (cal/K).
- Stem aromatic stacks → ΔH < 0 (kcal).
- Top-*k* pose mixture with Boltzmann weights from CF scores (scoring proxy, not ΔG_bind).
- ΔG = ΔH − T·(ΔS/1000).

`NucleationDetector` hairpin ΔG remains sequence-only. DualAssemblyEngine CF+Shannon instantaneous ΔG is **not** this coupling. `G_natural` is **not** fed by these patches. `DualAssemblyEngine::run()` does not apply them. Hook: `NATURaLConfig.enable_pose_helix_rewrite` (default `false`) + `compute_pose_helix_rewrite()`. DualAssemblyRunner does not invoke it yet (GA callbacks lack atom coords).

## Change class (pick **one** primary)

- [ ] **Fix** — bug; default path unchanged, or fail-closed
- [x] **Science enhancement** — opt-in; default **OFF** (`NATURaLConfig.enable_pose_helix_rewrite`)
- [ ] **Engine/code** — LIB/src behavior that is not a science gate
- [ ] **Docs / audit / swarm pack** — `docs/swarm/`, `docs/audit/` (own PR; do not mix with LIB)
- [ ] **Benchmark harness / frozen referee**
- [ ] **CI / hygiene**

`python3 scripts/classify_diff.py` reports `engine_critical` because `CMakeLists.txt` lists the new translation unit. Default paths do not apply patches to CF or ranking. Not `VERDICT: MIXED` (no swarm/audit pack). Docs + experimental module are requested together.

## Science-Impact

- [ ] none (cannot move docked coordinates or CF ranking)
- [x] gated OFF — flag name: `NATURaLConfig.enable_pose_helix_rewrite` (and DualAssemblyRunner `enable_pose_helix_rewrite`, unused)
- [ ] default-path (requires METHODOLOGY.md §1 parity)

## Scope

- [ ] Core 1.0 supported surface
- [x] Experimental surface only
- [ ] Documentation only
- [ ] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [x] no user-facing release impact

## Validation

- [x] unit tests (`PoseHelixThermoRewriteTests`, `NATURaLConfig` default-OFF)
- [ ] integration tests
- [ ] smoke benchmark
- [x] documentation review
- [ ] manual validation

## Security and safety

- [x] no new third-party dependency
- [ ] third-party dependency added and documented
- [x] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [x] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

- `docs/POSE_HELIX_THERMO_REWRITE.md` is the module contract.
- Follow-up: DualAssemblyRunner real-GA snapshots → optional rewrite call. Not in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0685cdf1-b6d2-4afc-99ca-010550107a56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0685cdf1-b6d2-4afc-99ca-010550107a56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added experimental pose-to-helix thermodynamic rewriting for RNA workflows.
  - Supports helix-level ΔH/ΔS and ΔG calculations, pose ranking, Boltzmann weighting, and configurable contact detection.
  - Added optional integration with dual assembly; disabled by default and does not alter existing scoring results.

- **Documentation**
  - Added configuration guidance, experimental-status notes, limitations, and clarified related NATURAL lineage and references.

- **Tests**
  - Added coverage for thermodynamic calculations, weighting, contact handling, defaults, and empty-input behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->