### PR TITLE
Add experimental PoseLocalThermoRewrite (cited NN/helix–coil ΔH/ΔS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1218,6 +1218,7 @@ if(ENABLE_DUAL_ASSEMBLY_TOOL)
     add_executable(dual_assembly
         LIB/NATURaL/dual_assembly_main.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/NATURaLDualAssembly.cpp
@@ -1509,6 +1510,15 @@ if(BUILD_TESTING)
     flexaids_add_unit_test(test_thermo_gate
         SOURCES tests/test_thermo_gate.cpp
         TEST_NAME ThermoGateTests
+    )
+
+    # test_pose_local_thermo_rewrite — experimental NATURaL pose→local SS ΔH/ΔS
+    # (pure function; no GA / DualAssemblyEngine).
+    flexaids_add_unit_test(test_pose_local_thermo_rewrite
+        SOURCES
+            tests/test_pose_local_thermo_rewrite.cpp
+            LIB/NATURaL/PoseLocalThermoRewrite.cpp
+        TEST_NAME PoseLocalThermoRewriteTests
     )
 
     # test_thermo_ledger — Thermo ledger tests
@@ -1804,6 +1814,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/LigandRingFlex/RingConformerLibrary.cpp
         LIB/LigandRingFlex/SugarPucker.cpp
         LIB/UnifiedHardwareDispatch.cpp
@@ -1863,6 +1874,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/LigandRingFlex/RingConformerLibrary.cpp
         LIB/LigandRingFlex/SugarPucker.cpp
         LIB/UnifiedHardwareDispatch.cpp
@@ -2141,6 +2153,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/ProtocolConfig.cpp
@@ -2199,6 +2212,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -2254,6 +2268,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/ProtocolConfig.cpp
@@ -2312,6 +2327,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )
@@ -2367,6 +2383,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -2424,6 +2441,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -2482,6 +2500,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -2538,6 +2557,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/InStreamClustering.cpp
@@ -2698,6 +2718,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/ProtocolConfig.cpp
@@ -2914,6 +2935,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
         LIB/ProtocolConfig.cpp
@@ -3238,6 +3260,7 @@ flexaids_add_unit_test(test_protocol_config
         LIB/NATURaL/NascentChainScheduler.cpp
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/NATURaL/NATURaLDualAssembly.cpp
         LIB/NATURaL/RibosomeElongation.cpp
         LIB/NATURaL/TransloconInsertion.cpp
@@ -3585,6 +3608,7 @@ if(BUILD_SWIFT_BRIDGE)
         LIB/NATURaL/FibrilGrowthOracle.cpp
         LIB/GrandPartitionFunction.cpp
         LIB/NATURaL/DualAssemblyRunner.cpp
+        LIB/NATURaL/PoseLocalThermoRewrite.cpp
         LIB/UnifiedHardwareDispatch.cpp
         LIB/hardware_detect.cpp
     )

--- a/LIB/CMakeLists.txt
+++ b/LIB/CMakeLists.txt
@@ -137,6 +137,7 @@ set(FLEXAID_CORE_SOURCES
     NATURaL/NascentChainScheduler.cpp
     NATURaL/FibrilGrowthOracle.cpp
     NATURaL/DualAssemblyRunner.cpp
+    NATURaL/PoseLocalThermoRewrite.cpp
     ChiralCenter/ChiralCenterGene.cpp
     # ── CleftDetector + Mol2Reader + SdfReader ──
     CleftDetector.cpp

--- a/LIB/NATURaL/DualAssemblyRunner.cpp
+++ b/LIB/NATURaL/DualAssemblyRunner.cpp
@@ -3,6 +3,7 @@
 // Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
 #include "DualAssemblyRunner.h"
 
+#include "../EnvFlags.h"
 #include "../ShannonThermoStack/ShannonThermoStack.h"
 
 #include <algorithm>
@@ -52,6 +53,9 @@ DualAssemblyRunner::DualAssemblyRunner(DualAssemblyConfig cfg,
         throw std::invalid_argument("DualAssemblyRunner: truncate callback is required");
     if (cfg_.sim_c_enabled && !sim_c_)
         throw std::invalid_argument("DualAssemblyRunner: sim_c callback required when sim_c_enabled");
+    if (flexaids::env_bool("FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE"))
+        cfg_.enable_pose_local_thermo_rewrite = true;
+    cfg_.pose_rewrite_cfg.temperature_K = cfg_.temperature_K;
 }
 
 // ─── Pose-entropy role discriminator ─────────────────────────────────────────
@@ -244,6 +248,23 @@ std::vector<std::pair<Checkpoint, CheckpointOutcome>> DualAssemblyRunner::run() 
 
         // ── T/L discriminator ───────────────────────────────────────────────
         assign_tl(out.H_A_nats, out.H_B_nats, state.tl_prev, out);
+
+        // Experimental pose→local SS rewrite. Diagnostic only: never overwrite
+        // dG_A_kcal / dG_B_kcal (validated DualAssembly thermo stays intact).
+        if (cfg_.enable_pose_local_thermo_rewrite &&
+            !cfg_.pose_rewrite_elements.empty() &&
+            !cfg_.pose_rewrite_poses.empty()) {
+            const LocalThermoMixture mix = rewrite_local_thermo_from_poses(
+                cfg_.pose_rewrite_poses,
+                cfg_.pose_rewrite_elements,
+                cfg_.pose_rewrite_cfg);
+            if (!mix.empty()) {
+                out.pose_local_thermo_applied = true;
+                out.pose_local_dH_kcal = mix.dH_kcal;
+                out.pose_local_dS_cal_per_mol_K = mix.dS_cal_per_mol_K;
+                out.pose_local_dG_kcal = mix.dG_kcal;
+            }
+        }
 
         scheduler_.record(ck, out);
         write_csv_row(cfg_.output_csv, ck, out);

--- a/LIB/NATURaL/DualAssemblyRunner.h
+++ b/LIB/NATURaL/DualAssemblyRunner.h
@@ -13,6 +13,7 @@
 
 #include "FibrilGrowthOracle.h"
 #include "NascentChainScheduler.h"
+#include "PoseLocalThermoRewrite.h"
 #include "../statmech.h"
 
 #include <functional>
@@ -40,11 +41,22 @@ struct DualAssemblyConfig {
     std::string output_csv                  = "cotranslational_trajectory.csv";
     std::string nascent_pdb_dir             = ".";
     double      acceptance_threshold        = 0.5;
-    // Experimental 2014 NATURAL pose→helix ΔH/ΔS rewrite. Default OFF.
-    // DualAssemblyRunner does not invoke PoseHelixThermoRewrite (GA callbacks
-    // currently supply pose RMSDs, not atom coords). Follow-up: wire when a
-    // real-GA backend emits ReceptorNtCoord / LigandPose snapshots.
+
+    // Experimental 2014 NATURAL pose→helix ΔH/ΔS rewrite (PoseHelixThermoRewrite).
+    // Default OFF. DualAssemblyRunner does not invoke it (GA callbacks currently
+    // supply pose RMSDs, not atom coords). Follow-up: wire when a real-GA backend
+    // emits ReceptorNtCoord / LigandPose snapshots. See docs/POSE_HELIX_THERMO_REWRITE.md.
     bool        enable_pose_helix_rewrite   = false;
+
+    // Experimental pose→local SS ΔH/ΔS rewrite (PoseLocalThermoRewrite). Default OFF.
+    // Env override: FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE=1.
+    // When on AND pose_rewrite_elements + pose_rewrite_poses are labelled,
+    // DualAssemblyRunner stores a diagnostic mixture on CheckpointOutcome and
+    // does not overwrite dG_A_kcal / dG_B_kcal or StatMech G_natural.
+    bool enable_pose_local_thermo_rewrite = false;
+    std::vector<DecisionElement> pose_rewrite_elements;
+    std::vector<PoseView>        pose_rewrite_poses;
+    PoseThermoRewriteConfig      pose_rewrite_cfg = default_pose_thermo_rewrite_config();
 };
 
 // ─── GA-backend callback signatures ──────────────────────────────────────────

--- a/LIB/NATURaL/NATURaLDualAssembly.h
+++ b/LIB/NATURaL/NATURaLDualAssembly.h
@@ -10,12 +10,14 @@
 //     (see PoseHelixThermoRewrite.h).
 //   2026 C++ header NATURaL = "Native Assembly of co-Transcriptionally /
 //     co-Translationally Unified Receptor–Ligand" (this DualAssembly module).
+// Directory name remains NATURaL (historical spelling).
 //
 // Distinct Zhao 2011 papers:
 //   • Zhao, Zhang, Chen, J. Chem. Phys. 135, 245101 (2011) — RNA
 //     cotranscriptional folding kinetics (2014 NATURAL lineage).
 //   • Zhao et al., J. Phys. Chem. B 115, 3987 (2011) — ribosome master
 //     equation / protein cotranslation ONLY (see RibosomeElongation.h).
+//     Do not cite JPCB 2011 as an RNA/DNA folding paper.
 //
 // Auto-detects when the ligand is nucleotide/sugar-containing or the receptor
 // is a nucleic acid chain, then activates DualAssembly mode.
@@ -29,6 +31,11 @@
 // Also supports transmembrane (TM) domain insertion via the Sec translocon
 // (see TransloconInsertion model below).
 //
+// Pose→local SS ΔH/ΔS rewrite (2014 ligand coupling, generalized to RNA/DNA/
+// protein helix/sheet) lives in PoseLocalThermoRewrite.h — experimental,
+// default OFF, not wired into G_natural. Same algebra, class-specific tables.
+// PoseHelixThermoRewrite remains the RNA decision-helix sidecar (default OFF).
+//
 // Fully integrated with:
 //   – RibosomeElongation (Zhao et al. 2011 JPCB master equation, codon rates)
 //   – ShannonThermoStack (entropy per growth step, time-weighted)
@@ -36,6 +43,7 @@
 //   – AlphaShape Contact Function (incremental ΔSASA)
 //   – TransloconInsertion (TM helix lateral gating, von Heijne 2007)
 //   – PoseHelixThermoRewrite (experimental, default OFF; RNA DualAssembly sidecar)
+//   – PoseLocalThermoRewrite (experimental, default OFF; RNA/DNA/helix/sheet)
 #pragma once
 
 #include "../flexaid.h"
@@ -71,6 +79,10 @@ struct NATURaLConfig {
     int              max_growth_steps        = -1; // -1 = full sequence length
     ribosome::Organism organism              = ribosome::Organism::EcoliK12;
     bool             use_ribosome_speed      = true;  // Zhao et al. 2011 JPCB rates
+
+    // Experimental pose→local SS ΔH/ΔS rewrite (PoseLocalThermoRewrite).
+    // Default OFF. Does not mutate DualAssemblyEngine growth ΔG or G_natural.
+    bool             pose_local_thermo_rewrite = false;
     bool             model_tm_insertion      = true;  // model TM translocon
 
     // ── Ion-dependent RNA folding ──────────────────────────────────────────

--- a/LIB/NATURaL/NascentChainScheduler.h
+++ b/LIB/NATURaL/NascentChainScheduler.h
@@ -57,6 +57,13 @@ struct CheckpointOutcome {
     bool   sim_c_gated_in = false;
     int    protofibril_state_index = 0;
     bool   protofibril_structure_updated = false;
+
+    // Experimental PoseLocalThermoRewrite diagnostic (default unused).
+    // Never a substitute for dG_A_kcal / dG_B_kcal. Finite zeros when inactive.
+    bool   pose_local_thermo_applied = false;
+    double pose_local_dH_kcal = 0.0;
+    double pose_local_dS_cal_per_mol_K = 0.0;
+    double pose_local_dG_kcal = 0.0;
 };
 
 // ─── NascentChainScheduler ───────────────────────────────────────────────────

--- a/LIB/NATURaL/NnMotifTables.h
+++ b/LIB/NATURaL/NnMotifTables.h
@@ -1,0 +1,212 @@
+// NnMotifTables.h — peer-reviewed NN / helix–coil motif ΔH/ΔS for PoseLocalThermoRewrite
+//
+// Ligand pose weight w scales the matched published stack or loop term.
+// RNA ≠ DNA ≠ helix ≠ sheet. Never alias Xia/Turner onto SantaLucia or protein.
+//
+// DNA Table 2: SantaLucia Jr (1998) PNAS 95:1460, doi:10.1073/pnas.95.4.1460
+//   (PMC19045). Unified 1 M NaCl. Review: SantaLucia & Hicks 2004.
+// RNA WC stacks: Xia et al. (1998) Biochemistry 37:14719, doi:10.1021/bi9809425
+//   NNDB: Turner & Mathews (2010) NAR, doi:10.1093/nar/gkp892
+//   https://rna.urmc.rochester.edu/NNDB/
+// RNA hairpin ΔH°: Lu, Turner, Mathews (2006) NAR 34:4912, doi:10.1093/nar/gkl472
+//
+// TSV copies (do not invent numbers): LIB/NATURaL/data/
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <array>
+#include <cctype>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace natural {
+
+struct MotifDeltaHS {
+    double dH_kcal = 0.0;
+    double dS_cal_per_mol_K = 0.0;
+};
+
+inline constexpr double kNnT37_K = 310.15;
+
+inline constexpr double nn_delta_S_cal(double dH_kcal, double dG_kcal, double T_K) noexcept
+{
+    return (dH_kcal - dG_kcal) / T_K * 1000.0;
+}
+
+template <std::size_t N>
+inline constexpr double motif_mean_dH(const std::array<MotifDeltaHS, N>& rows,
+                                      std::size_t count) noexcept
+{
+    double sum = 0.0;
+    for (std::size_t i = 0; i < count; ++i)
+        sum += rows[i].dH_kcal;
+    return sum / static_cast<double>(count);
+}
+
+template <std::size_t N>
+inline constexpr double motif_mean_dS(const std::array<MotifDeltaHS, N>& rows,
+                                      std::size_t count) noexcept
+{
+    double sum = 0.0;
+    for (std::size_t i = 0; i < count; ++i)
+        sum += rows[i].dS_cal_per_mol_K;
+    return sum / static_cast<double>(count);
+}
+
+// ── DNA: SantaLucia 1998 PNAS Table 2 (embed literally) ─────────────────────
+// Order matches the published table: 10 WC stacks, then Init G·C, Init A·T, Sym.
+inline constexpr std::array<const char*, 13> kSantaLucia1998Motif{
+    "AA/TT", "AT/TA", "TA/AT", "CA/GT", "GT/CA", "CT/GA", "GA/CT",
+    "CG/GC", "GC/CG", "GG/CC", "INIT_GC", "INIT_AT", "SYM"};
+
+inline constexpr std::array<MotifDeltaHS, 13> kSantaLucia1998PnasTable2{{
+    {-7.9, -22.2},
+    {-7.2, -20.4},
+    {-7.2, -21.3},
+    {-8.5, -22.7},
+    {-8.4, -22.4},
+    {-7.8, -21.0},
+    {-8.2, -22.2},
+    {-10.6, -27.2},
+    {-9.8, -24.4},
+    {-8.0, -19.9},
+    {0.1, -2.8},   // Init. w/term. G·C
+    {2.3, 4.1},    // Init. w/term. A·T
+    {0.0, -1.4},   // Symmetry correction
+}};
+
+inline constexpr std::size_t kSantaLucia1998WcStackCount = 10;
+
+inline constexpr double kSantaLucia1998DnaWcStackMean_dH_kcal =
+    motif_mean_dH(kSantaLucia1998PnasTable2, kSantaLucia1998WcStackCount);
+inline constexpr double kSantaLucia1998DnaWcStackMean_dS_cal =
+    motif_mean_dS(kSantaLucia1998PnasTable2, kSantaLucia1998WcStackCount);
+
+// ── RNA: Xia 1998 INN-HB unique WC propagation stacks ───────────────────────
+// ΔS from published ΔH and ΔG°37 at 310.15 K. Order: Zuber 2022 Table 1A 1998 Model.
+inline constexpr std::array<const char*, 10> kXia1998RnaMotif{
+    "GC/CG", "CC/GG", "GA/CU", "CG/GC", "AC/UG",
+    "CA/GU", "AG/UC", "UA/AU", "AU/UA", "AA/UU"};
+
+inline constexpr std::array<double, 10> kXia1998RnaWcStack_dH_kcal{
+    -14.88, -13.39, -12.44, -10.64, -11.40,
+    -10.44, -10.48,  -7.69,  -9.38,  -6.82};
+inline constexpr std::array<double, 10> kXia1998RnaWcStack_dG37_kcal{
+    -3.42, -3.26, -2.35, -2.36, -2.08,
+    -2.11, -2.08, -1.33, -1.10, -0.93};
+
+inline constexpr MotifDeltaHS xia1998_stack_at(std::size_t i) noexcept
+{
+    const double dH = kXia1998RnaWcStack_dH_kcal[i];
+    const double dS = nn_delta_S_cal(dH, kXia1998RnaWcStack_dG37_kcal[i], kNnT37_K);
+    return {dH, dS};
+}
+
+inline constexpr std::array<MotifDeltaHS, 10> kXia1998RnaWcStacks{{
+    xia1998_stack_at(0), xia1998_stack_at(1), xia1998_stack_at(2), xia1998_stack_at(3),
+    xia1998_stack_at(4), xia1998_stack_at(5), xia1998_stack_at(6), xia1998_stack_at(7),
+    xia1998_stack_at(8), xia1998_stack_at(9)}};
+
+inline constexpr double kXia1998RnaWcStackMean_dH_kcal =
+    motif_mean_dH(kXia1998RnaWcStacks, 10);
+inline constexpr double kXia1998RnaWcStackMean_dS_cal =
+    motif_mean_dS(kXia1998RnaWcStacks, 10);
+
+// ── RNA hairpin initiation ΔH° (Lu 2006 Table 1) ────────────────────────────
+// Default unmatched loop size is n = 4 (canonical tetraloop published term).
+inline constexpr int kLu2006DefaultHairpinN = 4;
+
+inline constexpr double lu2006_hairpin_initiation_dH_kcal(int unpaired_n) noexcept
+{
+    if (unpaired_n < 3)
+        return 0.0;
+    switch (unpaired_n) {
+    case 3: return 1.3;
+    case 4: return 4.8;
+    case 5: return 3.6;
+    case 6: return -2.9;
+    case 7: return 1.3;
+    case 8: return -2.9;
+    default: return 5.0;  // n >= 9
+    }
+}
+
+inline constexpr MotifDeltaHS kLu2006DefaultHairpin{
+    lu2006_hairpin_initiation_dH_kcal(kLu2006DefaultHairpinN),
+    0.0};  // ΔS not tabulated; extra length cost is entropic (Lu 2006)
+
+// ── protein helix / sheet (class-specific; not NN nucleic-acid tables) ───────
+// Scholtz 1991 PNAS doi:10.1073/pnas.88.7.2854 — calorimetric helix unfolding
+// ΔH ≈ +1.3 kcal mol⁻¹ residue⁻¹ → formation ΔH = −1.3.
+inline constexpr double kScholtz1991HelixFormation_dH_kcal = -1.3;
+// Zavrtanik, Lah, Hadži, Biophys. J. 125:305 (2026), doi:10.1016/j.bpj.2025.11.2689
+// PubMed 41318999. Helix→coil ΔS_BB = 5.2 ± 0.3 cal mol⁻¹ K⁻¹ per peptide unit
+// → formation ΔS = −5.2 (backbone baseline).
+inline constexpr double kZavrtanik2026HelixFormation_dS_cal = -5.2;
+
+// Meier & Seelig, J. Am. Chem. Soc. (2008) doi:10.1021/ja077231r — membrane
+// coil⇄β, length-dependent ΔH_fold ≈ −0.2 to −0.6 kcal mol⁻¹ residue⁻¹,
+// TΔS_fold ≈ −0.1 to −0.5 kcal mol⁻¹ residue⁻¹. Default mid, labelled experimental:
+// ΔH = −0.4 ; ΔS ≈ −1.0 e.u. at 298 K from TΔS ≈ −0.3.
+// Caveat: Deechongkit et al. Nature 430:101 (2004) doi:10.1038/nature02611 —
+// β H-bond energetics are context-dependent. No universal NN sheet table.
+inline constexpr double kMeierSeelig2008SheetFold_dH_kcal = -0.4;
+inline constexpr double kMeierSeelig2008SheetFold_dS_cal = -1.0;
+inline constexpr bool kMeierSeelig2008SheetFoldIsExperimental = true;
+
+static_assert(kXia1998RnaWcStackMean_dH_kcal != kSantaLucia1998DnaWcStackMean_dH_kcal,
+              "RNA Xia 1998 mean must not equal DNA SantaLucia 1998 Table 2 mean");
+static_assert(kScholtz1991HelixFormation_dH_kcal < 0.0);
+static_assert(kZavrtanik2026HelixFormation_dS_cal < 0.0);
+static_assert(kMeierSeelig2008SheetFold_dH_kcal != kScholtz1991HelixFormation_dH_kcal);
+
+inline std::string normalize_nn_motif(std::string_view raw)
+{
+    std::string out;
+    out.reserve(raw.size());
+    for (unsigned char ch : raw) {
+        if (ch == ' ' || ch == '\t')
+            continue;
+        out.push_back(static_cast<char>(std::toupper(ch)));
+    }
+    return out;
+}
+
+inline std::optional<MotifDeltaHS> lookup_santalucia1998_dna(std::string_view motif)
+{
+    if (motif.empty())
+        return MotifDeltaHS{kSantaLucia1998DnaWcStackMean_dH_kcal,
+                            kSantaLucia1998DnaWcStackMean_dS_cal};
+    const std::string key = normalize_nn_motif(motif);
+    for (std::size_t i = 0; i < kSantaLucia1998Motif.size(); ++i) {
+        if (key == kSantaLucia1998Motif[i])
+            return kSantaLucia1998PnasTable2[i];
+    }
+    return std::nullopt;
+}
+
+inline std::optional<MotifDeltaHS> lookup_xia1998_rna(std::string_view motif)
+{
+    if (motif.empty())
+        return MotifDeltaHS{kXia1998RnaWcStackMean_dH_kcal, kXia1998RnaWcStackMean_dS_cal};
+    const std::string key = normalize_nn_motif(motif);
+    for (std::size_t i = 0; i < kXia1998RnaMotif.size(); ++i) {
+        if (key == kXia1998RnaMotif[i])
+            return kXia1998RnaWcStacks[i];
+    }
+    return std::nullopt;
+}
+
+// loop_unpaired < 0 → Lu 2006 n=4 default. 0..2 → not a hairpin (nullopt).
+inline std::optional<MotifDeltaHS> lookup_lu2006_rna_hairpin(int loop_unpaired)
+{
+    const int n = (loop_unpaired < 0) ? kLu2006DefaultHairpinN : loop_unpaired;
+    if (n < 3)
+        return std::nullopt;
+    return MotifDeltaHS{lu2006_hairpin_initiation_dH_kcal(n), 0.0};
+}
+
+} // namespace natural

--- a/LIB/NATURaL/PoseLocalThermoRewrite.cpp
+++ b/LIB/NATURaL/PoseLocalThermoRewrite.cpp
@@ -242,22 +242,78 @@ SSClass ss_class_for_kind(ContactKind kind) noexcept
 PoseThermoRewriteConfig default_pose_thermo_rewrite_config()
 {
     PoseThermoRewriteConfig cfg;
-    // Draft experimental increments (tunable; not claim-ready).
-    // RNA (Turner-shaped): stem stack ΔH = −1.2 w; loop H-bond ΔS = −3.0 w
-    set_inc(cfg.rna, ContactKind::RNA_STEM_STACK, -1.2, 0.0);
-    set_inc(cfg.rna, ContactKind::RNA_LOOP_HBOND, 0.0, -3.0);
-    // DNA (SantaLucia-shaped): NEVER a copy of the RNA table.
-    set_inc(cfg.dna, ContactKind::DNA_STEM_STACK, -1.0, 0.0);
-    set_inc(cfg.dna, ContactKind::DNA_LOOP_HBOND, 0.0, -2.5);
-    set_inc(cfg.dna, ContactKind::DNA_INTERCALATION, -1.5, -1.0);
-    // Protein α-helix
-    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_BB_HBOND, -1.5, -1.0);
-    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_PACKING, -0.8, -2.0);
-    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_CLASH, 2.0, 0.0);
-    // Protein β-sheet
-    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_BRIDGE_HBOND, -1.8, -1.5);
-    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK, -1.0, -2.5);
-    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_SHEAR, 2.5, 1.0);
+
+    // RNA stem stack: Xia 1998 INN-HB mean of 10 unique WC propagation stacks.
+    // doi:10.1021/bi9809425 ; Zuber 2022 NAR Table 1A "1998 Model"
+    // doi:10.1093/nar/gkac261. Sequence-specific NN lookup is future work.
+    set_inc(cfg.rna, ContactKind::RNA_STEM_STACK,
+            kXia1998RnaWcStackMean_dH_kcal, kXia1998RnaWcStackMean_dS_cal);
+
+    // TODO(burgundy): RNA ligand–loop H-bond ΔH/ΔS. Mathews, Sabina, Zuker,
+    // Turner, J. Mol. Biol. 288:911 (1999), doi:10.1006/jmbi.1999.2700 is
+    // hairpin/internal-loop *initiation* ΔG, not a ligand–loop H-bond increment.
+    // Leave unset until a calorimetric consensus is harvested.
+    set_inc(cfg.rna, ContactKind::RNA_LOOP_HBOND,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+
+    // DNA stem stack: SantaLucia & Hicks 2004 Table 1 mean of 10 WC
+    // propagation stacks (1 M NaCl). doi:10.1146/annurev.biophys.32.110601.141800
+    // NEVER a copy of the RNA table — RNA mean ΔH (−10.756) ≠ DNA mean (−8.33).
+    set_inc(cfg.dna, ContactKind::DNA_STEM_STACK,
+            kSantaLucia2004DnaNnMean_dH_kcal, kSantaLucia2004DnaNnMean_dS_cal);
+
+    // TODO(burgundy): DNA ligand–loop H-bond ΔH/ΔS. SantaLucia 2004 hairpin
+    // initiation tables are loop-initiation ΔG, not this contact increment.
+    set_inc(cfg.dna, ContactKind::DNA_LOOP_HBOND,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+
+    // TODO(burgundy): DNA intercalation ΔH/ΔS. Ligand-specific (e.g. Chaires
+    // reviews); no generic calorimetric consensus for a geometry-weighted
+    // increment. Leave unset — do not invent a mean intercalator.
+    set_inc(cfg.dna, ContactKind::DNA_INTERCALATION,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+
+    // Protein α-helix backbone H-bond: Scholtz 1991 PNAS calorimetric
+    // helix-formation ΔH. doi:10.1073/pnas.88.7.2854
+    // ΔS: experimental gap (helix–coil s is published in Scholtz 1991
+    // Biopolymers doi:10.1002/bip.360311304, but there is no calorimetric
+    // per-residue ΔS consensus independent of ΔCp assumptions).
+    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_BB_HBOND,
+            kScholtz1991HelixFormation_dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+
+    // TODO(burgundy): helix side-chain packing ΔH/ΔS — no calorimetric
+    // per-contact consensus distinct from the backbone H-bond term above.
+    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_PACKING,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+
+    // TODO(burgundy): helix steric clash ΔH/ΔS — no calorimetric consensus.
+    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_CLASH,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+
+    // Protein β-sheet: Maynard, Sharman, Searle, J. Am. Chem. Soc. 120:1996
+    // (1998), doi:10.1021/ja9726769 reports whole 16-residue β-hairpin folding
+    // as endothermic / entropy-driven in water (ΔH ≈ +7 kJ mol⁻¹ for the
+    // *peptide*). That is the wrong scale and often the opposite sign versus a
+    // per-bridge H-bond increment — do not reuse it here.
+    // TODO(burgundy): sheet bridge H-bond ΔH/ΔS (per-bridge calorimetry).
+    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_BRIDGE_HBOND,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+    // TODO(burgundy): sheet hydrophobic packing ΔH/ΔS.
+    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+    // TODO(burgundy): sheet shear / mismatch ΔH/ΔS.
+    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_SHEAR,
+            kExperimentalGapIncrement.dH_kcal,
+            kExperimentalGapIncrement.dS_cal_per_mol_K);
+
     return cfg;
 }
 

--- a/LIB/NATURaL/PoseLocalThermoRewrite.cpp
+++ b/LIB/NATURaL/PoseLocalThermoRewrite.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <utility>
 
 namespace natural {
@@ -93,6 +94,38 @@ ThermoIncrement lookup(const ThermoIncrementTable& table, ContactKind kind) noex
     return table.increments[static_cast<std::size_t>(i)];
 }
 
+ThermoIncrement from_motif(const MotifDeltaHS& m) noexcept
+{
+    return ThermoIncrement{m.dH_kcal, m.dS_cal_per_mol_K};
+}
+
+// Sequence-specific NN / loop terms override the class-table mean when the
+// contact carries a motif or unpaired-loop annotation. Unknown motifs skip.
+std::optional<ThermoIncrement> increment_for_contact(
+    const PoseContact& c,
+    const DecisionElement& el,
+    const PoseThermoRewriteConfig& cfg)
+{
+    ThermoIncrement inc = lookup(table_for_ss(cfg, el.ss), c.kind);
+    if (c.kind == ContactKind::RNA_STEM_STACK) {
+        const auto m = lookup_xia1998_rna(c.motif);
+        if (!m.has_value())
+            return std::nullopt;
+        inc = from_motif(*m);
+    } else if (c.kind == ContactKind::DNA_STEM_STACK) {
+        const auto m = lookup_santalucia1998_dna(c.motif);
+        if (!m.has_value())
+            return std::nullopt;
+        inc = from_motif(*m);
+    } else if (c.kind == ContactKind::RNA_LOOP_HBOND) {
+        const auto m = lookup_lu2006_rna_hairpin(c.loop_unpaired);
+        if (!m.has_value())
+            return std::nullopt;
+        inc = from_motif(*m);
+    }
+    return inc;
+}
+
 void set_inc(ThermoIncrementTable& table, ContactKind kind,
              double dH_kcal, double dS_cal_per_mol_K) noexcept
 {
@@ -159,7 +192,10 @@ bool accumulate_pose(const PoseView& pose,
         const DecisionElement* el = first_matching_element(c, elements);
         if (el == nullptr)
             continue;  // require_decision_element_only: unmatched contacts drop
-        const ThermoIncrement inc = lookup(table_for_ss(cfg, el->ss), c.kind);
+        const std::optional<ThermoIncrement> maybe = increment_for_contact(c, *el, cfg);
+        if (!maybe.has_value())
+            continue;
+        const ThermoIncrement inc = *maybe;
         if (el->ss == SSClass::PROTEIN_OTHER &&
             inc.dH_kcal == 0.0 && inc.dS_cal_per_mol_K == 0.0)
             continue;
@@ -245,25 +281,24 @@ PoseThermoRewriteConfig default_pose_thermo_rewrite_config()
 
     // RNA stem stack: Xia 1998 INN-HB mean of 10 unique WC propagation stacks.
     // doi:10.1021/bi9809425 ; Zuber 2022 NAR Table 1A "1998 Model"
-    // doi:10.1093/nar/gkac261. Sequence-specific NN lookup is future work.
+    // doi:10.1093/nar/gkac261. PoseContact::motif selects a published dimer.
     set_inc(cfg.rna, ContactKind::RNA_STEM_STACK,
             kXia1998RnaWcStackMean_dH_kcal, kXia1998RnaWcStackMean_dS_cal);
 
-    // TODO(burgundy): RNA ligand–loop H-bond ΔH/ΔS. Mathews, Sabina, Zuker,
-    // Turner, J. Mol. Biol. 288:911 (1999), doi:10.1006/jmbi.1999.2700 is
-    // hairpin/internal-loop *initiation* ΔG, not a ligand–loop H-bond increment.
-    // Leave unset until a calorimetric consensus is harvested.
+    // RNA loop: Lu, Turner, Mathews, NAR 34:4912 (2006), doi:10.1093/nar/gkl472
+    // Table 1 hairpin-loop *initiation* ΔH°(n). Default n=4. ΔS is not tabulated
+    // (extra length cost is treated as entropic). This is initiation enthalpy,
+    // not a ligand–loop H-bond increment. PoseContact::loop_unpaired selects n.
     set_inc(cfg.rna, ContactKind::RNA_LOOP_HBOND,
-            kExperimentalGapIncrement.dH_kcal,
-            kExperimentalGapIncrement.dS_cal_per_mol_K);
+            kLu2006DefaultHairpin.dH_kcal, kLu2006DefaultHairpin.dS_cal_per_mol_K);
 
-    // DNA stem stack: SantaLucia & Hicks 2004 Table 1 mean of 10 WC
-    // propagation stacks (1 M NaCl). doi:10.1146/annurev.biophys.32.110601.141800
-    // NEVER a copy of the RNA table — RNA mean ΔH (−10.756) ≠ DNA mean (−8.33).
+    // DNA stem stack: SantaLucia 1998 PNAS Table 2 mean of 10 WC propagation
+    // stacks (1 M NaCl). doi:10.1073/pnas.95.4.1460 (PMC19045).
+    // NEVER a copy of the RNA table. PoseContact::motif selects a Table 2 dimer.
     set_inc(cfg.dna, ContactKind::DNA_STEM_STACK,
-            kSantaLucia2004DnaNnMean_dH_kcal, kSantaLucia2004DnaNnMean_dS_cal);
+            kSantaLucia1998DnaWcStackMean_dH_kcal, kSantaLucia1998DnaWcStackMean_dS_cal);
 
-    // TODO(burgundy): DNA ligand–loop H-bond ΔH/ΔS. SantaLucia 2004 hairpin
+    // TODO(burgundy): DNA ligand–loop H-bond ΔH/ΔS. SantaLucia hairpin
     // initiation tables are loop-initiation ΔG, not this contact increment.
     set_inc(cfg.dna, ContactKind::DNA_LOOP_HBOND,
             kExperimentalGapIncrement.dH_kcal,
@@ -276,14 +311,13 @@ PoseThermoRewriteConfig default_pose_thermo_rewrite_config()
             kExperimentalGapIncrement.dH_kcal,
             kExperimentalGapIncrement.dS_cal_per_mol_K);
 
-    // Protein α-helix backbone H-bond: Scholtz 1991 PNAS calorimetric
-    // helix-formation ΔH. doi:10.1073/pnas.88.7.2854
-    // ΔS: experimental gap (helix–coil s is published in Scholtz 1991
-    // Biopolymers doi:10.1002/bip.360311304, but there is no calorimetric
-    // per-residue ΔS consensus independent of ΔCp assumptions).
+    // Protein α-helix backbone: Scholtz 1991 PNAS calorimetric helix-formation
+    // ΔH (doi:10.1073/pnas.88.7.2854) + Zavrtanik, Lah, Hadži, Biophys. J.
+    // 125:305 (2026) helix→coil ΔS_BB = 5.2 ± 0.3 e.u. → formation −5.2
+    // (doi:10.1016/j.bpj.2025.11.2689, PubMed 41318999).
     set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_BB_HBOND,
             kScholtz1991HelixFormation_dH_kcal,
-            kExperimentalGapIncrement.dS_cal_per_mol_K);
+            kZavrtanik2026HelixFormation_dS_cal);
 
     // TODO(burgundy): helix side-chain packing ΔH/ΔS — no calorimetric
     // per-contact consensus distinct from the backbone H-bond term above.
@@ -296,15 +330,15 @@ PoseThermoRewriteConfig default_pose_thermo_rewrite_config()
             kExperimentalGapIncrement.dH_kcal,
             kExperimentalGapIncrement.dS_cal_per_mol_K);
 
-    // Protein β-sheet: Maynard, Sharman, Searle, J. Am. Chem. Soc. 120:1996
-    // (1998), doi:10.1021/ja9726769 reports whole 16-residue β-hairpin folding
-    // as endothermic / entropy-driven in water (ΔH ≈ +7 kJ mol⁻¹ for the
-    // *peptide*). That is the wrong scale and often the opposite sign versus a
-    // per-bridge H-bond increment — do not reuse it here.
-    // TODO(burgundy): sheet bridge H-bond ΔH/ΔS (per-bridge calorimetry).
+    // Protein β-sheet bridge: labelled experimental midpoint from Meier &
+    // Seelig, J. Am. Chem. Soc. 130:1017 (2008), doi:10.1021/ja077231r
+    // (membrane coil⇄β, ΔH_fold ≈ −0.2 to −0.6 kcal mol⁻¹ residue⁻¹).
+    // Caveat: Deechongkit et al. Nature 430:101 (2004) doi:10.1038/nature02611
+    // — β H-bond energetics are context-dependent. Not a universal NN table.
+    // Maynard 1998 whole-hairpin folding is the wrong scale — do not reuse.
     set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_BRIDGE_HBOND,
-            kExperimentalGapIncrement.dH_kcal,
-            kExperimentalGapIncrement.dS_cal_per_mol_K);
+            kMeierSeelig2008SheetFold_dH_kcal,
+            kMeierSeelig2008SheetFold_dS_cal);
     // TODO(burgundy): sheet hydrophobic packing ΔH/ΔS.
     set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK,
             kExperimentalGapIncrement.dH_kcal,

--- a/LIB/NATURaL/PoseLocalThermoRewrite.cpp
+++ b/LIB/NATURaL/PoseLocalThermoRewrite.cpp
@@ -1,0 +1,368 @@
+// PoseLocalThermoRewrite.cpp — see header for physics, citations, and status.
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#include "PoseLocalThermoRewrite.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+
+namespace natural {
+
+namespace {
+
+bool in_closed_range(int value, int lo, int hi) noexcept
+{
+    if (lo < 0 || hi < 0 || hi < lo) return false;
+    return value >= lo && value <= hi;
+}
+
+bool na_range_set(const DecisionElement& el) noexcept
+{
+    return el.na_start >= 0 && el.na_end >= el.na_start;
+}
+
+bool res_range_set(const DecisionElement& el) noexcept
+{
+    return el.res_start >= 0 && el.res_end >= el.res_start;
+}
+
+bool partner_range_set(const DecisionElement& el) noexcept
+{
+    return el.sheet_partner_start >= 0 &&
+           el.sheet_partner_end >= el.sheet_partner_start;
+}
+
+bool contact_hits_element(const PoseContact& c, const DecisionElement& el) noexcept
+{
+    if (!c.element_label.empty())
+        return c.element_label == el.label;
+
+    switch (el.ss) {
+    case SSClass::RNA_STEM_LOOP:
+    case SSClass::DNA_STEM_LOOP:
+        if (!na_range_set(el))
+            return false;
+        return in_closed_range(c.nt_index, el.na_start, el.na_end);
+    case SSClass::PROTEIN_HELIX:
+    case SSClass::PROTEIN_OTHER:
+        if (!res_range_set(el))
+            return false;
+        return in_closed_range(c.res_index, el.res_start, el.res_end);
+    case SSClass::PROTEIN_SHEET: {
+        if (!res_range_set(el))
+            return false;
+        const bool on_primary = in_closed_range(c.res_index, el.res_start, el.res_end);
+        const bool on_partner_as_primary =
+            partner_range_set(el) &&
+            in_closed_range(c.res_index, el.sheet_partner_start, el.sheet_partner_end);
+        if (!on_primary && !on_partner_as_primary)
+            return false;
+        if (!partner_range_set(el))
+            return true;
+        const bool partner_ok =
+            in_closed_range(c.partner_res_index, el.sheet_partner_start, el.sheet_partner_end) ||
+            in_closed_range(c.partner_res_index, el.res_start, el.res_end) ||
+            c.partner_res_index < 0;
+        return partner_ok;
+    }
+    }
+    return false;
+}
+
+const DecisionElement* first_matching_element(
+    const PoseContact& c,
+    const std::vector<DecisionElement>& elements) noexcept
+{
+    const SSClass need = ss_class_for_kind(c.kind);
+    for (const DecisionElement& el : elements) {
+        if (el.ss != need)
+            continue;
+        if (contact_hits_element(c, el))
+            return &el;
+    }
+    return nullptr;
+}
+
+ThermoIncrement lookup(const ThermoIncrementTable& table, ContactKind kind) noexcept
+{
+    const int i = static_cast<int>(kind);
+    if (i < 0 || i >= kContactKindCount)
+        return {};
+    return table.increments[static_cast<std::size_t>(i)];
+}
+
+void set_inc(ThermoIncrementTable& table, ContactKind kind,
+             double dH_kcal, double dS_cal_per_mol_K) noexcept
+{
+    const int i = static_cast<int>(kind);
+    if (i < 0 || i >= kContactKindCount)
+        return;
+    table.increments[static_cast<std::size_t>(i)] = ThermoIncrement{dH_kcal, dS_cal_per_mol_K};
+}
+
+double log_sum_exp(const std::vector<double>& values) noexcept
+{
+    if (values.empty())
+        return -std::numeric_limits<double>::infinity();
+    double xmax = values[0];
+    for (std::size_t i = 1; i < values.size(); ++i)
+        if (values[i] > xmax) xmax = values[i];
+    if (!std::isfinite(xmax))
+        return xmax;
+    double sum = 0.0;
+    for (double v : values)
+        sum += std::exp(v - xmax);
+    if (!(sum > 0.0) || !std::isfinite(sum))
+        return xmax;
+    return xmax + std::log(sum);
+}
+
+struct PoseAccum {
+    std::size_t original_index = 0;
+    double score_kcal = 0.0;
+    double dH_kcal = 0.0;
+    double dS_cal_per_mol_K = 0.0;
+    double dG_kcal = 0.0;
+    std::vector<LocalThermoPatch> per_element;
+};
+
+LocalThermoPatch& patch_for(std::vector<LocalThermoPatch>& patches,
+                            const DecisionElement& el)
+{
+    for (LocalThermoPatch& p : patches) {
+        if (p.label == el.label && p.ss == el.ss)
+            return p;
+    }
+    LocalThermoPatch created;
+    created.label = el.label;
+    created.ss = el.ss;
+    patches.push_back(created);
+    return patches.back();
+}
+
+bool accumulate_pose(const PoseView& pose,
+                     const std::vector<DecisionElement>& elements,
+                     const PoseThermoRewriteConfig& cfg,
+                     PoseAccum& out)
+{
+    out.score_kcal = pose.score_kcal;
+    out.dH_kcal = 0.0;
+    out.dS_cal_per_mol_K = 0.0;
+    out.per_element.clear();
+
+    bool any = false;
+    for (const PoseContact& c : pose.contacts) {
+        if (!std::isfinite(c.geometry_weight))
+            continue;
+        const DecisionElement* el = first_matching_element(c, elements);
+        if (el == nullptr)
+            continue;  // require_decision_element_only: unmatched contacts drop
+        const ThermoIncrement inc = lookup(table_for_ss(cfg, el->ss), c.kind);
+        if (el->ss == SSClass::PROTEIN_OTHER &&
+            inc.dH_kcal == 0.0 && inc.dS_cal_per_mol_K == 0.0)
+            continue;
+        const double w = c.geometry_weight;
+        const double dH = inc.dH_kcal * w;
+        const double dS = inc.dS_cal_per_mol_K * w;
+        if (!std::isfinite(dH) || !std::isfinite(dS))
+            continue;
+        LocalThermoPatch& patch = patch_for(out.per_element, *el);
+        patch.dH_kcal += dH;
+        patch.dS_cal_per_mol_K += dS;
+        out.dH_kcal += dH;
+        out.dS_cal_per_mol_K += dS;
+        any = true;
+    }
+    out.dG_kcal = delta_G_kcal(out.dH_kcal, out.dS_cal_per_mol_K, cfg.temperature_K);
+    for (LocalThermoPatch& p : out.per_element)
+        p.dG_kcal = delta_G_kcal(p.dH_kcal, p.dS_cal_per_mol_K, cfg.temperature_K);
+    return any && std::isfinite(out.dG_kcal) && std::isfinite(out.dH_kcal) &&
+           std::isfinite(out.dS_cal_per_mol_K);
+}
+
+} // namespace
+
+const char* ss_class_name(SSClass ss) noexcept
+{
+    switch (ss) {
+    case SSClass::RNA_STEM_LOOP:  return "RNA_STEM_LOOP";
+    case SSClass::DNA_STEM_LOOP:  return "DNA_STEM_LOOP";
+    case SSClass::PROTEIN_HELIX:  return "PROTEIN_HELIX";
+    case SSClass::PROTEIN_SHEET:  return "PROTEIN_SHEET";
+    case SSClass::PROTEIN_OTHER:  return "PROTEIN_OTHER";
+    }
+    return "UNKNOWN";
+}
+
+const char* contact_kind_name(ContactKind kind) noexcept
+{
+    switch (kind) {
+    case ContactKind::RNA_STEM_STACK:                 return "RNA_STEM_STACK";
+    case ContactKind::RNA_LOOP_HBOND:                 return "RNA_LOOP_HBOND";
+    case ContactKind::DNA_STEM_STACK:                 return "DNA_STEM_STACK";
+    case ContactKind::DNA_LOOP_HBOND:                 return "DNA_LOOP_HBOND";
+    case ContactKind::DNA_INTERCALATION:              return "DNA_INTERCALATION";
+    case ContactKind::PROTEIN_HELIX_BB_HBOND:         return "PROTEIN_HELIX_BB_HBOND";
+    case ContactKind::PROTEIN_HELIX_PACKING:          return "PROTEIN_HELIX_PACKING";
+    case ContactKind::PROTEIN_HELIX_CLASH:            return "PROTEIN_HELIX_CLASH";
+    case ContactKind::PROTEIN_SHEET_BRIDGE_HBOND:     return "PROTEIN_SHEET_BRIDGE_HBOND";
+    case ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK: return "PROTEIN_SHEET_HYDROPHOBIC_PACK";
+    case ContactKind::PROTEIN_SHEET_SHEAR:            return "PROTEIN_SHEET_SHEAR";
+    case ContactKind::COUNT:                          return "COUNT";
+    }
+    return "UNKNOWN";
+}
+
+SSClass ss_class_for_kind(ContactKind kind) noexcept
+{
+    switch (kind) {
+    case ContactKind::RNA_STEM_STACK:
+    case ContactKind::RNA_LOOP_HBOND:
+        return SSClass::RNA_STEM_LOOP;
+    case ContactKind::DNA_STEM_STACK:
+    case ContactKind::DNA_LOOP_HBOND:
+    case ContactKind::DNA_INTERCALATION:
+        return SSClass::DNA_STEM_LOOP;
+    case ContactKind::PROTEIN_HELIX_BB_HBOND:
+    case ContactKind::PROTEIN_HELIX_PACKING:
+    case ContactKind::PROTEIN_HELIX_CLASH:
+        return SSClass::PROTEIN_HELIX;
+    case ContactKind::PROTEIN_SHEET_BRIDGE_HBOND:
+    case ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK:
+    case ContactKind::PROTEIN_SHEET_SHEAR:
+        return SSClass::PROTEIN_SHEET;
+    case ContactKind::COUNT:
+        break;
+    }
+    return SSClass::PROTEIN_OTHER;
+}
+
+PoseThermoRewriteConfig default_pose_thermo_rewrite_config()
+{
+    PoseThermoRewriteConfig cfg;
+    // Draft experimental increments (tunable; not claim-ready).
+    // RNA (Turner-shaped): stem stack ΔH = −1.2 w; loop H-bond ΔS = −3.0 w
+    set_inc(cfg.rna, ContactKind::RNA_STEM_STACK, -1.2, 0.0);
+    set_inc(cfg.rna, ContactKind::RNA_LOOP_HBOND, 0.0, -3.0);
+    // DNA (SantaLucia-shaped): NEVER a copy of the RNA table.
+    set_inc(cfg.dna, ContactKind::DNA_STEM_STACK, -1.0, 0.0);
+    set_inc(cfg.dna, ContactKind::DNA_LOOP_HBOND, 0.0, -2.5);
+    set_inc(cfg.dna, ContactKind::DNA_INTERCALATION, -1.5, -1.0);
+    // Protein α-helix
+    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_BB_HBOND, -1.5, -1.0);
+    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_PACKING, -0.8, -2.0);
+    set_inc(cfg.protein_helix, ContactKind::PROTEIN_HELIX_CLASH, 2.0, 0.0);
+    // Protein β-sheet
+    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_BRIDGE_HBOND, -1.8, -1.5);
+    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK, -1.0, -2.5);
+    set_inc(cfg.protein_sheet, ContactKind::PROTEIN_SHEET_SHEAR, 2.5, 1.0);
+    return cfg;
+}
+
+const ThermoIncrementTable& table_for_ss(const PoseThermoRewriteConfig& cfg,
+                                         SSClass ss) noexcept
+{
+    switch (ss) {
+    case SSClass::RNA_STEM_LOOP: return cfg.rna;
+    case SSClass::DNA_STEM_LOOP: return cfg.dna;
+    case SSClass::PROTEIN_HELIX: return cfg.protein_helix;
+    case SSClass::PROTEIN_SHEET: return cfg.protein_sheet;
+    case SSClass::PROTEIN_OTHER: return cfg.protein_other;
+    }
+    return cfg.protein_other;
+}
+
+LocalThermoMixture rewrite_local_thermo_from_poses(
+    const std::vector<PoseView>&        poses,
+    const std::vector<DecisionElement>& elements,
+    const PoseThermoRewriteConfig&      cfg)
+{
+    LocalThermoMixture mix;
+    if (poses.empty() || !std::isfinite(cfg.temperature_K) || cfg.temperature_K <= 0.0)
+        return mix;
+    if (cfg.require_decision_element_only && elements.empty())
+        return mix;
+
+    std::vector<PoseAccum> scored;
+    scored.reserve(poses.size());
+    for (std::size_t i = 0; i < poses.size(); ++i) {
+        if (!std::isfinite(poses[i].score_kcal))
+            continue;
+        PoseAccum acc;
+        acc.original_index = i;
+        if (!accumulate_pose(poses[i], elements, cfg, acc))
+            continue;
+        scored.push_back(std::move(acc));
+    }
+    if (scored.empty())
+        return mix;
+
+    std::stable_sort(scored.begin(), scored.end(),
+                     [](const PoseAccum& a, const PoseAccum& b) {
+                         if (a.score_kcal != b.score_kcal)
+                             return a.score_kcal < b.score_kcal;
+                         return a.original_index < b.original_index;
+                     });
+    const int k = (cfg.top_k <= 0) ? static_cast<int>(scored.size())
+                                   : std::min(cfg.top_k, static_cast<int>(scored.size()));
+    scored.resize(static_cast<std::size_t>(k));
+
+    const double kT = kPoseRewrite_kB_kcal_mol_K * cfg.temperature_K;
+    std::vector<double> log_w;
+    log_w.reserve(scored.size());
+    if (!(kT > 0.0) || !std::isfinite(kT)) {
+        for (std::size_t i = 0; i < scored.size(); ++i)
+            log_w.push_back(0.0);
+    } else {
+        for (const PoseAccum& acc : scored)
+            log_w.push_back(-acc.dG_kcal / kT);
+    }
+    const double lnZ = log_sum_exp(log_w);
+    mix.pose_weights.resize(scored.size(), 0.0);
+    if (!std::isfinite(lnZ))
+        return mix;
+
+    for (std::size_t i = 0; i < scored.size(); ++i) {
+        const double p = std::exp(log_w[i] - lnZ);
+        mix.pose_weights[i] = std::isfinite(p) ? p : 0.0;
+    }
+
+    mix.n_poses_used = static_cast<int>(scored.size());
+    std::vector<LocalThermoPatch> mixed_elements;
+    for (std::size_t i = 0; i < scored.size(); ++i) {
+        const double p = mix.pose_weights[i];
+        mix.dH_kcal += p * scored[i].dH_kcal;
+        mix.dS_cal_per_mol_K += p * scored[i].dS_cal_per_mol_K;
+        for (const LocalThermoPatch& patch : scored[i].per_element) {
+            LocalThermoPatch* dest = nullptr;
+            for (LocalThermoPatch& m : mixed_elements) {
+                if (m.label == patch.label && m.ss == patch.ss) {
+                    dest = &m;
+                    break;
+                }
+            }
+            if (dest == nullptr) {
+                LocalThermoPatch created;
+                created.label = patch.label;
+                created.ss = patch.ss;
+                mixed_elements.push_back(created);
+                dest = &mixed_elements.back();
+            }
+            dest->dH_kcal += p * patch.dH_kcal;
+            dest->dS_cal_per_mol_K += p * patch.dS_cal_per_mol_K;
+        }
+    }
+    mix.dG_kcal = delta_G_kcal(mix.dH_kcal, mix.dS_cal_per_mol_K, cfg.temperature_K);
+    for (LocalThermoPatch& p : mixed_elements)
+        p.dG_kcal = delta_G_kcal(p.dH_kcal, p.dS_cal_per_mol_K, cfg.temperature_K);
+    mix.per_element = std::move(mixed_elements);
+
+    if (!std::isfinite(mix.dH_kcal)) mix.dH_kcal = 0.0;
+    if (!std::isfinite(mix.dS_cal_per_mol_K)) mix.dS_cal_per_mol_K = 0.0;
+    if (!std::isfinite(mix.dG_kcal)) mix.dG_kcal = 0.0;
+    return mix;
+}
+
+} // namespace natural

--- a/LIB/NATURaL/PoseLocalThermoRewrite.h
+++ b/LIB/NATURaL/PoseLocalThermoRewrite.h
@@ -6,16 +6,18 @@
 //
 // Class-specific increment tables are never shared:
 //   RNA hairpin  ≠  DNA duplex/hairpin  ≠  protein α-helix  ≠  protein β-sheet.
-// RNA uses Turner-shaped defaults; DNA uses SantaLucia-shaped defaults.
+// Filled defaults are peer-reviewed NN / helix–coil means (Xia 1998 RNA,
+// SantaLucia 2004 DNA, Scholtz 1991 helix ΔH). Motifs without a calorimetric
+// consensus stay {0,0} experimental gaps — never invent numbers, never alias
+// RNA Turner parameters onto DNA or protein.
 //
 // This is thermodynamic rewrite glue. It is NOT k_fold / Arrhenius coupling
 // in RibosomeElongation (that remains a later, optional PR).
 //
-// Status: EXPERIMENTAL, default OFF, not claim-ready. Draft increments are
-// tunable placeholders. Do not feed Astex / FlexADS claim contracts. Do not
-// silently mutate validated StatMech thermo. Optional DualAssembly hook stores
-// a diagnostic mixture only; G_natural stays unset unless a labelled caller
-// later opts in (not this PR).
+// Status: EXPERIMENTAL, default OFF, not claim-ready. Do not feed Astex /
+// FlexADS claim contracts. Do not silently mutate validated StatMech thermo.
+// Optional DualAssembly hook stores a diagnostic mixture only; G_natural stays
+// unset unless a labelled caller later opts in (not this PR).
 //
 // Lineage:
 //   NATURAL = Native Assembly of Transcriptionally / Translationally Unified
@@ -45,10 +47,10 @@ namespace natural {
 
 // ─── polymer / secondary-structure class ─────────────────────────────────────
 enum class SSClass {
-    RNA_STEM_LOOP,   // Turner-shaped defaults
-    DNA_STEM_LOOP,   // SantaLucia-shaped defaults — NEVER alias the RNA table
-    PROTEIN_HELIX,
-    PROTEIN_SHEET,
+    RNA_STEM_LOOP,   // Xia 1998 INN-HB WC-stack mean; loop H-bond is an experimental gap
+    DNA_STEM_LOOP,   // SantaLucia 2004 NN-stack mean — NEVER alias the RNA table
+    PROTEIN_HELIX,   // Scholtz 1991 calorimetric helix-formation ΔH; packing/clash gaps
+    PROTEIN_SHEET,   // all contact kinds experimental gaps until a per-bridge consensus
     PROTEIN_OTHER    // default: no rewrite unless annotated with a filled table
 };
 
@@ -81,8 +83,79 @@ struct ThermoIncrement {
     double dS_cal_per_mol_K = 0.0;   // cal mol⁻¹ K⁻¹ per unit geometry weight
 };
 
+// Unset slot: motifs without a calorimetric / NN consensus. Burgundy harvest
+// fills these; do not invent placeholder ΔH/ΔS.
+inline constexpr ThermoIncrement kExperimentalGapIncrement{0.0, 0.0};
+
+template <std::size_t N>
+inline constexpr double pose_local_mean(const std::array<double, N>& values) noexcept
+{
+    double sum = 0.0;
+    for (double v : values)
+        sum += v;
+    return sum / static_cast<double>(N);
+}
+
+// Xia, SantaLucia, Turner et al., Biochemistry 37:14719 (1998), doi:10.1021/bi9809425
+// INN-HB unique Watson–Crick *propagation* stacks (exclude initiation, AU-end,
+// symmetry). Values restated as “1998 Model” in Zuber et al., Nucleic Acids Res.
+// 50:5251 (2022) Table 1A, doi:10.1093/nar/gkac261 (PMC9122537).
+// Order: GC/CG, CC/GG, GA/CU, CG/GC, AC/UG, CA/GU, AG/UC, UA/AU, AU/UA, AA/UU.
+// Sequence-specific NN lookup is future work; the default is this unweighted mean.
+inline constexpr double kXia1998T37_K = 310.15;
+inline constexpr std::array<double, 10> kXia1998RnaWcStack_dH_kcal{
+    -14.88, -13.39, -12.44, -10.64, -11.40,
+    -10.44, -10.48,  -7.69,  -9.38,  -6.82};
+inline constexpr std::array<double, 10> kXia1998RnaWcStack_dG37_kcal{
+    -3.42, -3.26, -2.35, -2.36, -2.08,
+    -2.11, -2.08, -1.33, -1.10, -0.93};
+
+inline constexpr double kXia1998RnaWcStackMean_dH_kcal =
+    pose_local_mean(kXia1998RnaWcStack_dH_kcal);
+
+inline constexpr double xia1998_rna_wc_stack_mean_dS_cal() noexcept
+{
+    double sum = 0.0;
+    for (std::size_t i = 0; i < kXia1998RnaWcStack_dH_kcal.size(); ++i) {
+        sum += (kXia1998RnaWcStack_dH_kcal[i] - kXia1998RnaWcStack_dG37_kcal[i]) /
+               kXia1998T37_K * kCalPerKcal;
+    }
+    return sum / static_cast<double>(kXia1998RnaWcStack_dH_kcal.size());
+}
+
+inline constexpr double kXia1998RnaWcStackMean_dS_cal =
+    xia1998_rna_wc_stack_mean_dS_cal();
+
+// SantaLucia & Hicks, Annu. Rev. Biophys. Biomol. Struct. 33:415 (2004)
+// doi:10.1146/annurev.biophys.32.110601.141800 — Table 1, 1 M NaCl,
+// 10 WC propagation stacks (exclude Initiation, Terminal AT, Symmetry).
+// Order: AA/TT, AT/TA, TA/AT, CA/GT, GT/CA, CT/GA, GA/CT, CG/GC, GC/CG, GG/CC.
+inline constexpr std::array<double, 10> kSantaLucia2004DnaNn_dH_kcal{
+    -7.6, -7.2, -7.2, -8.5, -8.4, -7.8, -8.2, -10.6, -9.8, -8.0};
+inline constexpr std::array<double, 10> kSantaLucia2004DnaNn_dS_cal{
+    -21.3, -20.4, -21.3, -22.7, -22.4, -21.0, -22.2, -27.2, -24.4, -19.9};
+
+inline constexpr double kSantaLucia2004DnaNnMean_dH_kcal =
+    pose_local_mean(kSantaLucia2004DnaNn_dH_kcal);
+inline constexpr double kSantaLucia2004DnaNnMean_dS_cal =
+    pose_local_mean(kSantaLucia2004DnaNn_dS_cal);
+
+// Scholtz, Marqusee, Baldwin et al., PNAS 88:2854 (1991), doi:10.1073/pnas.88.7.2854
+// Calorimetric helix *unfolding* ΔH ≈ +1.3 kcal mol⁻¹ residue⁻¹ (best estimate;
+// lower limit 0.9 if ΔCp = 0). Formation increment used here is the negative:
+// ΔH = −1.3 kcal mol⁻¹ residue⁻¹. Companion helix–coil CD fit: Scholtz, Qian,
+// Baldwin, Biopolymers 31:1463 (1991), doi:10.1002/bip.360311304 (ΔH° ≈ −0.955
+// kcal mol⁻¹ residue⁻¹). Prefer the calorimetric ΔH; per-residue ΔS is left as
+// an experimental gap (do not invent ΔS from s without a published consensus).
+inline constexpr double kScholtz1991HelixFormation_dH_kcal = -1.3;
+
+static_assert(kXia1998RnaWcStackMean_dH_kcal != kSantaLucia2004DnaNnMean_dH_kcal,
+              "RNA Xia 1998 WC-stack mean must not equal DNA SantaLucia 2004 mean");
+static_assert(kScholtz1991HelixFormation_dH_kcal < 0.0,
+              "helix formation ΔH is exothermic (Scholtz 1991 calorimetry)");
+
 // Dense per-kind table. Unused slots stay {0,0} so a DNA kind looked up in an
-// RNA table cannot leak Turner increments.
+// RNA table cannot leak Xia/Turner increments.
 struct ThermoIncrementTable {
     std::array<ThermoIncrement, kContactKindCount> increments{};
 };
@@ -103,7 +176,7 @@ struct DecisionElement {
 
 struct PoseContact {
     ContactKind kind = ContactKind::RNA_STEM_STACK;
-    double      geometry_weight = 1.0;  // w in the draft increment tables
+    double      geometry_weight = 1.0;  // w in ΔH += coeff_H · w, ΔS += coeff_S · w
     int         nt_index = -1;          // RNA/DNA
     int         res_index = -1;         // protein
     int         partner_res_index = -1; // sheet partner (optional)
@@ -120,7 +193,7 @@ struct PoseThermoRewriteConfig {
     ThermoIncrementTable dna;
     ThermoIncrementTable protein_helix;
     ThermoIncrementTable protein_sheet;
-    ThermoIncrementTable protein_other;  // empty in the draft defaults
+    ThermoIncrementTable protein_other;  // remains empty (experimental / unused)
     double temperature_K = 298.15;
     int    top_k = 10;
     bool   require_decision_element_only = true;

--- a/LIB/NATURaL/PoseLocalThermoRewrite.h
+++ b/LIB/NATURaL/PoseLocalThermoRewrite.h
@@ -1,0 +1,168 @@
+// PoseLocalThermoRewrite.h — experimental docking-pose rewrite of local SS ΔH/ΔS
+//
+// Physics (same algebra for every polymer class):
+//   docking poses rewrite *local* secondary-structure ΔH and ΔS on annotated
+//   decision elements; ΔG = ΔH − TΔS; mixture over top-k poses.
+//
+// Class-specific increment tables are never shared:
+//   RNA hairpin  ≠  DNA duplex/hairpin  ≠  protein α-helix  ≠  protein β-sheet.
+// RNA uses Turner-shaped defaults; DNA uses SantaLucia-shaped defaults.
+//
+// This is thermodynamic rewrite glue. It is NOT k_fold / Arrhenius coupling
+// in RibosomeElongation (that remains a later, optional PR).
+//
+// Status: EXPERIMENTAL, default OFF, not claim-ready. Draft increments are
+// tunable placeholders. Do not feed Astex / FlexADS claim contracts. Do not
+// silently mutate validated StatMech thermo. Optional DualAssembly hook stores
+// a diagnostic mixture only; G_natural stays unset unless a labelled caller
+// later opts in (not this PR).
+//
+// Lineage:
+//   NATURAL = Native Assembly of Transcriptionally / Translationally Unified
+//             Receptor and Ligand.
+//   Transcriptional → RNA/DNA + ligand (Zhao–Zhang–Chen J. Chem. Phys. 135,
+//     245101 (2011), doi:10.1063/1.3671644).
+//   Translational → protein + ligand (Zhao et al. J. Phys. Chem. B 2011, 115,
+//     3987 — ribosome/protein master equation only).
+//   2014-07-25 LP Morency R2 Perl NATURAL: clustering, population inheritance,
+//     pause at nt repeats, docking poses rewrite helix ΔH/ΔS.
+//   2026 DualAssembly (LIB/NATURaL/) is the broader C++ home.
+//
+// Units (Turner / SantaLucia nearest-neighbour convention):
+//   ΔH  kcal mol⁻¹
+//   ΔS  cal mol⁻¹ K⁻¹  (entropy units)
+//   ΔG  kcal mol⁻¹     = ΔH − T·(ΔS / 1000)
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace natural {
+
+// ─── polymer / secondary-structure class ─────────────────────────────────────
+enum class SSClass {
+    RNA_STEM_LOOP,   // Turner-shaped defaults
+    DNA_STEM_LOOP,   // SantaLucia-shaped defaults — NEVER alias the RNA table
+    PROTEIN_HELIX,
+    PROTEIN_SHEET,
+    PROTEIN_OTHER    // default: no rewrite unless annotated with a filled table
+};
+
+// Contact kinds that a pose may contribute. Each kind is legal for exactly one
+// SSClass; RNA kinds never read the DNA or protein tables.
+enum class ContactKind {
+    RNA_STEM_STACK = 0,
+    RNA_LOOP_HBOND,
+    DNA_STEM_STACK,
+    DNA_LOOP_HBOND,
+    DNA_INTERCALATION,
+    PROTEIN_HELIX_BB_HBOND,
+    PROTEIN_HELIX_PACKING,
+    PROTEIN_HELIX_CLASH,
+    PROTEIN_SHEET_BRIDGE_HBOND,
+    PROTEIN_SHEET_HYDROPHOBIC_PACK,
+    PROTEIN_SHEET_SHEAR,
+    COUNT
+};
+
+inline constexpr int kContactKindCount = static_cast<int>(ContactKind::COUNT);
+
+// Matches statmech::kB_kcal. Duplicated so this module has no GA / StatMech
+// / hardware-dispatch dependency.
+inline constexpr double kPoseRewrite_kB_kcal_mol_K = 0.001987206;
+inline constexpr double kCalPerKcal = 1000.0;
+
+struct ThermoIncrement {
+    double dH_kcal = 0.0;            // kcal mol⁻¹ per unit geometry weight
+    double dS_cal_per_mol_K = 0.0;   // cal mol⁻¹ K⁻¹ per unit geometry weight
+};
+
+// Dense per-kind table. Unused slots stay {0,0} so a DNA kind looked up in an
+// RNA table cannot leak Turner increments.
+struct ThermoIncrementTable {
+    std::array<ThermoIncrement, kContactKindCount> increments{};
+};
+
+struct DecisionElement {
+    SSClass     ss = SSClass::PROTEIN_OTHER;
+    std::string label;
+    // RNA/DNA stem-loop: inclusive 0-based nucleotide index range.
+    int na_start = -1;
+    int na_end   = -1;
+    // Protein: inclusive 0-based residue range of the annotated helix/sheet.
+    int res_start = -1;
+    int res_end   = -1;
+    // Optional β-sheet partner strand (inclusive). -1/-1 → partner not required.
+    int sheet_partner_start = -1;
+    int sheet_partner_end   = -1;
+};
+
+struct PoseContact {
+    ContactKind kind = ContactKind::RNA_STEM_STACK;
+    double      geometry_weight = 1.0;  // w in the draft increment tables
+    int         nt_index = -1;          // RNA/DNA
+    int         res_index = -1;         // protein
+    int         partner_res_index = -1; // sheet partner (optional)
+    std::string element_label;          // if non-empty, prefer this labelled element
+};
+
+struct PoseView {
+    double score_kcal = 0.0;  // CF/proxy; used only to pick top-k (lower is better)
+    std::vector<PoseContact> contacts;
+};
+
+struct PoseThermoRewriteConfig {
+    ThermoIncrementTable rna;
+    ThermoIncrementTable dna;
+    ThermoIncrementTable protein_helix;
+    ThermoIncrementTable protein_sheet;
+    ThermoIncrementTable protein_other;  // empty in the draft defaults
+    double temperature_K = 298.15;
+    int    top_k = 10;
+    bool   require_decision_element_only = true;
+};
+
+struct LocalThermoPatch {
+    std::string label;
+    SSClass     ss = SSClass::PROTEIN_OTHER;
+    double      dH_kcal = 0.0;
+    double      dS_cal_per_mol_K = 0.0;
+    double      dG_kcal = 0.0;
+};
+
+struct LocalThermoMixture {
+    double dH_kcal = 0.0;
+    double dS_cal_per_mol_K = 0.0;
+    double dG_kcal = 0.0;
+    int    n_poses_used = 0;
+    std::vector<double>           pose_weights;  // Boltzmann p_i for used poses
+    std::vector<LocalThermoPatch> per_element;
+    bool empty() const noexcept { return n_poses_used == 0 && per_element.empty(); }
+};
+
+const char* ss_class_name(SSClass ss) noexcept;
+const char* contact_kind_name(ContactKind kind) noexcept;
+SSClass     ss_class_for_kind(ContactKind kind) noexcept;
+
+inline double delta_G_kcal(double dH_kcal, double dS_cal_per_mol_K, double T_K) noexcept
+{
+    return dH_kcal - T_K * (dS_cal_per_mol_K / kCalPerKcal);
+}
+
+PoseThermoRewriteConfig default_pose_thermo_rewrite_config();
+
+const ThermoIncrementTable& table_for_ss(const PoseThermoRewriteConfig& cfg,
+                                         SSClass ss) noexcept;
+
+// Pure function: rewrite local SS ΔH/ΔS from labelled pose contacts.
+// Returns an empty mixture (finite zeros) when nothing matches.
+LocalThermoMixture rewrite_local_thermo_from_poses(
+    const std::vector<PoseView>&         poses,
+    const std::vector<DecisionElement>&  elements,
+    const PoseThermoRewriteConfig&       cfg);
+
+} // namespace natural

--- a/LIB/NATURaL/PoseLocalThermoRewrite.h
+++ b/LIB/NATURaL/PoseLocalThermoRewrite.h
@@ -6,10 +6,14 @@
 //
 // Class-specific increment tables are never shared:
 //   RNA hairpin  ≠  DNA duplex/hairpin  ≠  protein α-helix  ≠  protein β-sheet.
-// Filled defaults are peer-reviewed NN / helix–coil means (Xia 1998 RNA,
-// SantaLucia 2004 DNA, Scholtz 1991 helix ΔH). Motifs without a calorimetric
-// consensus stay {0,0} experimental gaps — never invent numbers, never alias
-// RNA Turner parameters onto DNA or protein.
+// Filled defaults are peer-reviewed NN / helix–coil values (see NnMotifTables.h):
+//   Xia 1998 RNA WC stacks, Lu 2006 RNA hairpin ΔH°, SantaLucia 1998 PNAS Table 2
+//   DNA, Scholtz 1991 helix ΔH, Zavrtanik 2026 helix ΔS. Sheet uses a labelled
+//   experimental Meier–Seelig 2008 midpoint. Remaining motifs stay {0,0}.
+// Ligand pose weight w scales the matched published stack or loop term.
+//
+// PoseHelixThermoRewrite remains the RNA decision-helix sidecar from PR #471
+// (atom-coord geometry). This module is the class-table generalization.
 //
 // This is thermodynamic rewrite glue. It is NOT k_fold / Arrhenius coupling
 // in RibosomeElongation (that remains a later, optional PR).
@@ -38,6 +42,8 @@
 // Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "NnMotifTables.h"
+
 #include <array>
 #include <cstddef>
 #include <string>
@@ -47,10 +53,10 @@ namespace natural {
 
 // ─── polymer / secondary-structure class ─────────────────────────────────────
 enum class SSClass {
-    RNA_STEM_LOOP,   // Xia 1998 INN-HB WC-stack mean; loop H-bond is an experimental gap
-    DNA_STEM_LOOP,   // SantaLucia 2004 NN-stack mean — NEVER alias the RNA table
-    PROTEIN_HELIX,   // Scholtz 1991 calorimetric helix-formation ΔH; packing/clash gaps
-    PROTEIN_SHEET,   // all contact kinds experimental gaps until a per-bridge consensus
+    RNA_STEM_LOOP,   // Xia 1998 stacks + Lu 2006 hairpin ΔH°; never DNA Table 2
+    DNA_STEM_LOOP,   // SantaLucia 1998 PNAS Table 2 — NEVER alias the RNA table
+    PROTEIN_HELIX,   // Scholtz 1991 ΔH + Zavrtanik 2026 backbone ΔS
+    PROTEIN_SHEET,   // Meier–Seelig 2008 experimental midpoint (bridge only)
     PROTEIN_OTHER    // default: no rewrite unless annotated with a filled table
 };
 
@@ -83,76 +89,8 @@ struct ThermoIncrement {
     double dS_cal_per_mol_K = 0.0;   // cal mol⁻¹ K⁻¹ per unit geometry weight
 };
 
-// Unset slot: motifs without a calorimetric / NN consensus. Burgundy harvest
-// fills these; do not invent placeholder ΔH/ΔS.
+// Unset slot: motifs without a calorimetric / NN consensus.
 inline constexpr ThermoIncrement kExperimentalGapIncrement{0.0, 0.0};
-
-template <std::size_t N>
-inline constexpr double pose_local_mean(const std::array<double, N>& values) noexcept
-{
-    double sum = 0.0;
-    for (double v : values)
-        sum += v;
-    return sum / static_cast<double>(N);
-}
-
-// Xia, SantaLucia, Turner et al., Biochemistry 37:14719 (1998), doi:10.1021/bi9809425
-// INN-HB unique Watson–Crick *propagation* stacks (exclude initiation, AU-end,
-// symmetry). Values restated as “1998 Model” in Zuber et al., Nucleic Acids Res.
-// 50:5251 (2022) Table 1A, doi:10.1093/nar/gkac261 (PMC9122537).
-// Order: GC/CG, CC/GG, GA/CU, CG/GC, AC/UG, CA/GU, AG/UC, UA/AU, AU/UA, AA/UU.
-// Sequence-specific NN lookup is future work; the default is this unweighted mean.
-inline constexpr double kXia1998T37_K = 310.15;
-inline constexpr std::array<double, 10> kXia1998RnaWcStack_dH_kcal{
-    -14.88, -13.39, -12.44, -10.64, -11.40,
-    -10.44, -10.48,  -7.69,  -9.38,  -6.82};
-inline constexpr std::array<double, 10> kXia1998RnaWcStack_dG37_kcal{
-    -3.42, -3.26, -2.35, -2.36, -2.08,
-    -2.11, -2.08, -1.33, -1.10, -0.93};
-
-inline constexpr double kXia1998RnaWcStackMean_dH_kcal =
-    pose_local_mean(kXia1998RnaWcStack_dH_kcal);
-
-inline constexpr double xia1998_rna_wc_stack_mean_dS_cal() noexcept
-{
-    double sum = 0.0;
-    for (std::size_t i = 0; i < kXia1998RnaWcStack_dH_kcal.size(); ++i) {
-        sum += (kXia1998RnaWcStack_dH_kcal[i] - kXia1998RnaWcStack_dG37_kcal[i]) /
-               kXia1998T37_K * kCalPerKcal;
-    }
-    return sum / static_cast<double>(kXia1998RnaWcStack_dH_kcal.size());
-}
-
-inline constexpr double kXia1998RnaWcStackMean_dS_cal =
-    xia1998_rna_wc_stack_mean_dS_cal();
-
-// SantaLucia & Hicks, Annu. Rev. Biophys. Biomol. Struct. 33:415 (2004)
-// doi:10.1146/annurev.biophys.32.110601.141800 — Table 1, 1 M NaCl,
-// 10 WC propagation stacks (exclude Initiation, Terminal AT, Symmetry).
-// Order: AA/TT, AT/TA, TA/AT, CA/GT, GT/CA, CT/GA, GA/CT, CG/GC, GC/CG, GG/CC.
-inline constexpr std::array<double, 10> kSantaLucia2004DnaNn_dH_kcal{
-    -7.6, -7.2, -7.2, -8.5, -8.4, -7.8, -8.2, -10.6, -9.8, -8.0};
-inline constexpr std::array<double, 10> kSantaLucia2004DnaNn_dS_cal{
-    -21.3, -20.4, -21.3, -22.7, -22.4, -21.0, -22.2, -27.2, -24.4, -19.9};
-
-inline constexpr double kSantaLucia2004DnaNnMean_dH_kcal =
-    pose_local_mean(kSantaLucia2004DnaNn_dH_kcal);
-inline constexpr double kSantaLucia2004DnaNnMean_dS_cal =
-    pose_local_mean(kSantaLucia2004DnaNn_dS_cal);
-
-// Scholtz, Marqusee, Baldwin et al., PNAS 88:2854 (1991), doi:10.1073/pnas.88.7.2854
-// Calorimetric helix *unfolding* ΔH ≈ +1.3 kcal mol⁻¹ residue⁻¹ (best estimate;
-// lower limit 0.9 if ΔCp = 0). Formation increment used here is the negative:
-// ΔH = −1.3 kcal mol⁻¹ residue⁻¹. Companion helix–coil CD fit: Scholtz, Qian,
-// Baldwin, Biopolymers 31:1463 (1991), doi:10.1002/bip.360311304 (ΔH° ≈ −0.955
-// kcal mol⁻¹ residue⁻¹). Prefer the calorimetric ΔH; per-residue ΔS is left as
-// an experimental gap (do not invent ΔS from s without a published consensus).
-inline constexpr double kScholtz1991HelixFormation_dH_kcal = -1.3;
-
-static_assert(kXia1998RnaWcStackMean_dH_kcal != kSantaLucia2004DnaNnMean_dH_kcal,
-              "RNA Xia 1998 WC-stack mean must not equal DNA SantaLucia 2004 mean");
-static_assert(kScholtz1991HelixFormation_dH_kcal < 0.0,
-              "helix formation ΔH is exothermic (Scholtz 1991 calorimetry)");
 
 // Dense per-kind table. Unused slots stay {0,0} so a DNA kind looked up in an
 // RNA table cannot leak Xia/Turner increments.
@@ -176,10 +114,12 @@ struct DecisionElement {
 
 struct PoseContact {
     ContactKind kind = ContactKind::RNA_STEM_STACK;
-    double      geometry_weight = 1.0;  // w in ΔH += coeff_H · w, ΔS += coeff_S · w
+    double      geometry_weight = 1.0;  // w scales the matched published motif term
     int         nt_index = -1;          // RNA/DNA
     int         res_index = -1;         // protein
     int         partner_res_index = -1; // sheet partner (optional)
+    std::string motif;                  // NN dimer e.g. "AA/TT" or "GC/CG"; empty → WC-stack mean
+    int         loop_unpaired = -1;     // RNA hairpin n; <0 → Lu 2006 n=4 default
     std::string element_label;          // if non-empty, prefer this labelled element
 };
 

--- a/LIB/NATURaL/data/lu_2006_rna_hairpin_initiation.tsv
+++ b/LIB/NATURaL/data/lu_2006_rna_hairpin_initiation.tsv
@@ -1,0 +1,14 @@
+# Lu, Turner, Mathews (2006) Nucleic Acids Res. 34:4912–4924, doi:10.1093/nar/gkl472
+# Table 1 — hairpin-loop initiation enthalpy ΔH°initiation(n)
+# n = number of unpaired nucleotides in the hairpin. n < 3 is not allowed.
+# n > 9 uses the n = 9 term (additional length cost is treated as entropic; ΔS not tabulated).
+# Units: ΔH kcal/mol. ΔS is an experimental gap (not published per n).
+n	dH_kcal
+3	1.3
+4	4.8
+5	3.6
+6	-2.9
+7	1.3
+8	-2.9
+9	5.0
+>9	5.0

--- a/LIB/NATURaL/data/santalucia_1998_pnas_table2.tsv
+++ b/LIB/NATURaL/data/santalucia_1998_pnas_table2.tsv
@@ -1,0 +1,22 @@
+# SantaLucia Jr (1998) PNAS 95:1460–1465, doi:10.1073/pnas.95.4.1460 (PMC19045)
+# Table 2 — Unified oligonucleotide ΔH° and ΔS° NN parameters in 1 M NaCl
+# (Allawi & SantaLucia 1997 unified set as tabulated in the 1998 PNAS).
+# Units: ΔH kcal/mol ; ΔS cal/K·mol
+# Sequence notation: 5′→3′ / 3′→5′ (antiparallel). Copy of Table 2, not a mean.
+# Review: SantaLucia & Hicks (2004) Annu. Rev. Biophys. Biomol. Struct. 33:415
+#   doi:10.1146/annurev.biophys.32.110601.141800 — later reprint; this file is 1998 Table 2.
+# kind: WC = propagation stack; INIT = duplex initiation; SYM = self-complementary symmetry
+motif	kind	dH_kcal	dS_cal
+AA/TT	WC	-7.9	-22.2
+AT/TA	WC	-7.2	-20.4
+TA/AT	WC	-7.2	-21.3
+CA/GT	WC	-8.5	-22.7
+GT/CA	WC	-8.4	-22.4
+CT/GA	WC	-7.8	-21.0
+GA/CT	WC	-8.2	-22.2
+CG/GC	WC	-10.6	-27.2
+GC/CG	WC	-9.8	-24.4
+GG/CC	WC	-8.0	-19.9
+INIT_GC	INIT	0.1	-2.8
+INIT_AT	INIT	2.3	4.1
+SYM	SYM	0.0	-1.4

--- a/LIB/NATURaL/data/xia_1998_rna_wc_stacks.tsv
+++ b/LIB/NATURaL/data/xia_1998_rna_wc_stacks.tsv
@@ -1,0 +1,21 @@
+# Xia, SantaLucia, Turner et al. (1998) Biochemistry 37:14719–14735
+# doi:10.1021/bi9809425 — INN-HB Watson–Crick propagation stacks (unique 10).
+# ΔH° and ΔG°37 as restated in Zuber et al. (2022) Nucleic Acids Res. 50:5251
+# Table 1A “1998 Model”, doi:10.1093/nar/gkac261 (PMC9122537).
+# ΔS° = (ΔH° − ΔG°37) / 310.15 K × 1000  (cal mol⁻¹ K⁻¹); T = 37 °C.
+# Initiation, AU-end, and symmetry terms are excluded (not WC stacks).
+# NNDB: Turner & Mathews (2010) NAR 38:D280, doi:10.1093/nar/gkp892
+#   https://rna.urmc.rochester.edu/NNDB/
+# Units: ΔH and ΔG37 kcal/mol ; ΔS cal mol⁻¹ K⁻¹
+# motif: 5′→3′ / 3′→5′ RNA
+motif	dH_kcal	dG37_kcal	dS_cal
+GC/CG	-14.88	-3.42	-36.949863
+CC/GG	-13.39	-3.26	-32.661615
+GA/CU	-12.44	-2.35	-32.532645
+CG/GC	-10.64	-2.36	-26.696760
+AC/UG	-11.40	-2.08	-30.049976
+CA/GU	-10.44	-2.11	-26.857972
+AG/UC	-10.48	-2.08	-27.083669
+UA/AU	-7.69	-1.33	-20.506207
+AU/UA	-9.38	-1.10	-26.696760
+AA/UU	-6.82	-0.93	-18.990811

--- a/LIB/NATURaL/dual_assembly_main.cpp
+++ b/LIB/NATURaL/dual_assembly_main.cpp
@@ -15,6 +15,7 @@
 //                 [--nascent-pdb-dir .]
 //                 [--synthetic]    # use built-in synthetic GA backend (MVP default)
 //                 [--real-ga]      # reserved; exits until FlexAID GA callback lands
+//                 [--pose-local-thermo-rewrite]  # experimental; default OFF
 //
 // The MVP ships a built-in synthetic GA backend (Gaussian pose distributions whose
 // width narrows as L_k grows) so the full pipeline can be exercised end-to-end on
@@ -52,6 +53,7 @@ struct Args {
     bool   reciprocal_controls = true;
     bool   sim_c_enabled       = true;
     bool   synthetic           = true;   // MVP default
+    bool   pose_local_thermo_rewrite = false;  // experimental, default OFF
     std::string output_csv     = "cotranslational_trajectory.csv";
     std::string nascent_pdb_dir = ".";
 };
@@ -96,6 +98,7 @@ Args parse_args(int argc, char** argv) {
         else if (k == "--no-sim-c")            a.sim_c_enabled       = false;
         else if (k == "--synthetic")           a.synthetic           = true;
         else if (k == "--real-ga")             a.synthetic           = false;
+        else if (k == "--pose-local-thermo-rewrite") a.pose_local_thermo_rewrite = true;
         else if (k == "--output-csv")          a.output_csv          = next(k.c_str());
         else if (k == "--nascent-pdb-dir")     a.nascent_pdb_dir     = next(k.c_str());
         else if (k == "--help" || k == "-h") { usage(); std::exit(0); }
@@ -210,6 +213,7 @@ int main(int argc, char** argv) {
         cfg.sim_c_enabled                = a.sim_c_enabled && !a.monomer_pdb.empty();
         cfg.output_csv                   = a.output_csv;
         cfg.nascent_pdb_dir              = a.nascent_pdb_dir;
+        cfg.enable_pose_local_thermo_rewrite = a.pose_local_thermo_rewrite;
 
         natural::SimAFn sim_a = make_synthetic_sim_a();
         natural::SimBFn sim_b = make_synthetic_sim_b();

--- a/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
+++ b/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
@@ -460,9 +460,11 @@ Pose→local secondary-structure ΔH/ΔS rewrite (`LIB/NATURaL/PoseLocalThermoRe
 is that 2014 ligand coupling generalized to RNA stem-loops, DNA stem-loops,
 protein α-helix, and protein β-sheet. The four classes share **algebra only**
 (ΔG = ΔH − TΔS, geometry-weighted contacts, Boltzmann mixture over top-k poses)
-and keep **class-specific increment tables**. Experimental, default OFF; see
-`docs/POSE_LOCAL_THERMO_REWRITE.md`. It is not `k_fold` in RibosomeElongation
-and does not mutate validated DualAssembly `dG_A` / `dG_B`.
+and keep **class-specific increment tables** (Xia 1998 RNA ≠ SantaLucia 2004
+DNA ≠ Scholtz 1991 helix; sheet and several contact kinds remain experimental
+gaps). Experimental, default OFF; see `docs/POSE_LOCAL_THERMO_REWRITE.md`.
+It is not `k_fold` in RibosomeElongation and does not mutate validated
+DualAssembly `dG_A` / `dG_B`.
 
 ---
 

--- a/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
+++ b/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
@@ -460,9 +460,9 @@ Pose→local secondary-structure ΔH/ΔS rewrite (`LIB/NATURaL/PoseLocalThermoRe
 is that 2014 ligand coupling generalized to RNA stem-loops, DNA stem-loops,
 protein α-helix, and protein β-sheet. The four classes share **algebra only**
 (ΔG = ΔH − TΔS, geometry-weighted contacts, Boltzmann mixture over top-k poses)
-and keep **class-specific increment tables** (Xia 1998 RNA ≠ SantaLucia 2004
-DNA ≠ Scholtz 1991 helix; sheet and several contact kinds remain experimental
-gaps). Experimental, default OFF; see `docs/POSE_LOCAL_THERMO_REWRITE.md`.
+and keep **class-specific increment tables** (Xia 1998 RNA ≠ SantaLucia 1998
+PNAS Table 2 DNA ≠ Scholtz 1991 / Zavrtanik 2026 helix ≠ Meier–Seelig 2008
+sheet midpoint). Experimental, default OFF; see `docs/POSE_LOCAL_THERMO_REWRITE.md`.
 It is not `k_fold` in RibosomeElongation and does not mutate validated
 DualAssembly `dG_A` / `dG_B`.
 

--- a/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
+++ b/docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md
@@ -379,6 +379,10 @@ a long trajectory is partially readable on disk even if the run is interrupted.
   • `LIB/NATURaL/PoseHelixThermoRewrite.{h,cpp}` — experimental sidecar; RNA DualAssembly
     hook is `NATURaLConfig.enable_pose_helix_rewrite` (false) +
     `DualAssemblyEngine::compute_pose_helix_rewrite()`. `run()` does not apply patches.
+  • `LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}` — experimental generalized pose→local SS
+    ΔH/ΔS rewrite (RNA/DNA/helix/sheet, class-specific tables). Runner hook is
+    `DualAssemblyConfig.enable_pose_local_thermo_rewrite` (false). Diagnostic only;
+    does not mutate `dG_A` / `dG_B`. See `docs/POSE_LOCAL_THERMO_REWRITE.md`.
   • `LIB/DatasetRunner.{h,cpp}` — not touched. The cotranslational runner is a separate
     top-level driver to avoid cross-cutting changes.
 
@@ -422,6 +426,9 @@ a long trajectory is partially readable on disk even if the run is interrupted.
   • Pose→helix ΔH/ΔS rewrite is experimental and default OFF. DualAssemblyRunner does not
     call it (no atom-level poses from the injected GA). DualAssemblyEngine::run() does not
     add patches to CF or `FA->natural_deltaG`.
+  • Pose→local SS ΔH/ΔS rewrite (`PoseLocalThermoRewrite`) is experimental and default OFF.
+    When enabled it writes diagnostic fields on `CheckpointOutcome` only; it does not
+    mutate `dG_A` / `dG_B` or add CSV columns.
   • The transcription tracks do not dock directly against the protofibril
     (`direct_encounter_allowed = false`). Polysome-mode (multiple nascent chains at
     staggered lengths sharing one mRNA against a single protofibril) is a future
@@ -434,6 +441,28 @@ a long trajectory is partially readable on disk even if the run is interrupted.
   • The fibril-growth oracle assumes a single monomer-binding site per checkpoint and a
     well-mixed monomer pool. Surface-bound oligomeric intermediates (e.g. dodecameric
     Aβ*56) are not represented.
+
+---
+
+## 9.1 NATURAL lineage and pose-local SS rewrite
+
+**NATURAL** = Native Assembly of Transcriptionally / Translationally Unified
+Receptor and Ligand.
+
+- Transcriptional → RNA/DNA + ligand (Zhao–Zhang–Chen JCP 2011, above).
+- Translational → protein + ligand (Zhao JPCB 2011 master equation, above).
+
+2014 seminar (LP Morency R2, 2014-07-25) Perl NATURAL: clustering, population
+inheritance, pause at nt repeats, docking poses rewrite helix ΔH/ΔS. 2026
+DualAssembly is the broader C++ home.
+
+Pose→local secondary-structure ΔH/ΔS rewrite (`LIB/NATURaL/PoseLocalThermoRewrite`)
+is that 2014 ligand coupling generalized to RNA stem-loops, DNA stem-loops,
+protein α-helix, and protein β-sheet. The four classes share **algebra only**
+(ΔG = ΔH − TΔS, geometry-weighted contacts, Boltzmann mixture over top-k poses)
+and keep **class-specific increment tables**. Experimental, default OFF; see
+`docs/POSE_LOCAL_THERMO_REWRITE.md`. It is not `k_fold` in RibosomeElongation
+and does not mutate validated DualAssembly `dG_A` / `dG_B`.
 
 ---
 

--- a/docs/EXPERIMENTAL_CAPABILITIES.md
+++ b/docs/EXPERIMENTAL_CAPABILITIES.md
@@ -22,9 +22,11 @@ At the current stage, the following should be treated as experimental:
 - PoseLocalThermoRewrite (`LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}`): experimental
   docking-pose rewrite of local secondary-structure ΔH/ΔS. RNA, DNA, protein
   α-helix, and protein β-sheet share the same algebra and use **class-specific**
-  increment tables (Turner-shaped RNA ≠ SantaLucia-shaped DNA ≠ helix ≠ sheet).
-  Default OFF (`DualAssemblyConfig::enable_pose_local_thermo_rewrite`,
-  `FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE`). Draft increments are not claim-ready.
+  increment tables (Xia 1998 RNA NN mean ≠ SantaLucia 2004 DNA NN mean ≠
+  Scholtz 1991 helix ΔH ≠ sheet gaps). Default OFF
+  (`DualAssemblyConfig::enable_pose_local_thermo_rewrite`,
+  `FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE`). Motifs without a calorimetric
+  consensus stay unset (`TODO(burgundy)` cite slots) — no invented placeholders.
   Does not feed `G_natural` / Astex / FlexADS claim contracts. See
   `docs/POSE_LOCAL_THERMO_REWRITE.md`.
 - backend-specific acceleration paths not required by the Core 1.0 support matrix

--- a/docs/EXPERIMENTAL_CAPABILITIES.md
+++ b/docs/EXPERIMENTAL_CAPABILITIES.md
@@ -22,8 +22,8 @@ At the current stage, the following should be treated as experimental:
 - PoseLocalThermoRewrite (`LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}`): experimental
   docking-pose rewrite of local secondary-structure ΔH/ΔS. RNA, DNA, protein
   α-helix, and protein β-sheet share the same algebra and use **class-specific**
-  increment tables (Xia 1998 RNA NN mean ≠ SantaLucia 2004 DNA NN mean ≠
-  Scholtz 1991 helix ΔH ≠ sheet gaps). Default OFF
+  increment tables (Xia 1998 RNA NN ≠ SantaLucia 1998 PNAS Table 2 DNA ≠
+  Scholtz 1991 / Zavrtanik 2026 helix ≠ Meier–Seelig 2008 sheet midpoint). Default OFF
   (`DualAssemblyConfig::enable_pose_local_thermo_rewrite`,
   `FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE`). Motifs without a calorimetric
   consensus stay unset (`TODO(burgundy)` cite slots) — no invented placeholders.

--- a/docs/EXPERIMENTAL_CAPABILITIES.md
+++ b/docs/EXPERIMENTAL_CAPABILITIES.md
@@ -19,7 +19,14 @@ At the current stage, the following should be treated as experimental:
 - Bonhomme Fleet and iCloud-driven distributed execution
 - NATURaL and related co-translational or co-transcriptional workflows
 - PoseHelixThermoRewrite / pose→helix ΔH/ΔS rewrite (2014 NATURAL seminar glue; default OFF; not Astex / not `G_natural`)
-- backend-specific acceleration paths not required by the Core 1.0 support matrix
+- PoseLocalThermoRewrite (`LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}`): experimental
+  docking-pose rewrite of local secondary-structure ΔH/ΔS. RNA, DNA, protein
+  α-helix, and protein β-sheet share the same algebra and use **class-specific**
+  increment tables (Turner-shaped RNA ≠ SantaLucia-shaped DNA ≠ helix ≠ sheet).
+  Default OFF (`DualAssemblyConfig::enable_pose_local_thermo_rewrite`,
+  `FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE`). Draft increments are not claim-ready.
+  Does not feed `G_natural` / Astex / FlexADS claim contracts. See
+  `docs/POSE_LOCAL_THERMO_REWRITE.md`.
 - backend-specific acceleration paths not required by the Core 1.0 support matrix
 - benchmark claims not yet backed by a repository reproducibility bundle
 
@@ -43,6 +50,9 @@ The following are intentionally kept experimental (see `docs/thermodynamics.md` 
 - PoseHelixThermoRewrite (`LIB/NATURaL/PoseHelixThermoRewrite`) — docking-pose mixture that
   rewrites RNA decision-helix ΔH/ΔS (loop ΔS, stem stacking ΔH). Experimental; default OFF;
   DualAssemblyEngine::run() does not apply it. See `docs/POSE_HELIX_THERMO_REWRITE.md`.
+- PoseLocalThermoRewrite (`LIB/NATURaL/PoseLocalThermoRewrite`) — same algebra generalized
+  to RNA/DNA/helix/sheet with class-specific tables. Experimental; default OFF. See
+  `docs/POSE_LOCAL_THERMO_REWRITE.md`.
 
 These features are fully implemented with tests and JSON exposure but require additional benchmarking or calibration data before promotion to validated status.
 4. an unambiguous ownership in the product boundary defined by `PRODUCT.md`

--- a/docs/POSE_HELIX_THERMO_REWRITE.md
+++ b/docs/POSE_HELIX_THERMO_REWRITE.md
@@ -78,3 +78,14 @@ of `atom_struct`, so unit tests do not need a full engine.
 Do not use this module for Astex success, PoseBusters gates, or METHODS claim
 contracts. Treat outputs as a helix-parameter diagnostic for RNA DualAssembly
 experiments only.
+
+## Class-table generalization
+
+`LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}` (see `docs/POSE_LOCAL_THERMO_REWRITE.md`)
+extends this 2014 ligand coupling to **RNA, DNA, protein helix, and protein sheet**
+with class-specific published tables (Xia 1998, Lu/Mathews 2006 / NNDB,
+SantaLucia 1998 PNAS Table 2, Scholtz 1991, Meier–Seelig 2008). Same algebra
+(`ΔG = ΔH − TΔS`, geometry weight `w`, Boltzmann mixture); **different tables**.
+PoseLocal does **not** use this module’s seminar defaults (−1.2 kcal/stack,
+−3.0 e.u./loop H-bond). Both DualAssembly flags default **OFF**. Neither path
+feeds `G_natural` or Astex claim metrics.

--- a/docs/POSE_LOCAL_THERMO_REWRITE.md
+++ b/docs/POSE_LOCAL_THERMO_REWRITE.md
@@ -1,0 +1,134 @@
+# Pose-local secondary-structure thermodynamic rewrite
+
+**Status: experimental. Not claim-ready. Default OFF.** Draft ΔH/ΔS increments
+are tunable placeholders. This path must not be cited as Astex success, FlexADS
+claim-ready ranking, or a validated binding free energy.
+
+This document specifies the physics, class-specific tables, and API for
+`LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}`.
+
+## NATURAL lineage
+
+**NATURAL** = Native Assembly of Transcriptionally / Translationally Unified
+Receptor and Ligand.
+
+- **Transcriptional** → RNA/DNA + ligand. Cotranscriptional RNA secondary-structure
+  kinetics: Zhao, Zhang, Chen, *J. Chem. Phys.* **135**, 245101 (2011),
+  doi:10.1063/1.3671644 ("Cotranscriptional folding kinetics of ribonucleic acid
+  secondary structures").
+- **Translational** → protein + ligand. Ribosome elongation master equation:
+  Zhao et al., *J. Phys. Chem. B* **115**, 3987 (2011). That JPCB paper is
+  **ribosome/protein only** — do not retarget it as an RNA/DNA folding citation.
+
+2014 seminar (LP Morency R2, 2014-07-25) Perl NATURAL: clustering, population
+inheritance, pause at nt repeats, docking poses rewrite helix ΔH/ΔS. 2026
+DualAssembly (`LIB/NATURaL/`) is the broader C++ home. This module generalizes
+the 2014 ligand coupling from protein helix rewrite to RNA, DNA, α-helix, and
+β-sheet.
+
+`G_natural` on `ThermodynamicBreakdown` is an optional StatMech flag. This PR
+does **not** feed pose patches into `G_natural` / `has_natural`. Optional later
+work may do so only on a labelled path.
+
+This rewrite is **not** `k_fold` in `RibosomeElongation`. Arrhenius coupling of
+rewritten ΔG into elongation/folding rates is a later PR.
+
+## Physics contract
+
+The **same calculation** applies to every polymer:
+
+1. Annotate decision elements (RNA/DNA stem-loop indices, or protein residue
+   range plus optional sheet partner).
+2. Docking poses contribute geometry-weighted contacts on those elements.
+3. Each contact looks up **its own class table** and adds `ΔH += coeff_H · w`,
+   `ΔS += coeff_S · w`.
+4. `ΔG = ΔH − TΔS` with Turner/SantaLucia units (below).
+5. Mix the top-k poses with Boltzmann weights from the rewritten local ΔG.
+
+α-helix and β-sheet use the **same method** as an RNA/DNA stem-loop and
+**different proper values**.
+
+RNA hairpin ≠ DNA duplex/hairpin ≠ protein helix ≠ protein sheet.
+
+NucleationDetector remains sequence-only (Turner / Chou-Fasman seeds). It does
+not perform pose→local ΔH/ΔS rewrite.
+
+## Units
+
+Nearest-neighbour convention (Turner RNA, SantaLucia DNA):
+
+| Symbol | Unit |
+|--------|------|
+| ΔH | kcal mol⁻¹ |
+| ΔS | cal mol⁻¹ K⁻¹ (e.u.) |
+| T | K |
+| ΔG | kcal mol⁻¹ = ΔH − T·(ΔS / 1000) |
+
+`kB = 0.001987206 kcal mol⁻¹ K⁻¹` (matches `statmech::kB_kcal`) is used only
+for the Boltzmann mixture, not for converting ΔS.
+
+## Class-specific increment tables (draft, experimental)
+
+`SSClass` members:
+
+- `RNA_STEM_LOOP` — Turner-shaped defaults
+- `DNA_STEM_LOOP` — SantaLucia-shaped defaults — **never** an alias of the RNA table
+- `PROTEIN_HELIX`
+- `PROTEIN_SHEET`
+- `PROTEIN_OTHER` — no rewrite unless annotated **and** that table is filled
+
+Draft coefficients, geometry weight `w`:
+
+| Class | Contact | ΔH (kcal mol⁻¹) | ΔS (cal mol⁻¹ K⁻¹) |
+|-------|---------|-----------------|---------------------|
+| RNA | stem stack | −1.2 w | 0 |
+| RNA | loop H-bond | 0 | −3.0 w |
+| DNA | stem stack | −1.0 w | 0 |
+| DNA | loop H-bond | 0 | −2.5 w |
+| DNA | intercalation-like | −1.5 w | −1.0 w |
+| PROTEIN_HELIX | backbone H-bond | −1.5 w | −1.0 w |
+| PROTEIN_HELIX | packing | −0.8 w | −2.0 w |
+| PROTEIN_HELIX | clash | +2.0 w | 0 |
+| PROTEIN_SHEET | bridge H-bond | −1.8 w | −1.5 w |
+| PROTEIN_SHEET | hydrophobic pack | −1.0 w | −2.5 w |
+| PROTEIN_SHEET | shear | +2.5 w | +1.0 w |
+
+An RNA `ContactKind` never reads the DNA or protein tables (and conversely).
+Shared algebra, separate numbers.
+
+## API
+
+Pure functions in `namespace natural` — no GA / `FA_Global` / DualAssemblyEngine
+required.
+
+```cpp
+DecisionElement { SSClass ss; label; RNA/DNA na_start/na_end
+                  OR protein res_start/res_end + optional sheet partner }
+PoseView { score_kcal; contacts[] }   // score used only to pick top-k
+PoseThermoRewriteConfig { ThermoIncrementTable per class; T; top_k;
+                          require_decision_element_only }
+LocalThermoMixture rewrite_local_thermo_from_poses(poses, elements, cfg);
+```
+
+- `require_decision_element_only` (default true): contacts outside every
+  annotated element of the matching class are dropped. If nothing remains, the
+  mixture is empty (finite zeros, `n_poses_used == 0`).
+- Boltzmann mixture: sort by `score_kcal` ascending, keep `top_k`,
+  `p_i ∝ exp(−ΔG_i / kT)` via log-sum-exp. Ranking of docking poses is not
+  changed; this is a diagnostic local-SS mixture.
+- No NaN in the returned mixture.
+
+## DualAssembly hook (default OFF)
+
+`DualAssemblyConfig::enable_pose_local_thermo_rewrite` defaults to `false`.
+Environment `FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE` (1/true/yes/on) may opt in.
+CLI: `dual_assembly --pose-local-thermo-rewrite`.
+
+When the flag is on **and** labelled `pose_rewrite_elements` +
+`pose_rewrite_poses` are supplied, `DualAssemblyRunner` stores the mixture in
+`CheckpointOutcome` diagnostic fields (`pose_local_*`). It does **not** overwrite
+`dG_A_kcal` / `dG_B_kcal` or set `has_natural`. The 21-column trajectory CSV is
+unchanged.
+
+See also `docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md` §10 and
+`docs/EXPERIMENTAL_CAPABILITIES.md`.

--- a/docs/POSE_LOCAL_THERMO_REWRITE.md
+++ b/docs/POSE_LOCAL_THERMO_REWRITE.md
@@ -1,7 +1,9 @@
 # Pose-local secondary-structure thermodynamic rewrite
 
-**Status: experimental. Not claim-ready. Default OFF.** Draft ΔH/ΔS increments
-are tunable placeholders. This path must not be cited as Astex success, FlexADS
+**Status: experimental. Not claim-ready. Default OFF.** Filled ΔH/ΔS increments
+are peer-reviewed NN / helix–coil means (cited below). Motifs without a
+calorimetric consensus stay `{0,0}` experimental gaps — they are **not**
+invented placeholders. This path must not be cited as Astex success, FlexADS
 claim-ready ranking, or a validated binding free energy.
 
 This document specifies the physics, class-specific tables, and API for
@@ -42,7 +44,7 @@ The **same calculation** applies to every polymer:
 2. Docking poses contribute geometry-weighted contacts on those elements.
 3. Each contact looks up **its own class table** and adds `ΔH += coeff_H · w`,
    `ΔS += coeff_S · w`.
-4. `ΔG = ΔH − TΔS` with Turner/SantaLucia units (below).
+4. `ΔG = ΔH − TΔS` with nearest-neighbour units (below).
 5. Mix the top-k poses with Boltzmann weights from the rewritten local ΔG.
 
 α-helix and β-sheet use the **same method** as an RNA/DNA stem-loop and
@@ -55,7 +57,7 @@ not perform pose→local ΔH/ΔS rewrite.
 
 ## Units
 
-Nearest-neighbour convention (Turner RNA, SantaLucia DNA):
+Nearest-neighbour convention (Xia/Turner RNA, SantaLucia DNA):
 
 | Symbol | Unit |
 |--------|------|
@@ -67,34 +69,47 @@ Nearest-neighbour convention (Turner RNA, SantaLucia DNA):
 `kB = 0.001987206 kcal mol⁻¹ K⁻¹` (matches `statmech::kB_kcal`) is used only
 for the Boltzmann mixture, not for converting ΔS.
 
-## Class-specific increment tables (draft, experimental)
+## Class-specific increment tables (published vs experimental gaps)
 
 `SSClass` members:
 
-- `RNA_STEM_LOOP` — Turner-shaped defaults
-- `DNA_STEM_LOOP` — SantaLucia-shaped defaults — **never** an alias of the RNA table
-- `PROTEIN_HELIX`
-- `PROTEIN_SHEET`
+- `RNA_STEM_LOOP` — Xia 1998 INN-HB WC-stack **mean** (sequence-specific NN is future work)
+- `DNA_STEM_LOOP` — SantaLucia 2004 NN-stack **mean** — **never** an alias of the RNA table
+- `PROTEIN_HELIX` — Scholtz 1991 calorimetric helix-formation ΔH; packing/clash unset
+- `PROTEIN_SHEET` — all contact kinds unset until a per-bridge consensus exists
 - `PROTEIN_OTHER` — no rewrite unless annotated **and** that table is filled
 
-Draft coefficients, geometry weight `w`:
+Geometry weight `w` multiplies the increment. An RNA `ContactKind` never reads the
+DNA or protein tables (and conversely). Shared algebra, separate numbers.
 
-| Class | Contact | ΔH (kcal mol⁻¹) | ΔS (cal mol⁻¹ K⁻¹) |
-|-------|---------|-----------------|---------------------|
-| RNA | stem stack | −1.2 w | 0 |
-| RNA | loop H-bond | 0 | −3.0 w |
-| DNA | stem stack | −1.0 w | 0 |
-| DNA | loop H-bond | 0 | −2.5 w |
-| DNA | intercalation-like | −1.5 w | −1.0 w |
-| PROTEIN_HELIX | backbone H-bond | −1.5 w | −1.0 w |
-| PROTEIN_HELIX | packing | −0.8 w | −2.0 w |
-| PROTEIN_HELIX | clash | +2.0 w | 0 |
-| PROTEIN_SHEET | bridge H-bond | −1.8 w | −1.5 w |
-| PROTEIN_SHEET | hydrophobic pack | −1.0 w | −2.5 w |
-| PROTEIN_SHEET | shear | +2.5 w | +1.0 w |
+### Filled (peer-reviewed)
 
-An RNA `ContactKind` never reads the DNA or protein tables (and conversely).
-Shared algebra, separate numbers.
+| Class | Contact | ΔH (kcal mol⁻¹) | ΔS (cal mol⁻¹ K⁻¹) | Source |
+|-------|---------|-----------------|---------------------|--------|
+| RNA | stem stack | −10.756 w | −27.9026… w | Xia et al. *Biochemistry* **37**:14719 (1998), doi:10.1021/bi9809425. Unweighted mean of the 10 unique WC **propagation** stacks (GC/CG, CC/GG, GA/CU, CG/GC, AC/UG, CA/GU, AG/UC, UA/AU, AU/UA, AA/UU) as restated in Zuber et al. *Nucleic Acids Res.* **50**:5251 (2022) Table 1A “1998 Model”, doi:10.1093/nar/gkac261. Initiation, AU-end, and symmetry terms are excluded. ΔS is recovered from each stack’s published ΔH and ΔG°37 at 310.15 K: ΔS = (ΔH − ΔG)/T. |
+| DNA | stem stack | −8.33 w | −22.28 w | SantaLucia & Hicks, *Annu. Rev. Biophys. Biomol. Struct.* **33**:415 (2004), doi:10.1146/annurev.biophys.32.110601.141800, Table 1 (1 M NaCl). Unweighted mean of the 10 WC **propagation** stacks (AA/TT … GG/CC). Initiation, terminal AT, and symmetry are excluded. |
+| PROTEIN_HELIX | backbone H-bond | −1.3 w | *gap* (0) | Scholtz, Marqusee, Baldwin et al., *PNAS* **88**:2854 (1991), doi:10.1073/pnas.88.7.2854. Calorimetric helix **unfolding** ΔH ≈ +1.3 kcal mol⁻¹ residue⁻¹ (best estimate; lower limit 0.9 if ΔCp = 0). The formation increment is the negative. Companion helix–coil CD fit: Scholtz, Qian, Baldwin, *Biopolymers* **31**:1463 (1991), doi:10.1002/bip.360311304 (ΔH° ≈ −0.955 kcal mol⁻¹ residue⁻¹). Per-residue ΔS is **not** filled — there is no calorimetric consensus independent of ΔCp assumptions; do not invent ΔS from *s*. |
+
+RNA mean ≠ DNA mean (required). Sequence-specific stack lookup is future work;
+the default is the unweighted propagation-stack mean, not a single invented
+“typical stack”.
+
+### Experimental gaps (`TODO(burgundy)` cite slots)
+
+These slots are `{0,0}` in `default_pose_thermo_rewrite_config()`. They are
+**labelled experimental**, not draft numbers. Burgundy is harvesting literature;
+align the harvested set here and in `LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}`.
+
+| Class | Contact | Why unset | Canonical reference (wrong quantity or wrong scale — do not paste as the increment) |
+|-------|---------|-----------|-------------------------------------------------------------------------------------|
+| RNA | loop H-bond | No calorimetric consensus for a **ligand–loop** H-bond ΔH/ΔS | Mathews, Sabina, Zuker, Turner, *J. Mol. Biol.* **288**:911 (1999), doi:10.1006/jmbi.1999.2700 — hairpin/internal-loop **initiation** ΔG, not this contact |
+| DNA | loop H-bond | Same mismatch of physical quantity | SantaLucia 2004 hairpin initiation tables (doi:10.1146/annurev.biophys.32.110601.141800) |
+| DNA | intercalation | Ligand-specific; no generic calorimetric mean | Leave cite slot for a harvested intercalator review (e.g. Chaires) once a consensus increment exists |
+| PROTEIN_HELIX | packing | No per-contact calorimetric consensus distinct from the backbone H-bond term | `TODO(burgundy)` |
+| PROTEIN_HELIX | clash | No calorimetric consensus | `TODO(burgundy)` |
+| PROTEIN_SHEET | bridge H-bond | No per-bridge consensus | Maynard, Sharman, Searle, *J. Am. Chem. Soc.* **120**:1996 (1998), doi:10.1021/ja9726769 is **whole 16-residue β-hairpin** folding (endothermic / entropy-driven in water, ΔH ≈ +7 kJ mol⁻¹ for the peptide). Wrong scale and often opposite sign versus a per-bridge increment — **do not reuse** |
+| PROTEIN_SHEET | hydrophobic pack | No per-contact consensus | `TODO(burgundy)` |
+| PROTEIN_SHEET | shear | No calorimetric consensus | `TODO(burgundy)` |
 
 ## API
 
@@ -132,3 +147,13 @@ unchanged.
 
 See also `docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md` §10 and
 `docs/EXPERIMENTAL_CAPABILITIES.md`.
+
+## Literature (DOIs)
+
+- Xia, SantaLucia, Turner et al. (1998) *Biochemistry* **37**:14719, doi:10.1021/bi9809425
+- Zuber, Schroeder, Kennedy, Turner (2022) *Nucleic Acids Res.* **50**:5251, doi:10.1093/nar/gkac261
+- SantaLucia & Hicks (2004) *Annu. Rev. Biophys. Biomol. Struct.* **33**:415, doi:10.1146/annurev.biophys.32.110601.141800
+- Scholtz, Marqusee, Baldwin et al. (1991) *PNAS* **88**:2854, doi:10.1073/pnas.88.7.2854
+- Scholtz, Qian, Baldwin (1991) *Biopolymers* **31**:1463, doi:10.1002/bip.360311304
+- Mathews, Sabina, Zuker, Turner (1999) *J. Mol. Biol.* **288**:911, doi:10.1006/jmbi.1999.2700 — loop **initiation** (not a ligand–loop increment)
+- Maynard, Sharman, Searle (1998) *J. Am. Chem. Soc.* **120**:1996, doi:10.1021/ja9726769 — whole-hairpin folding (not a per-bridge increment)

--- a/docs/POSE_LOCAL_THERMO_REWRITE.md
+++ b/docs/POSE_LOCAL_THERMO_REWRITE.md
@@ -1,13 +1,16 @@
 # Pose-local secondary-structure thermodynamic rewrite
 
 **Status: experimental. Not claim-ready. Default OFF.** Filled ΔH/ΔS increments
-are peer-reviewed NN / helix–coil means (cited below). Motifs without a
+are peer-reviewed NN / helix–coil values (cited below). Motifs without a
 calorimetric consensus stay `{0,0}` experimental gaps — they are **not**
 invented placeholders. This path must not be cited as Astex success, FlexADS
 claim-ready ranking, or a validated binding free energy.
 
 This document specifies the physics, class-specific tables, and API for
-`LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}`.
+`LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}` and `LIB/NATURaL/NnMotifTables.h`.
+It **generalizes** PR #471 `PoseHelixThermoRewrite` (RNA decision-helix, atom
+coords) to RNA/DNA/helix/sheet class tables. `#471` files stay; this module is
+the cited-table API.
 
 ## NATURAL lineage
 
@@ -73,10 +76,10 @@ for the Boltzmann mixture, not for converting ΔS.
 
 `SSClass` members:
 
-- `RNA_STEM_LOOP` — Xia 1998 INN-HB WC-stack **mean** (sequence-specific NN is future work)
-- `DNA_STEM_LOOP` — SantaLucia 2004 NN-stack **mean** — **never** an alias of the RNA table
-- `PROTEIN_HELIX` — Scholtz 1991 calorimetric helix-formation ΔH; packing/clash unset
-- `PROTEIN_SHEET` — all contact kinds unset until a per-bridge consensus exists
+- `RNA_STEM_LOOP` — Xia 1998 INN-HB WC stacks (mean default; `PoseContact::motif` selects a dimer)
+- `DNA_STEM_LOOP` — SantaLucia 1998 PNAS Table 2 — **never** an alias of the RNA table
+- `PROTEIN_HELIX` — Scholtz 1991 calorimetric helix-formation ΔH + Zavrtanik 2026 backbone ΔS
+- `PROTEIN_SHEET` — Meier–Seelig 2008 labelled experimental midpoint on the bridge H-bond only
 - `PROTEIN_OTHER` — no rewrite unless annotated **and** that table is filled
 
 Geometry weight `w` multiplies the increment. An RNA `ContactKind` never reads the
@@ -86,13 +89,13 @@ DNA or protein tables (and conversely). Shared algebra, separate numbers.
 
 | Class | Contact | ΔH (kcal mol⁻¹) | ΔS (cal mol⁻¹ K⁻¹) | Source |
 |-------|---------|-----------------|---------------------|--------|
-| RNA | stem stack | −10.756 w | −27.9026… w | Xia et al. *Biochemistry* **37**:14719 (1998), doi:10.1021/bi9809425. Unweighted mean of the 10 unique WC **propagation** stacks (GC/CG, CC/GG, GA/CU, CG/GC, AC/UG, CA/GU, AG/UC, UA/AU, AU/UA, AA/UU) as restated in Zuber et al. *Nucleic Acids Res.* **50**:5251 (2022) Table 1A “1998 Model”, doi:10.1093/nar/gkac261. Initiation, AU-end, and symmetry terms are excluded. ΔS is recovered from each stack’s published ΔH and ΔG°37 at 310.15 K: ΔS = (ΔH − ΔG)/T. |
-| DNA | stem stack | −8.33 w | −22.28 w | SantaLucia & Hicks, *Annu. Rev. Biophys. Biomol. Struct.* **33**:415 (2004), doi:10.1146/annurev.biophys.32.110601.141800, Table 1 (1 M NaCl). Unweighted mean of the 10 WC **propagation** stacks (AA/TT … GG/CC). Initiation, terminal AT, and symmetry are excluded. |
-| PROTEIN_HELIX | backbone H-bond | −1.3 w | *gap* (0) | Scholtz, Marqusee, Baldwin et al., *PNAS* **88**:2854 (1991), doi:10.1073/pnas.88.7.2854. Calorimetric helix **unfolding** ΔH ≈ +1.3 kcal mol⁻¹ residue⁻¹ (best estimate; lower limit 0.9 if ΔCp = 0). The formation increment is the negative. Companion helix–coil CD fit: Scholtz, Qian, Baldwin, *Biopolymers* **31**:1463 (1991), doi:10.1002/bip.360311304 (ΔH° ≈ −0.955 kcal mol⁻¹ residue⁻¹). Per-residue ΔS is **not** filled — there is no calorimetric consensus independent of ΔCp assumptions; do not invent ΔS from *s*. |
+| RNA | stem stack | Xia dimer, or −10.756 w mean | recovered ΔS, or −27.90… w mean | Xia et al. *Biochemistry* **37**:14719 (1998), doi:10.1021/bi9809425. Ten unique WC **propagation** stacks (GC/CG … AA/UU) as restated in Zuber et al. *Nucleic Acids Res.* **50**:5251 (2022) Table 1A “1998 Model”, doi:10.1093/nar/gkac261. Empty `motif` → unweighted mean. Named `motif` (e.g. `GC/CG`) → that row. TSV copy: `LIB/NATURaL/data/xia_1998_rna_wc_stacks.tsv`. |
+| RNA | loop (hairpin initiation) | Lu ΔH°(*n*) · w | *gap* (0) | Lu, Turner, Mathews, *Nucleic Acids Res.* **34**:4912 (2006), doi:10.1093/nar/gkl472, Table 1. Default *n*=4 → +4.8. `loop_unpaired` selects *n* (3:1.3; 4:4.8; 5:3.6; 6:−2.9; 7:1.3; 8:−2.9; ≥9:5.0). This is hairpin **initiation enthalpy**, not a ligand–loop H-bond. ΔS is not tabulated (extra length cost is treated as entropic). TSV: `LIB/NATURaL/data/lu_2006_rna_hairpin_initiation.tsv`. |
+| DNA | stem stack | Table 2 dimer, or −8.36 w mean | Table 2 dimer, or −22.37 w mean | SantaLucia Jr, *PNAS* **95**:1460 (1998), doi:10.1073/pnas.95.4.1460 (PMC19045), **Table 2** in 1 M NaCl. Ten WC propagation stacks (AA/TT … GG/CC); Init G·C / Init A·T / Symmetry are stored but are not the stem-stack default. Empty `motif` → WC-stack mean. Named `motif` (e.g. `AA/TT` = −7.9 / −22.2) → that row. 2004 review is a reprint, not the table source. TSV: `LIB/NATURaL/data/santalucia_1998_pnas_table2.tsv`. |
+| PROTEIN_HELIX | backbone H-bond | −1.3 w | −5.2 w | ΔH: Scholtz, Marqusee, Baldwin et al., *PNAS* **88**:2854 (1991), doi:10.1073/pnas.88.7.2854 (calorimetric helix **unfolding** +1.3 → formation −1.3). ΔS: Zavrtanik, Lah, Hadži, *Biophys. J.* **125**:305 (2026), doi:10.1016/j.bpj.2025.11.2689 (PubMed 41318999). Helix→coil ΔS_BB = 5.2 ± 0.3 cal mol⁻¹ K⁻¹ per peptide unit → formation −5.2. |
+| PROTEIN_SHEET | bridge H-bond | −0.4 w | −1.0 w | **Labelled experimental midpoint.** Meier & Seelig, *J. Am. Chem. Soc.* **130**:1017 (2008), doi:10.1021/ja077231r — membrane coil⇄β, ΔH_fold ≈ −0.2 to −0.6 kcal mol⁻¹ residue⁻¹, TΔS_fold ≈ −0.1 to −0.5; mid ΔH = −0.4, ΔS ≈ −1.0 e.u. at 298 K. Caveat: Deechongkit et al., *Nature* **430**:101 (2004), doi:10.1038/nature02611 — β H-bond energetics are context-dependent. Not a universal NN sheet table. |
 
-RNA mean ≠ DNA mean (required). Sequence-specific stack lookup is future work;
-the default is the unweighted propagation-stack mean, not a single invented
-“typical stack”.
+RNA mean ≠ DNA mean (required). `w` multiplies the matched published term. An RNA `ContactKind` never reads the DNA or protein tables (and conversely). Shared algebra, separate numbers.
 
 ### Experimental gaps (`TODO(burgundy)` cite slots)
 
@@ -102,14 +105,14 @@ align the harvested set here and in `LIB/NATURaL/PoseLocalThermoRewrite.{h,cpp}`
 
 | Class | Contact | Why unset | Canonical reference (wrong quantity or wrong scale — do not paste as the increment) |
 |-------|---------|-----------|-------------------------------------------------------------------------------------|
-| RNA | loop H-bond | No calorimetric consensus for a **ligand–loop** H-bond ΔH/ΔS | Mathews, Sabina, Zuker, Turner, *J. Mol. Biol.* **288**:911 (1999), doi:10.1006/jmbi.1999.2700 — hairpin/internal-loop **initiation** ΔG, not this contact |
-| DNA | loop H-bond | Same mismatch of physical quantity | SantaLucia 2004 hairpin initiation tables (doi:10.1146/annurev.biophys.32.110601.141800) |
+| DNA | loop H-bond | No calorimetric consensus for a **ligand–loop** H-bond ΔH/ΔS | SantaLucia 1998/2004 hairpin initiation tables are loop-initiation ΔG, not this contact |
 | DNA | intercalation | Ligand-specific; no generic calorimetric mean | Leave cite slot for a harvested intercalator review (e.g. Chaires) once a consensus increment exists |
 | PROTEIN_HELIX | packing | No per-contact calorimetric consensus distinct from the backbone H-bond term | `TODO(burgundy)` |
 | PROTEIN_HELIX | clash | No calorimetric consensus | `TODO(burgundy)` |
-| PROTEIN_SHEET | bridge H-bond | No per-bridge consensus | Maynard, Sharman, Searle, *J. Am. Chem. Soc.* **120**:1996 (1998), doi:10.1021/ja9726769 is **whole 16-residue β-hairpin** folding (endothermic / entropy-driven in water, ΔH ≈ +7 kJ mol⁻¹ for the peptide). Wrong scale and often opposite sign versus a per-bridge increment — **do not reuse** |
 | PROTEIN_SHEET | hydrophobic pack | No per-contact consensus | `TODO(burgundy)` |
 | PROTEIN_SHEET | shear | No calorimetric consensus | `TODO(burgundy)` |
+
+Maynard, Sharman, Searle, *J. Am. Chem. Soc.* **120**:1996 (1998), doi:10.1021/ja9726769 is **whole 16-residue β-hairpin** folding — wrong scale versus a per-bridge increment; **do not reuse**.
 
 ## API
 
@@ -152,8 +155,11 @@ See also `docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md` §10 and
 
 - Xia, SantaLucia, Turner et al. (1998) *Biochemistry* **37**:14719, doi:10.1021/bi9809425
 - Zuber, Schroeder, Kennedy, Turner (2022) *Nucleic Acids Res.* **50**:5251, doi:10.1093/nar/gkac261
-- SantaLucia & Hicks (2004) *Annu. Rev. Biophys. Biomol. Struct.* **33**:415, doi:10.1146/annurev.biophys.32.110601.141800
+- Lu, Turner, Mathews (2006) *Nucleic Acids Res.* **34**:4912, doi:10.1093/nar/gkl472
+- SantaLucia Jr (1998) *PNAS* **95**:1460, doi:10.1073/pnas.95.4.1460 (PMC19045) — DNA Table 2
+- SantaLucia & Hicks (2004) *Annu. Rev. Biophys. Biomol. Struct.* **33**:415, doi:10.1146/annurev.biophys.32.110601.141800 — review reprint, not the DNA table source
 - Scholtz, Marqusee, Baldwin et al. (1991) *PNAS* **88**:2854, doi:10.1073/pnas.88.7.2854
-- Scholtz, Qian, Baldwin (1991) *Biopolymers* **31**:1463, doi:10.1002/bip.360311304
-- Mathews, Sabina, Zuker, Turner (1999) *J. Mol. Biol.* **288**:911, doi:10.1006/jmbi.1999.2700 — loop **initiation** (not a ligand–loop increment)
+- Zavrtanik, Lah, Hadži (2026) *Biophys. J.* **125**:305, doi:10.1016/j.bpj.2025.11.2689 (PubMed 41318999)
+- Meier & Seelig (2008) *J. Am. Chem. Soc.* **130**:1017, doi:10.1021/ja077231r — labelled experimental sheet midpoint
+- Deechongkit et al. (2004) *Nature* **430**:101, doi:10.1038/nature02611 — β H-bond context caveat
 - Maynard, Sharman, Searle (1998) *J. Am. Chem. Soc.* **120**:1996, doi:10.1021/ja9726769 — whole-hairpin folding (not a per-bridge increment)

--- a/docs/POSE_LOCAL_THERMO_REWRITE.md
+++ b/docs/POSE_LOCAL_THERMO_REWRITE.md
@@ -154,6 +154,7 @@ See also `docs/DUAL_ASSEMBLY_COTRANSLATIONAL.md` §10 and
 ## Literature (DOIs)
 
 - Xia, SantaLucia, Turner et al. (1998) *Biochemistry* **37**:14719, doi:10.1021/bi9809425
+- NNDB: Turner & Mathews (2010) *Nucleic Acids Res.* **38**:D280, doi:10.1093/nar/gkp892 — https://rna.urmc.rochester.edu/NNDB/
 - Zuber, Schroeder, Kennedy, Turner (2022) *Nucleic Acids Res.* **50**:5251, doi:10.1093/nar/gkac261
 - Lu, Turner, Mathews (2006) *Nucleic Acids Res.* **34**:4912, doi:10.1093/nar/gkl472
 - SantaLucia Jr (1998) *PNAS* **95**:1460, doi:10.1073/pnas.95.4.1460 (PMC19045) — DNA Table 2

--- a/tests/test_nascent_chain_scheduler.cpp
+++ b/tests/test_nascent_chain_scheduler.cpp
@@ -586,3 +586,67 @@ TEST(DualAssemblyRunner, SimCCadenceIsPerTrackNotGlobal) {
     EXPECT_TRUE(translation_sim_c_flags[3]);
     EXPECT_EQ(sim_c_calls, 2);
 }
+
+TEST(DualAssemblyRunner, PoseLocalThermoRewriteDefaultsOff)
+{
+    natural::DualAssemblyConfig cfg;
+    EXPECT_FALSE(cfg.enable_pose_local_thermo_rewrite);
+    EXPECT_TRUE(cfg.pose_rewrite_elements.empty());
+    EXPECT_TRUE(cfg.pose_rewrite_poses.empty());
+}
+
+TEST(DualAssemblyRunner, PoseLocalThermoRewriteIsDiagnosticOnly)
+{
+    natural::DualAssemblyConfig cfg;
+    cfg.protofibril_pdb = "fake.pdb";
+    cfg.sequence_fasta  = std::string(80, 'A');
+    cfg.checkpoint_interval = 20;
+    cfg.include_reciprocal_controls = false;
+    cfg.sim_c_enabled = false;
+    cfg.output_csv = "/tmp/dual_assembly_pose_rewrite.csv";
+    cfg.nascent_pdb_dir = "/tmp/dual_assembly_pose_rewrite_pdbs";
+    cfg.enable_pose_local_thermo_rewrite = true;
+
+    natural::DecisionElement el;
+    el.ss = natural::SSClass::RNA_STEM_LOOP;
+    el.label = "hp";
+    el.na_start = 0;
+    el.na_end = 10;
+    cfg.pose_rewrite_elements.push_back(el);
+
+    natural::PoseView pose;
+    pose.score_kcal = -1.0;
+    natural::PoseContact c;
+    c.kind = natural::ContactKind::RNA_STEM_STACK;
+    c.geometry_weight = 1.0;
+    c.nt_index = 3;
+    pose.contacts.push_back(c);
+    cfg.pose_rewrite_poses.push_back(pose);
+
+    auto sim_a = [](const std::string&, const std::string&, int L_k, double T) {
+        return synthetic_engine(T, 16, 1.0, -4.0, 9u + L_k);
+    };
+    auto trunc = [](const std::string&, int L_k, const std::string&) {
+        return std::string("/tmp/dual_assembly_pose_rewrite_L") + std::to_string(L_k) + ".pdb";
+    };
+
+    natural::DualAssemblyRunner runner(std::move(cfg), sim_a, nullptr, nullptr, trunc);
+    auto history = runner.run();
+    ASSERT_FALSE(history.empty());
+
+    bool saw_rewrite = false;
+    for (const auto& [ck, out] : history) {
+        if (ck.in_tunnel || ck.chaperone_shielded || !ck.direct_encounter_allowed)
+            continue;
+        EXPECT_TRUE(std::isfinite(out.dG_A_kcal));
+        EXPECT_TRUE(out.pose_local_thermo_applied);
+        EXPECT_LT(out.pose_local_dH_kcal, 0.0);
+        EXPECT_NEAR(out.pose_local_dH_kcal, -1.2, 1e-12);
+        EXPECT_TRUE(std::isfinite(out.pose_local_dG_kcal));
+        // Validated DualAssembly ΔG is the StatMech engine value, not the local SS patch.
+        EXPECT_NE(out.dG_A_kcal, out.pose_local_dG_kcal);
+        saw_rewrite = true;
+        break;
+    }
+    EXPECT_TRUE(saw_rewrite);
+}

--- a/tests/test_nascent_chain_scheduler.cpp
+++ b/tests/test_nascent_chain_scheduler.cpp
@@ -641,7 +641,9 @@ TEST(DualAssemblyRunner, PoseLocalThermoRewriteIsDiagnosticOnly)
         EXPECT_TRUE(std::isfinite(out.dG_A_kcal));
         EXPECT_TRUE(out.pose_local_thermo_applied);
         EXPECT_LT(out.pose_local_dH_kcal, 0.0);
-        EXPECT_NEAR(out.pose_local_dH_kcal, -1.2, 1e-12);
+        EXPECT_NEAR(out.pose_local_dH_kcal, natural::kXia1998RnaWcStackMean_dH_kcal, 1e-12);
+        EXPECT_NEAR(out.pose_local_dS_cal_per_mol_K,
+                    natural::kXia1998RnaWcStackMean_dS_cal, 1e-12);
         EXPECT_TRUE(std::isfinite(out.pose_local_dG_kcal));
         // Validated DualAssembly ΔG is the StatMech engine value, not the local SS patch.
         EXPECT_NE(out.dG_A_kcal, out.pose_local_dG_kcal);

--- a/tests/test_natural.cpp
+++ b/tests/test_natural.cpp
@@ -405,6 +405,7 @@ TEST(NATURaLConfig, DefaultsAreReasonable) {
     EXPECT_FALSE(cfg.enabled);
     EXPECT_FALSE(cfg.enable_pose_helix_rewrite);
     EXPECT_TRUE(cfg.decision_helices.empty());
+    EXPECT_FALSE(cfg.pose_local_thermo_rewrite);
     EXPECT_GT(cfg.temperature_K, 200.0);
     EXPECT_LT(cfg.temperature_K, 400.0);
     EXPECT_GT(cfg.mg_concentration_mM, 0.0);

--- a/tests/test_pose_local_thermo_rewrite.cpp
+++ b/tests/test_pose_local_thermo_rewrite.cpp
@@ -1,6 +1,7 @@
 // tests/test_pose_local_thermo_rewrite.cpp
 // Experimental PoseLocalThermoRewrite: class-specific ΔH/ΔS tables share algebra
-// only. Xia 1998 RNA ≠ SantaLucia 2004 DNA ≠ Scholtz 1991 helix ≠ sheet gaps.
+// only. Xia 1998 RNA ≠ SantaLucia 1998 DNA ≠ Scholtz/Zavrtanik helix ≠
+// Meier–Seelig sheet. PoseHelixThermoRewrite (#471) is a separate RNA sidecar.
 //
 // Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
 #include <gtest/gtest.h>
@@ -18,13 +19,22 @@ using natural::PoseView;
 using natural::SSClass;
 using natural::delta_G_kcal;
 using natural::kCalPerKcal;
-using natural::kExperimentalGapIncrement;
+using natural::kLu2006DefaultHairpin;
+using natural::kMeierSeelig2008SheetFold_dH_kcal;
+using natural::kMeierSeelig2008SheetFold_dS_cal;
 using natural::kPoseRewrite_kB_kcal_mol_K;
-using natural::kSantaLucia2004DnaNnMean_dH_kcal;
-using natural::kSantaLucia2004DnaNnMean_dS_cal;
+using natural::kSantaLucia1998DnaWcStackMean_dH_kcal;
+using natural::kSantaLucia1998DnaWcStackMean_dS_cal;
+using natural::kSantaLucia1998PnasTable2;
 using natural::kScholtz1991HelixFormation_dH_kcal;
 using natural::kXia1998RnaWcStackMean_dH_kcal;
 using natural::kXia1998RnaWcStackMean_dS_cal;
+using natural::kXia1998RnaWcStacks;
+using natural::kZavrtanik2026HelixFormation_dS_cal;
+using natural::lookup_lu2006_rna_hairpin;
+using natural::lookup_santalucia1998_dna;
+using natural::lookup_xia1998_rna;
+using natural::lu2006_hairpin_initiation_dH_kcal;
 using natural::rewrite_local_thermo_from_poses;
 using natural::ss_class_for_kind;
 using natural::ss_class_name;
@@ -103,9 +113,9 @@ TEST(PoseLocalThermoRewrite, TablesAreClassSpecific)
     EXPECT_NEAR(rna.increments[rna_stack].dH_kcal, kXia1998RnaWcStackMean_dH_kcal, 1e-12);
     EXPECT_NEAR(rna.increments[rna_stack].dS_cal_per_mol_K,
                 kXia1998RnaWcStackMean_dS_cal, 1e-12);
-    EXPECT_NEAR(dna.increments[dna_stack].dH_kcal, kSantaLucia2004DnaNnMean_dH_kcal, 1e-12);
+    EXPECT_NEAR(dna.increments[dna_stack].dH_kcal, kSantaLucia1998DnaWcStackMean_dH_kcal, 1e-12);
     EXPECT_NEAR(dna.increments[dna_stack].dS_cal_per_mol_K,
-                kSantaLucia2004DnaNnMean_dS_cal, 1e-12);
+                kSantaLucia1998DnaWcStackMean_dS_cal, 1e-12);
     EXPECT_NE(rna.increments[rna_stack].dH_kcal, dna.increments[dna_stack].dH_kcal);
     EXPECT_NE(rna.increments[rna_stack].dS_cal_per_mol_K,
               dna.increments[dna_stack].dS_cal_per_mol_K);
@@ -115,10 +125,11 @@ TEST(PoseLocalThermoRewrite, TablesAreClassSpecific)
     const int hx_hb = static_cast<int>(ContactKind::PROTEIN_HELIX_BB_HBOND);
     const int sh_hb = static_cast<int>(ContactKind::PROTEIN_SHEET_BRIDGE_HBOND);
     EXPECT_NEAR(hx.increments[hx_hb].dH_kcal, kScholtz1991HelixFormation_dH_kcal, 1e-12);
-    EXPECT_NEAR(hx.increments[hx_hb].dS_cal_per_mol_K, 0.0, 1e-12);
-    EXPECT_NEAR(sh.increments[sh_hb].dH_kcal, kExperimentalGapIncrement.dH_kcal, 1e-12);
+    EXPECT_NEAR(hx.increments[hx_hb].dS_cal_per_mol_K,
+                kZavrtanik2026HelixFormation_dS_cal, 1e-12);
+    EXPECT_NEAR(sh.increments[sh_hb].dH_kcal, kMeierSeelig2008SheetFold_dH_kcal, 1e-12);
     EXPECT_NEAR(sh.increments[sh_hb].dS_cal_per_mol_K,
-                kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
+                kMeierSeelig2008SheetFold_dS_cal, 1e-12);
     EXPECT_NE(hx.increments[hx_hb].dH_kcal, sh.increments[sh_hb].dH_kcal);
 }
 
@@ -137,16 +148,29 @@ TEST(PoseLocalThermoRewrite, RnaStemStackUsesXia1998Mean)
     EXPECT_EQ(ss_class_name(mix.per_element.at(0).ss), std::string("RNA_STEM_LOOP"));
 }
 
-TEST(PoseLocalThermoRewrite, RnaLoopHbondIsExperimentalGap)
+TEST(PoseLocalThermoRewrite, RnaLoopUsesLu2006HairpinInitiation)
 {
     const auto cfg = natural::default_pose_thermo_rewrite_config();
+    auto pose = one_contact(ContactKind::RNA_LOOP_HBOND, 1.0, /*nt=*/5, /*res=*/-1);
     const auto mix = rewrite_local_thermo_from_poses(
-        {one_contact(ContactKind::RNA_LOOP_HBOND, 1.0, /*nt=*/5, /*res=*/-1)},
-        {rna_loop("hp", 0, 10)},
-        cfg);
+        {pose}, {rna_loop("hp", 0, 10)}, cfg);
     ASSERT_EQ(mix.n_poses_used, 1);
-    EXPECT_NEAR(mix.dH_kcal, kExperimentalGapIncrement.dH_kcal, 1e-12);
-    EXPECT_NEAR(mix.dS_cal_per_mol_K, kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
+    EXPECT_NEAR(mix.dH_kcal, kLu2006DefaultHairpin.dH_kcal, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, kLu2006DefaultHairpin.dS_cal_per_mol_K, 1e-12);
+    EXPECT_NEAR(mix.dH_kcal, 4.8, 1e-12);  // Lu 2006 n=4
+
+    pose.contacts[0].loop_unpaired = 3;
+    const auto mix3 = rewrite_local_thermo_from_poses(
+        {pose}, {rna_loop("hp", 0, 10)}, cfg);
+    ASSERT_EQ(mix3.n_poses_used, 1);
+    EXPECT_NEAR(mix3.dH_kcal, lu2006_hairpin_initiation_dH_kcal(3), 1e-12);
+    EXPECT_NEAR(mix3.dH_kcal, 1.3, 1e-12);
+    EXPECT_NE(mix3.dH_kcal, mix.dH_kcal);
+
+    pose.contacts[0].loop_unpaired = 2;
+    const auto mix_short = rewrite_local_thermo_from_poses(
+        {pose}, {rna_loop("hp", 0, 10)}, cfg);
+    EXPECT_TRUE(mix_short.empty());
 }
 
 TEST(PoseLocalThermoRewrite, DnaStemStackUsesDnaTableNotRna)
@@ -162,8 +186,8 @@ TEST(PoseLocalThermoRewrite, DnaStemStackUsesDnaTableNotRna)
     ASSERT_EQ(dna.n_poses_used, 1);
     EXPECT_EQ(ss_class_name(dna.per_element.at(0).ss), std::string("DNA_STEM_LOOP"));
     EXPECT_LT(dna.dH_kcal, 0.0);
-    EXPECT_NEAR(dna.dH_kcal, kSantaLucia2004DnaNnMean_dH_kcal, 1e-12);
-    EXPECT_NEAR(dna.dS_cal_per_mol_K, kSantaLucia2004DnaNnMean_dS_cal, 1e-12);
+    EXPECT_NEAR(dna.dH_kcal, kSantaLucia1998DnaWcStackMean_dH_kcal, 1e-12);
+    EXPECT_NEAR(dna.dS_cal_per_mol_K, kSantaLucia1998DnaWcStackMean_dS_cal, 1e-12);
     EXPECT_NEAR(rna.dH_kcal, kXia1998RnaWcStackMean_dH_kcal, 1e-12);
     EXPECT_NEAR(rna.dS_cal_per_mol_K, kXia1998RnaWcStackMean_dS_cal, 1e-12);
     EXPECT_NE(dna.dH_kcal, rna.dH_kcal);
@@ -180,7 +204,7 @@ TEST(PoseLocalThermoRewrite, ProteinHelixUsesHelixTable)
     ASSERT_EQ(mix.n_poses_used, 1);
     EXPECT_EQ(mix.per_element.at(0).ss, SSClass::PROTEIN_HELIX);
     EXPECT_NEAR(mix.dH_kcal, kScholtz1991HelixFormation_dH_kcal, 1e-12);
-    EXPECT_NEAR(mix.dS_cal_per_mol_K, kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, kZavrtanik2026HelixFormation_dS_cal, 1e-12);
     EXPECT_NE(ss_class_for_kind(ContactKind::PROTEIN_HELIX_BB_HBOND), SSClass::RNA_STEM_LOOP);
     EXPECT_NE(ss_class_for_kind(ContactKind::PROTEIN_HELIX_BB_HBOND), SSClass::DNA_STEM_LOOP);
 }
@@ -198,10 +222,11 @@ TEST(PoseLocalThermoRewrite, ProteinSheetBridgeDiffersFromHelix)
         cfg);
     ASSERT_EQ(sh.n_poses_used, 1);
     EXPECT_EQ(sh.per_element.at(0).ss, SSClass::PROTEIN_SHEET);
-    EXPECT_NEAR(sh.dH_kcal, kExperimentalGapIncrement.dH_kcal, 1e-12);
-    EXPECT_NEAR(sh.dS_cal_per_mol_K, kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
+    EXPECT_NEAR(sh.dH_kcal, kMeierSeelig2008SheetFold_dH_kcal, 1e-12);
+    EXPECT_NEAR(sh.dS_cal_per_mol_K, kMeierSeelig2008SheetFold_dS_cal, 1e-12);
     EXPECT_NEAR(hx.dH_kcal, kScholtz1991HelixFormation_dH_kcal, 1e-12);
     EXPECT_NE(sh.dH_kcal, hx.dH_kcal);
+    EXPECT_NE(sh.dS_cal_per_mol_K, hx.dS_cal_per_mol_K);
 }
 
 TEST(PoseLocalThermoRewrite, OutsideDecisionElementEmptyWhenRequired)
@@ -304,7 +329,6 @@ TEST(PoseLocalThermoRewrite, ProteinOtherDoesNotRewriteByDefault)
 TEST(PoseLocalThermoRewrite, ExperimentalGapsStayUnset)
 {
     const auto cfg = natural::default_pose_thermo_rewrite_config();
-    const auto& rna = table_for_ss(cfg, SSClass::RNA_STEM_LOOP);
     const auto& dna = table_for_ss(cfg, SSClass::DNA_STEM_LOOP);
     const auto& hx  = table_for_ss(cfg, SSClass::PROTEIN_HELIX);
     const auto& sh  = table_for_ss(cfg, SSClass::PROTEIN_SHEET);
@@ -314,12 +338,10 @@ TEST(PoseLocalThermoRewrite, ExperimentalGapsStayUnset)
         EXPECT_NEAR(inc.dH_kcal, 0.0, 1e-12);
         EXPECT_NEAR(inc.dS_cal_per_mol_K, 0.0, 1e-12);
     };
-    zero(rna, ContactKind::RNA_LOOP_HBOND);
     zero(dna, ContactKind::DNA_LOOP_HBOND);
     zero(dna, ContactKind::DNA_INTERCALATION);
     zero(hx, ContactKind::PROTEIN_HELIX_PACKING);
     zero(hx, ContactKind::PROTEIN_HELIX_CLASH);
-    zero(sh, ContactKind::PROTEIN_SHEET_BRIDGE_HBOND);
     zero(sh, ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK);
     zero(sh, ContactKind::PROTEIN_SHEET_SHEAR);
 }
@@ -332,4 +354,70 @@ TEST(PoseLocalThermoRewrite, RnaKindOnDnaElementIsIgnored)
         {dna_loop("d", 0, 10)},
         cfg);
     EXPECT_TRUE(mix.empty());
+}
+
+TEST(NnMotifTables, SantaLucia1998Table2AaTtIsNotTheWcMean)
+{
+    const auto aa = lookup_santalucia1998_dna("AA/TT");
+    ASSERT_TRUE(aa.has_value());
+    EXPECT_NEAR(aa->dH_kcal, -7.9, 1e-12);
+    EXPECT_NEAR(aa->dS_cal_per_mol_K, -22.2, 1e-12);
+    EXPECT_NEAR(aa->dH_kcal, kSantaLucia1998PnasTable2[0].dH_kcal, 1e-12);
+    EXPECT_NE(aa->dH_kcal, kSantaLucia1998DnaWcStackMean_dH_kcal);
+
+    const auto mean = lookup_santalucia1998_dna("");
+    ASSERT_TRUE(mean.has_value());
+    EXPECT_NEAR(mean->dH_kcal, kSantaLucia1998DnaWcStackMean_dH_kcal, 1e-12);
+    EXPECT_FALSE(lookup_santalucia1998_dna("ZZ/ZZ").has_value());
+}
+
+TEST(NnMotifTables, Xia1998GcCgIsNotTheWcMean)
+{
+    const auto gc = lookup_xia1998_rna("GC/CG");
+    ASSERT_TRUE(gc.has_value());
+    EXPECT_NEAR(gc->dH_kcal, kXia1998RnaWcStacks[0].dH_kcal, 1e-12);
+    EXPECT_NEAR(gc->dH_kcal, -14.88, 1e-12);
+    EXPECT_NE(gc->dH_kcal, kXia1998RnaWcStackMean_dH_kcal);
+    EXPECT_FALSE(lookup_xia1998_rna("AA/TT").has_value());  // DNA motif, not RNA
+}
+
+TEST(PoseLocalThermoRewrite, MotifLookupOverridesClassMean)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    PoseView dna_aa = one_contact(ContactKind::DNA_STEM_STACK, 1.0, 3, -1);
+    dna_aa.contacts[0].motif = "AA/TT";
+    const auto mix_aa = rewrite_local_thermo_from_poses(
+        {dna_aa}, {dna_loop("d", 0, 10)}, cfg);
+    ASSERT_EQ(mix_aa.n_poses_used, 1);
+    EXPECT_NEAR(mix_aa.dH_kcal, -7.9, 1e-12);
+    EXPECT_NEAR(mix_aa.dS_cal_per_mol_K, -22.2, 1e-12);
+
+    PoseView dna_mean = one_contact(ContactKind::DNA_STEM_STACK, 1.0, 3, -1);
+    const auto mix_mean = rewrite_local_thermo_from_poses(
+        {dna_mean}, {dna_loop("d", 0, 10)}, cfg);
+    EXPECT_NEAR(mix_mean.dH_kcal, kSantaLucia1998DnaWcStackMean_dH_kcal, 1e-12);
+    EXPECT_NE(mix_aa.dH_kcal, mix_mean.dH_kcal);
+
+    PoseView unknown = one_contact(ContactKind::DNA_STEM_STACK, 1.0, 3, -1);
+    unknown.contacts[0].motif = "ZZ/ZZ";
+    const auto mix_bad = rewrite_local_thermo_from_poses(
+        {unknown}, {dna_loop("d", 0, 10)}, cfg);
+    EXPECT_TRUE(mix_bad.empty());
+
+    PoseView rna_gc = one_contact(ContactKind::RNA_STEM_STACK, 1.0, 3, -1);
+    rna_gc.contacts[0].motif = "GC/CG";
+    const auto mix_gc = rewrite_local_thermo_from_poses(
+        {rna_gc}, {rna_loop("r", 0, 10)}, cfg);
+    ASSERT_EQ(mix_gc.n_poses_used, 1);
+    EXPECT_NEAR(mix_gc.dH_kcal, -14.88, 1e-12);
+}
+
+TEST(NnMotifTables, Lu2006HairpinNTable)
+{
+    EXPECT_NEAR(lu2006_hairpin_initiation_dH_kcal(3), 1.3, 1e-12);
+    EXPECT_NEAR(lu2006_hairpin_initiation_dH_kcal(4), 4.8, 1e-12);
+    EXPECT_NEAR(lu2006_hairpin_initiation_dH_kcal(9), 5.0, 1e-12);
+    EXPECT_NEAR(lu2006_hairpin_initiation_dH_kcal(12), 5.0, 1e-12);
+    EXPECT_FALSE(lookup_lu2006_rna_hairpin(0).has_value());
+    EXPECT_NEAR(lookup_lu2006_rna_hairpin(-1)->dH_kcal, 4.8, 1e-12);
 }

--- a/tests/test_pose_local_thermo_rewrite.cpp
+++ b/tests/test_pose_local_thermo_rewrite.cpp
@@ -25,8 +25,10 @@ using natural::kMeierSeelig2008SheetFold_dS_cal;
 using natural::kPoseRewrite_kB_kcal_mol_K;
 using natural::kSantaLucia1998DnaWcStackMean_dH_kcal;
 using natural::kSantaLucia1998DnaWcStackMean_dS_cal;
+using natural::kSantaLucia1998Motif;
 using natural::kSantaLucia1998PnasTable2;
 using natural::kScholtz1991HelixFormation_dH_kcal;
+using natural::kXia1998RnaMotif;
 using natural::kXia1998RnaWcStackMean_dH_kcal;
 using natural::kXia1998RnaWcStackMean_dS_cal;
 using natural::kXia1998RnaWcStacks;
@@ -420,4 +422,87 @@ TEST(NnMotifTables, Lu2006HairpinNTable)
     EXPECT_NEAR(lu2006_hairpin_initiation_dH_kcal(12), 5.0, 1e-12);
     EXPECT_FALSE(lookup_lu2006_rna_hairpin(0).has_value());
     EXPECT_NEAR(lookup_lu2006_rna_hairpin(-1)->dH_kcal, 4.8, 1e-12);
+}
+
+// ── Per-SSClass contracts (follow-up to merged #471 PoseHelixThermoRewrite) ──
+
+TEST(SSClassRnaStemLoop, Xia1998SequenceMatchedStackTimesWIsNotSeminarMinus1p2)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    PoseView pose = one_contact(ContactKind::RNA_STEM_STACK, 2.0, /*nt=*/3, /*res=*/-1);
+    pose.contacts[0].motif = "GC/CG";
+    const auto mix = rewrite_local_thermo_from_poses(
+        {pose}, {rna_loop("hp", 0, 10)}, cfg);
+    ASSERT_EQ(mix.n_poses_used, 1);
+    EXPECT_EQ(mix.per_element.at(0).ss, SSClass::RNA_STEM_LOOP);
+    EXPECT_NEAR(mix.dH_kcal, 2.0 * -14.88, 1e-12);
+    EXPECT_NE(mix.dH_kcal, -1.2);
+    EXPECT_NE(mix.dH_kcal, 2.0 * -1.2);
+    for (std::size_t i = 0; i < kXia1998RnaMotif.size(); ++i) {
+        const auto row = lookup_xia1998_rna(kXia1998RnaMotif[i]);
+        ASSERT_TRUE(row.has_value()) << kXia1998RnaMotif[i];
+        EXPECT_NEAR(row->dH_kcal, kXia1998RnaWcStacks[i].dH_kcal, 1e-12);
+        EXPECT_NE(row->dH_kcal, -1.2) << kXia1998RnaMotif[i];
+    }
+}
+
+TEST(SSClassDnaStemLoop, SantaLucia1998PnasTable2LiteralNeverAliasesRna)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    PoseView pose = one_contact(ContactKind::DNA_STEM_STACK, 1.0, 3, -1);
+    pose.contacts[0].motif = "AA/TT";
+    const auto mix = rewrite_local_thermo_from_poses(
+        {pose}, {dna_loop("d", 0, 10)}, cfg);
+    ASSERT_EQ(mix.n_poses_used, 1);
+    EXPECT_EQ(mix.per_element.at(0).ss, SSClass::DNA_STEM_LOOP);
+    EXPECT_NEAR(mix.dH_kcal, -7.9, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, -22.2, 1e-12);
+    EXPECT_NE(mix.dH_kcal, kXia1998RnaWcStackMean_dH_kcal);
+
+    ASSERT_EQ(kSantaLucia1998Motif.size(), 13u);
+    for (std::size_t i = 0; i < kSantaLucia1998Motif.size(); ++i) {
+        const auto row = lookup_santalucia1998_dna(kSantaLucia1998Motif[i]);
+        ASSERT_TRUE(row.has_value()) << kSantaLucia1998Motif[i];
+        EXPECT_NEAR(row->dH_kcal, kSantaLucia1998PnasTable2[i].dH_kcal, 1e-12)
+            << kSantaLucia1998Motif[i];
+        EXPECT_NEAR(row->dS_cal_per_mol_K, kSantaLucia1998PnasTable2[i].dS_cal_per_mol_K, 1e-12)
+            << kSantaLucia1998Motif[i];
+    }
+    const auto dna_gc = lookup_santalucia1998_dna("GC/CG");
+    const auto rna_gc = lookup_xia1998_rna("GC/CG");
+    ASSERT_TRUE(dna_gc.has_value());
+    ASSERT_TRUE(rna_gc.has_value());
+    EXPECT_NEAR(dna_gc->dH_kcal, -9.8, 1e-12);
+    EXPECT_NEAR(rna_gc->dH_kcal, -14.88, 1e-12);
+    EXPECT_NE(dna_gc->dH_kcal, rna_gc->dH_kcal);
+}
+
+TEST(SSClassProteinHelix, Scholtz1991DeltaHAndBackboneDeltaSFormation)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto mix = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::PROTEIN_HELIX_BB_HBOND, 1.0, -1, 12)},
+        {helix("H1", 10, 20)},
+        cfg);
+    ASSERT_EQ(mix.n_poses_used, 1);
+    EXPECT_EQ(mix.per_element.at(0).ss, SSClass::PROTEIN_HELIX);
+    EXPECT_NEAR(mix.dH_kcal, -1.3, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, -5.2, 1e-12);
+    EXPECT_NEAR(mix.dH_kcal, kScholtz1991HelixFormation_dH_kcal, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, kZavrtanik2026HelixFormation_dS_cal, 1e-12);
+}
+
+TEST(SSClassProteinSheet, MeierSeelig2008MidpointWithDistinctHelixTable)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto mix = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::PROTEIN_SHEET_BRIDGE_HBOND, 1.0, -1, 12, 40)},
+        {sheet("E1", 10, 20, 35, 45)},
+        cfg);
+    ASSERT_EQ(mix.n_poses_used, 1);
+    EXPECT_EQ(mix.per_element.at(0).ss, SSClass::PROTEIN_SHEET);
+    EXPECT_NEAR(mix.dH_kcal, -0.4, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, -1.0, 1e-12);
+    EXPECT_NEAR(mix.dH_kcal, kMeierSeelig2008SheetFold_dH_kcal, 1e-12);
+    EXPECT_NE(mix.dH_kcal, kScholtz1991HelixFormation_dH_kcal);
 }

--- a/tests/test_pose_local_thermo_rewrite.cpp
+++ b/tests/test_pose_local_thermo_rewrite.cpp
@@ -1,0 +1,292 @@
+// tests/test_pose_local_thermo_rewrite.cpp
+// Experimental PoseLocalThermoRewrite: class-specific ΔH/ΔS tables share algebra
+// only. RNA Turner-shaped ≠ DNA SantaLucia-shaped ≠ protein helix ≠ sheet.
+//
+// Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
+#include <gtest/gtest.h>
+
+#include "NATURaL/PoseLocalThermoRewrite.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+using natural::ContactKind;
+using natural::DecisionElement;
+using natural::PoseContact;
+using natural::PoseView;
+using natural::SSClass;
+using natural::delta_G_kcal;
+using natural::kCalPerKcal;
+using natural::kPoseRewrite_kB_kcal_mol_K;
+using natural::rewrite_local_thermo_from_poses;
+using natural::ss_class_for_kind;
+using natural::ss_class_name;
+using natural::table_for_ss;
+
+namespace {
+
+PoseView one_contact(ContactKind kind, double w, int nt, int res, int partner = -1)
+{
+    PoseView p;
+    p.score_kcal = 0.0;
+    PoseContact c;
+    c.kind = kind;
+    c.geometry_weight = w;
+    c.nt_index = nt;
+    c.res_index = res;
+    c.partner_res_index = partner;
+    p.contacts.push_back(c);
+    return p;
+}
+
+DecisionElement rna_loop(const std::string& label, int lo, int hi)
+{
+    DecisionElement el;
+    el.ss = SSClass::RNA_STEM_LOOP;
+    el.label = label;
+    el.na_start = lo;
+    el.na_end = hi;
+    return el;
+}
+
+DecisionElement dna_loop(const std::string& label, int lo, int hi)
+{
+    DecisionElement el;
+    el.ss = SSClass::DNA_STEM_LOOP;
+    el.label = label;
+    el.na_start = lo;
+    el.na_end = hi;
+    return el;
+}
+
+DecisionElement helix(const std::string& label, int lo, int hi)
+{
+    DecisionElement el;
+    el.ss = SSClass::PROTEIN_HELIX;
+    el.label = label;
+    el.res_start = lo;
+    el.res_end = hi;
+    return el;
+}
+
+DecisionElement sheet(const std::string& label, int lo, int hi, int plo, int phi)
+{
+    DecisionElement el;
+    el.ss = SSClass::PROTEIN_SHEET;
+    el.label = label;
+    el.res_start = lo;
+    el.res_end = hi;
+    el.sheet_partner_start = plo;
+    el.sheet_partner_end = phi;
+    return el;
+}
+
+} // namespace
+
+TEST(PoseLocalThermoRewrite, TablesAreClassSpecific)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto& rna = table_for_ss(cfg, SSClass::RNA_STEM_LOOP);
+    const auto& dna = table_for_ss(cfg, SSClass::DNA_STEM_LOOP);
+    const auto& hx  = table_for_ss(cfg, SSClass::PROTEIN_HELIX);
+    const auto& sh  = table_for_ss(cfg, SSClass::PROTEIN_SHEET);
+
+    const int rna_stack = static_cast<int>(ContactKind::RNA_STEM_STACK);
+    const int dna_stack = static_cast<int>(ContactKind::DNA_STEM_STACK);
+    EXPECT_NEAR(rna.increments[rna_stack].dH_kcal, -1.2, 1e-12);
+    EXPECT_NEAR(dna.increments[dna_stack].dH_kcal, -1.0, 1e-12);
+    EXPECT_NE(rna.increments[rna_stack].dH_kcal, dna.increments[dna_stack].dH_kcal);
+    EXPECT_NEAR(dna.increments[rna_stack].dH_kcal, 0.0, 1e-12);
+    EXPECT_NEAR(rna.increments[dna_stack].dH_kcal, 0.0, 1e-12);
+
+    const int hx_hb = static_cast<int>(ContactKind::PROTEIN_HELIX_BB_HBOND);
+    const int sh_hb = static_cast<int>(ContactKind::PROTEIN_SHEET_BRIDGE_HBOND);
+    EXPECT_NEAR(hx.increments[hx_hb].dH_kcal, -1.5, 1e-12);
+    EXPECT_NEAR(sh.increments[sh_hb].dH_kcal, -1.8, 1e-12);
+    EXPECT_NE(hx.increments[hx_hb].dH_kcal, sh.increments[sh_hb].dH_kcal);
+    EXPECT_NE(hx.increments[hx_hb].dS_cal_per_mol_K, sh.increments[sh_hb].dS_cal_per_mol_K);
+}
+
+TEST(PoseLocalThermoRewrite, RnaStemStackDeltaHNegative)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto mix = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::RNA_STEM_STACK, 1.0, /*nt=*/3, /*res=*/-1)},
+        {rna_loop("hp", 0, 10)},
+        cfg);
+    ASSERT_EQ(mix.n_poses_used, 1);
+    EXPECT_LT(mix.dH_kcal, 0.0);
+    EXPECT_NEAR(mix.dH_kcal, -1.2, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, 0.0, 1e-12);
+    EXPECT_EQ(ss_class_name(mix.per_element.at(0).ss), std::string("RNA_STEM_LOOP"));
+}
+
+TEST(PoseLocalThermoRewrite, RnaLoopHbondDeltaSNegative)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto mix = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::RNA_LOOP_HBOND, 1.0, /*nt=*/5, /*res=*/-1)},
+        {rna_loop("hp", 0, 10)},
+        cfg);
+    ASSERT_EQ(mix.n_poses_used, 1);
+    EXPECT_LT(mix.dS_cal_per_mol_K, 0.0);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, -3.0, 1e-12);
+    EXPECT_NEAR(mix.dH_kcal, 0.0, 1e-12);
+}
+
+TEST(PoseLocalThermoRewrite, DnaStemStackUsesDnaTableNotRna)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    auto rna_pose = one_contact(ContactKind::RNA_STEM_STACK, 1.0, 3, -1);
+    auto dna_pose = one_contact(ContactKind::DNA_STEM_STACK, 1.0, 3, -1);
+    const auto rna = rewrite_local_thermo_from_poses(
+        {rna_pose}, {rna_loop("r", 0, 10)}, cfg);
+    const auto dna = rewrite_local_thermo_from_poses(
+        {dna_pose}, {dna_loop("d", 0, 10)}, cfg);
+
+    ASSERT_EQ(dna.n_poses_used, 1);
+    EXPECT_EQ(ss_class_name(dna.per_element.at(0).ss), std::string("DNA_STEM_LOOP"));
+    EXPECT_LT(dna.dH_kcal, 0.0);
+    EXPECT_NEAR(dna.dH_kcal, -1.0, 1e-12);
+    EXPECT_NEAR(rna.dH_kcal, -1.2, 1e-12);
+    EXPECT_NE(std::fabs(dna.dH_kcal), std::fabs(rna.dH_kcal));
+}
+
+TEST(PoseLocalThermoRewrite, ProteinHelixUsesHelixTable)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto mix = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::PROTEIN_HELIX_BB_HBOND, 1.0, -1, /*res=*/12)},
+        {helix("H1", 10, 20)},
+        cfg);
+    ASSERT_EQ(mix.n_poses_used, 1);
+    EXPECT_EQ(mix.per_element.at(0).ss, SSClass::PROTEIN_HELIX);
+    EXPECT_NEAR(mix.dH_kcal, -1.5, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, -1.0, 1e-12);
+    EXPECT_NE(ss_class_for_kind(ContactKind::PROTEIN_HELIX_BB_HBOND), SSClass::RNA_STEM_LOOP);
+    EXPECT_NE(ss_class_for_kind(ContactKind::PROTEIN_HELIX_BB_HBOND), SSClass::DNA_STEM_LOOP);
+}
+
+TEST(PoseLocalThermoRewrite, ProteinSheetBridgeDiffersFromHelix)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto hx = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::PROTEIN_HELIX_BB_HBOND, 1.0, -1, 12)},
+        {helix("H1", 10, 20)},
+        cfg);
+    const auto sh = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::PROTEIN_SHEET_BRIDGE_HBOND, 1.0, -1, 12, /*partner=*/40)},
+        {sheet("E1", 10, 20, 35, 45)},
+        cfg);
+    ASSERT_EQ(sh.n_poses_used, 1);
+    EXPECT_EQ(sh.per_element.at(0).ss, SSClass::PROTEIN_SHEET);
+    EXPECT_NEAR(sh.dH_kcal, -1.8, 1e-12);
+    EXPECT_NEAR(sh.dS_cal_per_mol_K, -1.5, 1e-12);
+    EXPECT_NE(sh.dH_kcal, hx.dH_kcal);
+    EXPECT_NE(sh.dS_cal_per_mol_K, hx.dS_cal_per_mol_K);
+}
+
+TEST(PoseLocalThermoRewrite, OutsideDecisionElementEmptyWhenRequired)
+{
+    auto cfg = natural::default_pose_thermo_rewrite_config();
+    cfg.require_decision_element_only = true;
+    const auto mix = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::RNA_STEM_STACK, 1.0, /*nt=*/99, -1)},
+        {rna_loop("hp", 0, 10)},
+        cfg);
+    EXPECT_TRUE(mix.empty());
+    EXPECT_EQ(mix.n_poses_used, 0);
+    EXPECT_TRUE(mix.per_element.empty());
+    EXPECT_NEAR(mix.dH_kcal, 0.0, 1e-12);
+    EXPECT_NEAR(mix.dG_kcal, 0.0, 1e-12);
+}
+
+TEST(PoseLocalThermoRewrite, TwoPoseBoltzmannMixture)
+{
+    auto cfg = natural::default_pose_thermo_rewrite_config();
+    cfg.temperature_K = 298.15;
+    cfg.top_k = 2;
+    PoseView a = one_contact(ContactKind::RNA_STEM_STACK, 1.0, 3, -1);
+    PoseView b = one_contact(ContactKind::RNA_STEM_STACK, 2.0, 4, -1);
+    a.score_kcal = -1.0;
+    b.score_kcal = -0.5;
+    const auto mix = rewrite_local_thermo_from_poses(
+        {a, b}, {rna_loop("hp", 0, 10)}, cfg);
+
+    ASSERT_EQ(mix.n_poses_used, 2);
+    ASSERT_EQ(mix.pose_weights.size(), 2u);
+
+    const double dH0 = -1.2;
+    const double dH1 = -2.4;
+    const double dG0 = delta_G_kcal(dH0, 0.0, cfg.temperature_K);
+    const double dG1 = delta_G_kcal(dH1, 0.0, cfg.temperature_K);
+    const double kT = kPoseRewrite_kB_kcal_mol_K * cfg.temperature_K;
+    const double lw0 = -dG0 / kT;
+    const double lw1 = -dG1 / kT;
+    const double m = std::max(lw0, lw1);
+    const double Z = std::exp(lw0 - m) + std::exp(lw1 - m);
+    const double p0 = std::exp(lw0 - m) / Z;
+    const double p1 = std::exp(lw1 - m) / Z;
+    EXPECT_NEAR(mix.pose_weights[0], p0, 1e-10);
+    EXPECT_NEAR(mix.pose_weights[1], p1, 1e-10);
+    EXPECT_NEAR(mix.dH_kcal, p0 * dH0 + p1 * dH1, 1e-10);
+    EXPECT_NEAR(mix.pose_weights[0] + mix.pose_weights[1], 1.0, 1e-12);
+}
+
+TEST(PoseLocalThermoRewrite, NoNaNAndDocumentedUnits)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const std::vector<PoseView> poses = {
+        one_contact(ContactKind::RNA_STEM_STACK, 1.0, 2, -1),
+        one_contact(ContactKind::DNA_STEM_STACK, 1.0, 2, -1),
+        one_contact(ContactKind::PROTEIN_HELIX_PACKING, 1.0, -1, 11),
+        one_contact(ContactKind::PROTEIN_SHEET_SHEAR, 1.0, -1, 12, 40),
+    };
+    const std::vector<DecisionElement> els = {
+        rna_loop("r", 0, 10),
+        dna_loop("d", 0, 10),
+        helix("h", 0, 20),
+        sheet("e", 0, 20, 30, 50),
+    };
+    const auto mix = rewrite_local_thermo_from_poses(poses, els, cfg);
+    EXPECT_TRUE(std::isfinite(mix.dH_kcal));
+    EXPECT_TRUE(std::isfinite(mix.dS_cal_per_mol_K));
+    EXPECT_TRUE(std::isfinite(mix.dG_kcal));
+    for (double w : mix.pose_weights)
+        EXPECT_TRUE(std::isfinite(w));
+    for (const auto& p : mix.per_element) {
+        EXPECT_TRUE(std::isfinite(p.dH_kcal));
+        EXPECT_TRUE(std::isfinite(p.dS_cal_per_mol_K));
+        EXPECT_TRUE(std::isfinite(p.dG_kcal));
+        EXPECT_NEAR(p.dG_kcal,
+                    p.dH_kcal - cfg.temperature_K * (p.dS_cal_per_mol_K / kCalPerKcal),
+                    1e-12);
+    }
+    EXPECT_NEAR(mix.dG_kcal,
+                mix.dH_kcal - cfg.temperature_K * (mix.dS_cal_per_mol_K / kCalPerKcal),
+                1e-12);
+}
+
+TEST(PoseLocalThermoRewrite, ProteinOtherDoesNotRewriteByDefault)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    DecisionElement other;
+    other.ss = SSClass::PROTEIN_OTHER;
+    other.label = "loop";
+    other.res_start = 0;
+    other.res_end = 50;
+    PoseView pose = one_contact(ContactKind::PROTEIN_HELIX_BB_HBOND, 1.0, -1, 10);
+    const auto mix = rewrite_local_thermo_from_poses({pose}, {other}, cfg);
+    EXPECT_TRUE(mix.empty());
+}
+
+TEST(PoseLocalThermoRewrite, RnaKindOnDnaElementIsIgnored)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto mix = rewrite_local_thermo_from_poses(
+        {one_contact(ContactKind::RNA_STEM_STACK, 1.0, 3, -1)},
+        {dna_loop("d", 0, 10)},
+        cfg);
+    EXPECT_TRUE(mix.empty());
+}

--- a/tests/test_pose_local_thermo_rewrite.cpp
+++ b/tests/test_pose_local_thermo_rewrite.cpp
@@ -1,6 +1,6 @@
 // tests/test_pose_local_thermo_rewrite.cpp
 // Experimental PoseLocalThermoRewrite: class-specific ΔH/ΔS tables share algebra
-// only. RNA Turner-shaped ≠ DNA SantaLucia-shaped ≠ protein helix ≠ sheet.
+// only. Xia 1998 RNA ≠ SantaLucia 2004 DNA ≠ Scholtz 1991 helix ≠ sheet gaps.
 //
 // Copyright 2026 Le Bonhomme Pharma. SPDX-License-Identifier: Apache-2.0
 #include <gtest/gtest.h>
@@ -18,7 +18,13 @@ using natural::PoseView;
 using natural::SSClass;
 using natural::delta_G_kcal;
 using natural::kCalPerKcal;
+using natural::kExperimentalGapIncrement;
 using natural::kPoseRewrite_kB_kcal_mol_K;
+using natural::kSantaLucia2004DnaNnMean_dH_kcal;
+using natural::kSantaLucia2004DnaNnMean_dS_cal;
+using natural::kScholtz1991HelixFormation_dH_kcal;
+using natural::kXia1998RnaWcStackMean_dH_kcal;
+using natural::kXia1998RnaWcStackMean_dS_cal;
 using natural::rewrite_local_thermo_from_poses;
 using natural::ss_class_for_kind;
 using natural::ss_class_name;
@@ -94,21 +100,29 @@ TEST(PoseLocalThermoRewrite, TablesAreClassSpecific)
 
     const int rna_stack = static_cast<int>(ContactKind::RNA_STEM_STACK);
     const int dna_stack = static_cast<int>(ContactKind::DNA_STEM_STACK);
-    EXPECT_NEAR(rna.increments[rna_stack].dH_kcal, -1.2, 1e-12);
-    EXPECT_NEAR(dna.increments[dna_stack].dH_kcal, -1.0, 1e-12);
+    EXPECT_NEAR(rna.increments[rna_stack].dH_kcal, kXia1998RnaWcStackMean_dH_kcal, 1e-12);
+    EXPECT_NEAR(rna.increments[rna_stack].dS_cal_per_mol_K,
+                kXia1998RnaWcStackMean_dS_cal, 1e-12);
+    EXPECT_NEAR(dna.increments[dna_stack].dH_kcal, kSantaLucia2004DnaNnMean_dH_kcal, 1e-12);
+    EXPECT_NEAR(dna.increments[dna_stack].dS_cal_per_mol_K,
+                kSantaLucia2004DnaNnMean_dS_cal, 1e-12);
     EXPECT_NE(rna.increments[rna_stack].dH_kcal, dna.increments[dna_stack].dH_kcal);
+    EXPECT_NE(rna.increments[rna_stack].dS_cal_per_mol_K,
+              dna.increments[dna_stack].dS_cal_per_mol_K);
     EXPECT_NEAR(dna.increments[rna_stack].dH_kcal, 0.0, 1e-12);
     EXPECT_NEAR(rna.increments[dna_stack].dH_kcal, 0.0, 1e-12);
 
     const int hx_hb = static_cast<int>(ContactKind::PROTEIN_HELIX_BB_HBOND);
     const int sh_hb = static_cast<int>(ContactKind::PROTEIN_SHEET_BRIDGE_HBOND);
-    EXPECT_NEAR(hx.increments[hx_hb].dH_kcal, -1.5, 1e-12);
-    EXPECT_NEAR(sh.increments[sh_hb].dH_kcal, -1.8, 1e-12);
+    EXPECT_NEAR(hx.increments[hx_hb].dH_kcal, kScholtz1991HelixFormation_dH_kcal, 1e-12);
+    EXPECT_NEAR(hx.increments[hx_hb].dS_cal_per_mol_K, 0.0, 1e-12);
+    EXPECT_NEAR(sh.increments[sh_hb].dH_kcal, kExperimentalGapIncrement.dH_kcal, 1e-12);
+    EXPECT_NEAR(sh.increments[sh_hb].dS_cal_per_mol_K,
+                kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
     EXPECT_NE(hx.increments[hx_hb].dH_kcal, sh.increments[sh_hb].dH_kcal);
-    EXPECT_NE(hx.increments[hx_hb].dS_cal_per_mol_K, sh.increments[sh_hb].dS_cal_per_mol_K);
 }
 
-TEST(PoseLocalThermoRewrite, RnaStemStackDeltaHNegative)
+TEST(PoseLocalThermoRewrite, RnaStemStackUsesXia1998Mean)
 {
     const auto cfg = natural::default_pose_thermo_rewrite_config();
     const auto mix = rewrite_local_thermo_from_poses(
@@ -117,12 +131,13 @@ TEST(PoseLocalThermoRewrite, RnaStemStackDeltaHNegative)
         cfg);
     ASSERT_EQ(mix.n_poses_used, 1);
     EXPECT_LT(mix.dH_kcal, 0.0);
-    EXPECT_NEAR(mix.dH_kcal, -1.2, 1e-12);
-    EXPECT_NEAR(mix.dS_cal_per_mol_K, 0.0, 1e-12);
+    EXPECT_LT(mix.dS_cal_per_mol_K, 0.0);
+    EXPECT_NEAR(mix.dH_kcal, kXia1998RnaWcStackMean_dH_kcal, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, kXia1998RnaWcStackMean_dS_cal, 1e-12);
     EXPECT_EQ(ss_class_name(mix.per_element.at(0).ss), std::string("RNA_STEM_LOOP"));
 }
 
-TEST(PoseLocalThermoRewrite, RnaLoopHbondDeltaSNegative)
+TEST(PoseLocalThermoRewrite, RnaLoopHbondIsExperimentalGap)
 {
     const auto cfg = natural::default_pose_thermo_rewrite_config();
     const auto mix = rewrite_local_thermo_from_poses(
@@ -130,9 +145,8 @@ TEST(PoseLocalThermoRewrite, RnaLoopHbondDeltaSNegative)
         {rna_loop("hp", 0, 10)},
         cfg);
     ASSERT_EQ(mix.n_poses_used, 1);
-    EXPECT_LT(mix.dS_cal_per_mol_K, 0.0);
-    EXPECT_NEAR(mix.dS_cal_per_mol_K, -3.0, 1e-12);
-    EXPECT_NEAR(mix.dH_kcal, 0.0, 1e-12);
+    EXPECT_NEAR(mix.dH_kcal, kExperimentalGapIncrement.dH_kcal, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
 }
 
 TEST(PoseLocalThermoRewrite, DnaStemStackUsesDnaTableNotRna)
@@ -148,9 +162,12 @@ TEST(PoseLocalThermoRewrite, DnaStemStackUsesDnaTableNotRna)
     ASSERT_EQ(dna.n_poses_used, 1);
     EXPECT_EQ(ss_class_name(dna.per_element.at(0).ss), std::string("DNA_STEM_LOOP"));
     EXPECT_LT(dna.dH_kcal, 0.0);
-    EXPECT_NEAR(dna.dH_kcal, -1.0, 1e-12);
-    EXPECT_NEAR(rna.dH_kcal, -1.2, 1e-12);
-    EXPECT_NE(std::fabs(dna.dH_kcal), std::fabs(rna.dH_kcal));
+    EXPECT_NEAR(dna.dH_kcal, kSantaLucia2004DnaNnMean_dH_kcal, 1e-12);
+    EXPECT_NEAR(dna.dS_cal_per_mol_K, kSantaLucia2004DnaNnMean_dS_cal, 1e-12);
+    EXPECT_NEAR(rna.dH_kcal, kXia1998RnaWcStackMean_dH_kcal, 1e-12);
+    EXPECT_NEAR(rna.dS_cal_per_mol_K, kXia1998RnaWcStackMean_dS_cal, 1e-12);
+    EXPECT_NE(dna.dH_kcal, rna.dH_kcal);
+    EXPECT_NE(dna.dS_cal_per_mol_K, rna.dS_cal_per_mol_K);
 }
 
 TEST(PoseLocalThermoRewrite, ProteinHelixUsesHelixTable)
@@ -162,8 +179,8 @@ TEST(PoseLocalThermoRewrite, ProteinHelixUsesHelixTable)
         cfg);
     ASSERT_EQ(mix.n_poses_used, 1);
     EXPECT_EQ(mix.per_element.at(0).ss, SSClass::PROTEIN_HELIX);
-    EXPECT_NEAR(mix.dH_kcal, -1.5, 1e-12);
-    EXPECT_NEAR(mix.dS_cal_per_mol_K, -1.0, 1e-12);
+    EXPECT_NEAR(mix.dH_kcal, kScholtz1991HelixFormation_dH_kcal, 1e-12);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
     EXPECT_NE(ss_class_for_kind(ContactKind::PROTEIN_HELIX_BB_HBOND), SSClass::RNA_STEM_LOOP);
     EXPECT_NE(ss_class_for_kind(ContactKind::PROTEIN_HELIX_BB_HBOND), SSClass::DNA_STEM_LOOP);
 }
@@ -181,10 +198,10 @@ TEST(PoseLocalThermoRewrite, ProteinSheetBridgeDiffersFromHelix)
         cfg);
     ASSERT_EQ(sh.n_poses_used, 1);
     EXPECT_EQ(sh.per_element.at(0).ss, SSClass::PROTEIN_SHEET);
-    EXPECT_NEAR(sh.dH_kcal, -1.8, 1e-12);
-    EXPECT_NEAR(sh.dS_cal_per_mol_K, -1.5, 1e-12);
+    EXPECT_NEAR(sh.dH_kcal, kExperimentalGapIncrement.dH_kcal, 1e-12);
+    EXPECT_NEAR(sh.dS_cal_per_mol_K, kExperimentalGapIncrement.dS_cal_per_mol_K, 1e-12);
+    EXPECT_NEAR(hx.dH_kcal, kScholtz1991HelixFormation_dH_kcal, 1e-12);
     EXPECT_NE(sh.dH_kcal, hx.dH_kcal);
-    EXPECT_NE(sh.dS_cal_per_mol_K, hx.dS_cal_per_mol_K);
 }
 
 TEST(PoseLocalThermoRewrite, OutsideDecisionElementEmptyWhenRequired)
@@ -217,10 +234,12 @@ TEST(PoseLocalThermoRewrite, TwoPoseBoltzmannMixture)
     ASSERT_EQ(mix.n_poses_used, 2);
     ASSERT_EQ(mix.pose_weights.size(), 2u);
 
-    const double dH0 = -1.2;
-    const double dH1 = -2.4;
-    const double dG0 = delta_G_kcal(dH0, 0.0, cfg.temperature_K);
-    const double dG1 = delta_G_kcal(dH1, 0.0, cfg.temperature_K);
+    const double dH0 = kXia1998RnaWcStackMean_dH_kcal;
+    const double dS0 = kXia1998RnaWcStackMean_dS_cal;
+    const double dH1 = 2.0 * dH0;
+    const double dS1 = 2.0 * dS0;
+    const double dG0 = delta_G_kcal(dH0, dS0, cfg.temperature_K);
+    const double dG1 = delta_G_kcal(dH1, dS1, cfg.temperature_K);
     const double kT = kPoseRewrite_kB_kcal_mol_K * cfg.temperature_K;
     const double lw0 = -dG0 / kT;
     const double lw1 = -dG1 / kT;
@@ -231,6 +250,7 @@ TEST(PoseLocalThermoRewrite, TwoPoseBoltzmannMixture)
     EXPECT_NEAR(mix.pose_weights[0], p0, 1e-10);
     EXPECT_NEAR(mix.pose_weights[1], p1, 1e-10);
     EXPECT_NEAR(mix.dH_kcal, p0 * dH0 + p1 * dH1, 1e-10);
+    EXPECT_NEAR(mix.dS_cal_per_mol_K, p0 * dS0 + p1 * dS1, 1e-10);
     EXPECT_NEAR(mix.pose_weights[0] + mix.pose_weights[1], 1.0, 1e-12);
 }
 
@@ -279,6 +299,29 @@ TEST(PoseLocalThermoRewrite, ProteinOtherDoesNotRewriteByDefault)
     PoseView pose = one_contact(ContactKind::PROTEIN_HELIX_BB_HBOND, 1.0, -1, 10);
     const auto mix = rewrite_local_thermo_from_poses({pose}, {other}, cfg);
     EXPECT_TRUE(mix.empty());
+}
+
+TEST(PoseLocalThermoRewrite, ExperimentalGapsStayUnset)
+{
+    const auto cfg = natural::default_pose_thermo_rewrite_config();
+    const auto& rna = table_for_ss(cfg, SSClass::RNA_STEM_LOOP);
+    const auto& dna = table_for_ss(cfg, SSClass::DNA_STEM_LOOP);
+    const auto& hx  = table_for_ss(cfg, SSClass::PROTEIN_HELIX);
+    const auto& sh  = table_for_ss(cfg, SSClass::PROTEIN_SHEET);
+
+    const auto zero = [](const natural::ThermoIncrementTable& t, ContactKind kind) {
+        const auto& inc = t.increments[static_cast<int>(kind)];
+        EXPECT_NEAR(inc.dH_kcal, 0.0, 1e-12);
+        EXPECT_NEAR(inc.dS_cal_per_mol_K, 0.0, 1e-12);
+    };
+    zero(rna, ContactKind::RNA_LOOP_HBOND);
+    zero(dna, ContactKind::DNA_LOOP_HBOND);
+    zero(dna, ContactKind::DNA_INTERCALATION);
+    zero(hx, ContactKind::PROTEIN_HELIX_PACKING);
+    zero(hx, ContactKind::PROTEIN_HELIX_CLASH);
+    zero(sh, ContactKind::PROTEIN_SHEET_BRIDGE_HBOND);
+    zero(sh, ContactKind::PROTEIN_SHEET_HYDROPHOBIC_PACK);
+    zero(sh, ContactKind::PROTEIN_SHEET_SHEAR);
 }
 
 TEST(PoseLocalThermoRewrite, RnaKindOnDnaElementIsIgnored)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to **merged PR #471** (`a4096559`, `PoseHelixThermoRewrite`). Branch is **restarted from current `main`** (0 behind, 4 commits ahead). `#471` files stay; this PR does not duplicate the RNA atom-coord sidecar.

**PoseLocalThermoRewrite** extends that 2014 ligand coupling to class-specific tables. Same algebra (`ΔG = ΔH − TΔS`, geometry weight `w`, Boltzmann mixture); **different tables**. Experimental, **default OFF**. Does **not** feed `G_natural` or Astex claim metrics.

| `SSClass` | Table | DOIs |
|-----------|--------|------|
| `RNA_STEM_LOOP` | Xia 1998 INN-HB dimers × `w` (not seminar −1.2); Lu/Mathews 2006 hairpin initiation ΔH°(*n*); NNDB | doi:10.1021/bi9809425 ; doi:10.1093/nar/gkl472 ; doi:10.1093/nar/gkp892 |
| `DNA_STEM_LOOP` | SantaLucia 1998 PNAS **Table 2 literally** (never an RNA alias) | doi:10.1073/pnas.95.4.1460 |
| `PROTEIN_HELIX` | Scholtz 1991 formation ΔH ≈ −1.3 kcal mol⁻¹ res⁻¹; backbone formation ΔS ≈ −5.2 e.u. res⁻¹ | doi:10.1073/pnas.88.7.2854 ; doi:10.1016/j.bpj.2025.11.2689 |
| `PROTEIN_SHEET` | labelled experimental mid ΔH ≈ −0.4, ΔS ≈ −1.0 e.u.; Deechongkit caveat | doi:10.1021/ja077231r ; doi:10.1038/nature02611 |

Docs: `docs/POSE_LOCAL_THERMO_REWRITE.md` (tables + DOIs) and a pointer from `docs/POSE_HELIX_THERMO_REWRITE.md`. PoseHelix keeps seminar −1.2/−3.0 for RNA atom-coord geometry.

## Delta vs #471

- Keep `PoseHelixThermoRewrite.{h,cpp}` + `PoseHelixThermoRewriteTests` as merged.
- Add `PoseLocalThermoRewrite` + `NnMotifTables.h` + TSV copies under `LIB/NATURaL/data/`.
- DualAssembly: both flags default OFF; PoseLocal is diagnostic-only on `CheckpointOutcome`.

## Change class (pick **one** primary)

- [x] **Science enhancement** — opt-in; env-gated **OFF** (`flexaids::env_bool`)

## Science-Impact

- [x] gated OFF — `FLEXAIDDS_POSE_LOCAL_THERMO_REWRITE` / `DualAssemblyConfig::enable_pose_local_thermo_rewrite`

## Scope

- [x] Experimental surface only

## Release impact

- [x] affects CLI behavior (optional `--pose-local-thermo-rewrite` only)
- [x] no user-facing release impact on claim metrics

## Validation

Local (Clang 18 + GCC 13 libstdc++, commit `787c9868`):

```
ctest -R 'PoseLocalThermoRewriteTests|PoseHelixThermoRewriteTests|NATURaLTests|NascentChainSchedulerTests'
100% tests passed, 0 tests failed out of 4
```

- PoseHelixThermoRewrite **8/8** (#471 suite still green)
- PoseLocalThermoRewrite **20/20** (includes named `SSClassRnaStemLoop`, `SSClassDnaStemLoop`, `SSClassProteinHelix`, `SSClassProteinSheet`)
- NATURaLTests **53/53**
- `gh pr view 472` → `mergeable=MERGEABLE`

- [x] unit tests
- [x] documentation review

## Security and safety

- [x] no new third-party dependency
- [x] no known security-sensitive parsing change

## Reproducibility

- [x] no benchmark claim involved
- [x] benchmark language remains preliminary

## Notes

- RNA/DNA `GC/CG` dimers exist in both tables with **different** numbers (−14.88 vs −9.8); tests assert they never alias.
- This is the follow-up PR off `main` after #471 merged; a second PR with the same branch would be a duplicate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76947e8c-cdfa-4039-9902-b0a9eb78d2e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76947e8c-cdfa-4039-9902-b0a9eb78d2e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental pose-local thermodynamics rewrite for RNA, DNA, and protein secondary-structure classes.
  * Added command-line and environment controls; the feature is disabled by default.
  * Reports local ΔH, ΔS, and ΔG diagnostics without changing validated binding free-energy results.
  * Uses class-specific published thermodynamic data and clearly identifies unsupported experimental gaps.

* **Documentation**
  * Added guidance on configuration, supported models, data sources, and limitations.

* **Tests**
  * Added coverage for defaults, weighting, filtering, thermodynamic calculations, and diagnostic-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->