### PR TITLE
Update: Bump FetchContent googletest to v1.18.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1433,7 +1433,7 @@ if(BUILD_TESTING)
     # an implicitly-discovered GoogleTest win, which failed two ways:
     #
     #   * version drift — an active conda environment commonly supplies 1.11.0
-    #     (often pulled in transitively by yaml-cpp) while CI pins 1.17.0, so
+    #     (often pulled in transitively by yaml-cpp) while CI pins 1.18.0, so
     #     local and CI results were not measuring the same harness;
     #   * hard breakage — conda ships libgtest*.dylib whose install name is
     #     "@rpath/libgtest_main.<ver>.dylib", but CMake emits no LC_RPATH when an
@@ -1459,11 +1459,11 @@ if(BUILD_TESTING)
         FetchContent_Declare(
             googletest
             GIT_REPOSITORY https://github.com/google/googletest.git
-            GIT_TAG        v1.17.0
+            GIT_TAG        v1.18.0
         )
         set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
         FetchContent_MakeAvailable(googletest)
-        message(STATUS "GoogleTest: pinned FetchContent v1.17.0 (matches CI)")
+        message(STATUS "GoogleTest: pinned FetchContent v1.18.0 (matches CI)")
     endif()
 
     enable_testing()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps the pinned CMake FetchContent GoogleTest tag from `v1.17.0` to `v1.18.0` in root `CMakeLists.txt` (`GIT_TAG` plus the matching STATUS/comment). No engine, ranking, or test-source changes.

GoogleTest 1.18.0 requires C++17; FlexAIDdS already builds as C++26, so the language floor is unchanged.

Closes #470

## Change class (pick **one** primary)

- [ ] **Fix** — bug; default path unchanged, or fail-closed
- [ ] **Science enhancement** — opt-in; env-gated **OFF** (`flexaids::env_bool`)
- [ ] **Engine/code** — LIB/src behavior that is not a science gate
- [ ] **Docs / audit / swarm pack** — `docs/swarm/`, `docs/audit/` (own PR; do not mix with LIB)
- [ ] **Benchmark harness / frozen referee**
- [x] **CI / hygiene**

`python3 scripts/classify_diff.py` reports `engine_critical` only because it buckets root `CMakeLists.txt` that way. This diff is the googletest pin and two matching strings; it cannot move docked coordinates or CF ranking.

## Science-Impact

- [x] none (cannot move docked coordinates or CF ranking)
- [ ] gated OFF — flag name: `FLEXAIDDS_…`
- [ ] default-path (requires METHODOLOGY.md §1 parity)

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [x] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [x] no user-facing release impact

## Validation

- [x] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [ ] documentation review
- [x] manual validation

Local configure/build against GCC 14 + CMake 4.4.3:

- FetchContent cloned `google/googletest` tag `v1.18.0` (`063de7e9 Prepare for v1.18.0`)
- CMake STATUS: `GoogleTest: pinned FetchContent v1.18.0 (matches CI)`
- Built `gtest` / `gtest_main` and four unit binaries
- `ctest` 4/4 passed: AtomPointerLifetimeTests (7), ThermoGateTests (7), StatMechTests (112), HardwareDispatchTests (86) — 212 GoogleTest cases, 0 failures

Full `cxx_core_build` matrix is left to CI on this PR.

## Security and safety

- [ ] no new third-party dependency
- [x] third-party dependency added and documented
- [x] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

Existing FetchContent GoogleTest pin only; version bump, not a new dependency.

## Reproducibility

- [x] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

Issue #470 is left open for GitHub auto-close on merge (`Closes #470`). Do not close it manually while this bump is unmerged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb9b8f29-ecc3-4296-a27b-7635eec49b05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb9b8f29-ecc3-4296-a27b-7635eec49b05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

