### PR TITLE
Fix: restore Pages deploy so /FlexAIDdS/ repo stats stay live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
       - name: Check tracked secrets and hardcoded agent paths
         run: python3 scripts/check_repo_hygiene.py
       - name: Root run-artifact guard and diff classifier
-        run: python3 -m pytest tests/test_check_root_artifacts.py tests/test_classify_diff.py tests/test_tier1_pr_needs_dock.py tests/test_coverage_gate.py -q --tb=line
+        run: python3 -m pytest tests/test_check_root_artifacts.py tests/test_classify_diff.py tests/test_tier1_pr_needs_dock.py tests/test_coverage_gate.py tests/test_site_publish_scripts.py -q --tb=line
       - name: Validate public thermodynamic claims and provenance firewall
         run: |
           python3 scripts/validate_thermo_claims.py

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+# Publish the FlexAIDdS product tree to GitHub Pages.
+#
+# The github-pages environment only allows branches `gh-pages` and `master`
+# (not `main`). Calling actions/deploy-pages from Deploy Site on main is what
+# froze https://thebonhomme.com/FlexAIDdS/ at the 2026-07-14 artifact.
+#
+# This workflow must run with github.ref = refs/heads/gh-pages.
+# Deploy Site copies this file onto gh-pages and then:
+#   gh workflow run pages.yml --ref gh-pages
+# (GITHUB_TOKEN pushes do not start other workflows, so the push trigger
+# alone is not enough when the publisher is Actions.)
+
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [gh-pages]
+  workflow_dispatch:
+
+concurrency:
+  group: github-pages-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Require product index.html
+        run: test -f index.html
+
+      - name: Stage Pages artifact
+        run: |
+          mkdir -p "${RUNNER_TEMP}/pages-artifact"
+          rsync -a --delete \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            ./ "${RUNNER_TEMP}/pages-artifact/"
+          touch "${RUNNER_TEMP}/pages-artifact/.nojekyll"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ${{ runner.temp }}/pages-artifact
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -10,27 +10,33 @@ on:
       - 'scripts/update_site_stats.py'
       - 'scripts/sync_apex_to_ghpages.sh'
       - 'scripts/sync_apex_to_usersite.sh'
+      - 'scripts/verify_live_site_stats.py'
+      - 'tests/test_site_publish_scripts.py'
       - '.github/workflows/update-site.yml'
+      - '.github/workflows/pages.yml'
   schedule:
     - cron: '0 6 * * *'    # Daily 06:00 UTC
   workflow_dispatch:
 
 concurrency:
-  group: pages
+  group: update-site
   cancel-in-progress: true
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
   issues: write
+  actions: write
 
 jobs:
   deploy-site:
     runs-on: ubuntu-latest
-    # Pages source for this repo is the gh-pages branch (thebonhomme.com/FlexAIDdS/).
-    # Do not attach the github-pages environment: protection rules have been
-    # rejecting branch "main" before any step runs, so the live site froze.
+    # Do not attach environment: github-pages. That environment's deployment
+    # branch policy allows only `gh-pages` and `master`, so a job on `main`
+    # is rejected before any step runs. That is why PR #431 removed
+    # actions/deploy-pages and the live artifact froze at 2026-07-14.
+    # Pages build_type is still "workflow", so git-pushing gh-pages does
+    # not publish. This job snapshots gh-pages, then dispatches pages.yml
+    # with --ref gh-pages (the allowed branch) to run deploy-pages.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -40,22 +46,81 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Guard publish scripts
+        run: python3 tests/test_site_publish_scripts.py
+
       # Refresh stats in this job workspace only. Do not commit them to main:
       # the old git push origin HEAD:main advanced gated SHAs (dbd93169,
       # c30e7747, de92241a) and retriggered full ci.yml on non-science commits.
-      # Live numbers go to gh-pages / the user-site repo in the sync steps below.
       - name: Update site stats (workspace only)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/update_site_stats.py
 
-      - name: Publish site to gh-pages branch
+      - name: Verify stats landed in the Pages artifact
+        run: python3 scripts/verify_live_site_stats.py --local-only --json site/assets/repo-stats.json --html site/FlexAIDdS/index.html
+
+      - name: Publish snapshot to gh-pages branch
         run: bash scripts/sync_apex_to_ghpages.sh
 
-      - name: Sync full site to user-site repo (thebonhomme.com/)
+      - name: Dispatch Pages deploy from gh-pages (allowed environment branch)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bash scripts/sync_apex_to_usersite.sh || echo "::warning::user-site sync failed (check repo permissions). gh-pages deploy still live."
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # GITHUB_TOKEN pushes do not start other workflows. Dispatch the
+          # Pages job on the allowed ref so github-pages branch policy accepts it.
+          dispatched=0
+          for attempt in 1 2 3 4 5 6 7 8; do
+            if gh workflow run pages.yml --ref gh-pages -R "${GITHUB_REPOSITORY}"; then
+              dispatched=1
+              break
+            fi
+            echo "workflow dispatch attempt ${attempt} failed; retrying..."
+            sleep 5
+          done
+          if [ "$dispatched" -ne 1 ]; then
+            echo "::error::Could not dispatch pages.yml on gh-pages"
+            exit 1
+          fi
+          sha="$(git ls-remote origin refs/heads/gh-pages | awk '{print $1}')"
+          echo "Waiting for Deploy GitHub Pages run on gh-pages@${sha}..."
+          run_id=""
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            sleep 5
+            run_id="$(
+              gh run list --workflow=pages.yml --branch=gh-pages --limit 5 \
+                --json databaseId,headSha \
+                --jq ".[] | select(.headSha == \"${sha}\") | .databaseId" \
+                | head -n 1 | tr -d '[:space:]'
+            )"
+            if [ -n "$run_id" ]; then
+              break
+            fi
+            echo "no matching pages.yml run yet (attempt ${attempt})"
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::No pages.yml run found for gh-pages@${sha}"
+            exit 1
+          fi
+          echo "Watching run ${run_id}"
+          gh run watch "$run_id" --exit-status
+
+      - name: Patch apex user-site stats (optional; never rsync the tree)
+        env:
+          USER_SITE_TOKEN: ${{ secrets.USER_SITE_TOKEN }}
+        run: bash scripts/sync_apex_to_usersite.sh
+
+      - name: Verify live /FlexAIDdS/ markers
+        run: |
+          python3 scripts/verify_live_site_stats.py \
+            --url https://lebonhommepharma.github.io/FlexAIDdS/ \
+            --json site/assets/repo-stats.json \
+            --timeout 600 --interval 15
+          python3 scripts/verify_live_site_stats.py \
+            --url https://thebonhomme.com/FlexAIDdS/ \
+            --json site/assets/repo-stats.json \
+            --timeout 180 --interval 15
 
   check-cmake-deps:
     runs-on: ubuntu-latest

--- a/CLOUDFLARE_SETUP.md
+++ b/CLOUDFLARE_SETUP.md
@@ -45,9 +45,18 @@ A second repo (`FlexAIDdS` `gh-pages`) must **not** also claim `thebonhomme.com`
 
 **Why:** The FlexAIDdS repo was also claiming `thebonhomme.com`. GitHub then served **this repo’s root `index.html`** (corporate homepage) for the URL `/FlexAIDdS/` instead of the product page in the user-site repo.
 
-### A3. Full site sync (already automated)
+### A3. How `/FlexAIDdS/` is published (do not rsync the apex repo)
 
-CI runs `scripts/sync_apex_to_usersite.sh` after each deploy. It copies the entire `site/` folder to `lebonhommepharma.github.io`. That repo is what visitors get at `/`, `/FlexAIDdS/`, `/entropy-driven/`, etc.
+`https://thebonhomme.com/FlexAIDdS/` is the FlexAIDdS **project Pages** site (`build_type: workflow`). The daily `update-site.yml` job:
+
+1. Refreshes stats in the runner workspace (does **not** commit them to `main`).
+2. Snapshots `site/FlexAIDdS/` to the `gh-pages` branch (plus `.nojekyll` and a copy of `.github/workflows/pages.yml`).
+3. Dispatches **Deploy GitHub Pages** with `--ref gh-pages`. That is required because the `github-pages` environment only allows `gh-pages` and `master` — `actions/deploy-pages` from `main` is rejected, which is why the live artifact froze at 2026-07-14. Pushing `gh-pages` alone does **not** publish while Pages is in workflow mode. `GITHUB_TOKEN` pushes also do not start other workflows, so the dispatch is the actual publish step.
+4. Optionally patches **only** `FlexAIDdS/index.html`, `flexaid-ds/index.html`, and `assets/repo-stats.json` on `lebonhommepharma.github.io` when `USER_SITE_TOKEN` is set.
+
+Never copy the whole FlexAIDdS `site/` tree onto `lebonhommepharma.github.io`. That repo is a full brand site (rive, drugs, entropy, …). A `GITHUB_TOKEN` from FlexAIDdS cannot push there anyway (403). The apex repo pulls stats itself with `.github/workflows/update-flexaidds-stats.yml`.
+
+GitHub still mounts this repo’s Pages at `/FlexAIDdS/`, which **overlays** the folder of the same name in the user-site repo. `/flexaid-ds/` is served from the user-site. To make the user-site `FlexAIDdS/` folder the live URL, disable Pages on this repo (settings; the API rejects the default Actions token).
 
 ---
 
@@ -215,9 +224,10 @@ The Mol* viewer lives on the **legacy apex** bundle (`site/app.js` + `#molstar-v
 
 | Symptom | Fix |
 |---------|-----|
-| Stub “site update in progress” | User-site out of date → re-run deploy or `GITHUB_TOKEN=$(gh auth token) bash scripts/sync_apex_to_usersite.sh` |
+| Stub “site update in progress” | User-site out of date → re-run **Deploy GitHub Pages** on `lebonhommepharma.github.io`, or `USER_SITE_TOKEN=… bash scripts/sync_apex_to_usersite.sh` (stats-only; never a full-tree rsync) |
+| `/FlexAIDdS/` shows stale stats while Deploy Site is green | Pages `build_type` is workflow; Deploy Site must dispatch `pages.yml --ref gh-pages` so `actions/deploy-pages` runs on an allowed branch. Re-run **Deploy Site**. |
 | `/FlexAIDdS/` shows corporate homepage | Delete `CNAME` on FlexAIDdS `gh-pages`; purge Cloudflare cache |
-| CI deploy fails on “stats commit” | Non-fatal now; deploy still continues. Re-run workflow if needed. |
+| CI deploy fails on “stats commit” | Stats are no longer committed to `main`. Re-run **Deploy Site**. |
 | Old paths like `/FlexAIDdS/periodic` | Use `/periodic/` instead |
 
 ---

--- a/scripts/sync_apex_to_ghpages.sh
+++ b/scripts/sync_apex_to_ghpages.sh
@@ -24,6 +24,12 @@ rsync -a --delete \
 
 # Never claim the apex custom domain from this repo.
 rm -f "$WORKTREE/CNAME"
+# Branch-deploy fallback: GitHub's Jekyll builder must not mangle the product tree.
+touch "$WORKTREE/.nojekyll"
+# Install the Pages deploy workflow onto this branch so it can be dispatched
+# with --ref gh-pages (environment policy allows gh-pages + master, not main).
+mkdir -p "$WORKTREE/.github/workflows"
+cp "$ROOT/.github/workflows/pages.yml" "$WORKTREE/.github/workflows/pages.yml"
 
 cd "$WORKTREE"
 git add -A

--- a/scripts/sync_apex_to_usersite.sh
+++ b/scripts/sync_apex_to_usersite.sh
@@ -1,38 +1,50 @@
 #!/usr/bin/env bash
-# Sync full site/ to LeBonhommePharma/lebonhommepharma.github.io (thebonhomme.com CNAME).
-# User-site Pages serves the apex domain; gh-pages alone does not update /.
+# Surgically patch repo-stat markers on lebonhommepharma.github.io.
+#
+# The apex repo is a full brand site (rive, drugs, entropy, …). Never rsync
+# --delete site/ onto it: that would wipe unrelated routes. A FlexAIDdS
+# GITHUB_TOKEN also cannot push there (403), so the durable publisher is the
+# apex workflow `.github/workflows/update-flexaidds-stats.yml`, which pulls
+# GitHub API stats itself.
+#
+# This script is an optional same-day push when USER_SITE_TOKEN (a PAT / fine-
+# grained token with contents:write on the user-site repo) is set.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SITE="$ROOT/site"
 USER_REPO="${USER_SITE_REPO:-LeBonhommePharma/lebonhommepharma.github.io}"
 WORKDIR="/tmp/usersite-sync"
-TOKEN="${GITHUB_TOKEN:-}"
+TOKEN="${USER_SITE_TOKEN:-}"
+JSON="$ROOT/site/assets/repo-stats.json"
 
 if [ -z "$TOKEN" ]; then
-  echo "GITHUB_TOKEN is required to sync $USER_REPO" >&2
+  echo "usersite sync: skipped (no USER_SITE_TOKEN)."
+  echo "Apex stats are pulled by ${USER_REPO} workflow update-flexaidds-stats.yml."
+  exit 0
+fi
+
+if [ ! -f "$JSON" ]; then
+  echo "usersite sync: missing $JSON (run update_site_stats.py first)" >&2
   exit 1
 fi
 
 rm -rf "$WORKDIR"
-git clone "https://x-access-token:${TOKEN}@github.com/${USER_REPO}.git" "$WORKDIR"
+git clone --depth 1 "https://x-access-token:${TOKEN}@github.com/${USER_REPO}.git" "$WORKDIR"
 
-rsync -a --delete \
-  --exclude '.git' \
-  "$SITE/" "$WORKDIR/"
+python3 "$ROOT/scripts/update_site_stats.py" --from-json "$JSON" --patch-tree "$WORKDIR"
 
 cd "$WORKDIR"
-git add -A
+git add -- FlexAIDdS/index.html flexaid-ds/index.html assets/repo-stats.json
 
 if git diff --staged --quiet; then
   echo "user-site sync: no changes"
 else
   git -c user.name="github-actions[bot]" \
       -c user.email="github-actions[bot]@users.noreply.github.com" \
-      commit -m "Sync full site/ from FlexAIDdS (corporate homepage + product paths)"
+      commit -m "chore: refresh FlexAIDdS repo stats from engine snapshot"
   git push origin HEAD:main
-  echo "user-site sync: pushed"
+  echo "user-site sync: pushed stats-only patch"
 fi
 
 rm -rf "$WORKDIR"

--- a/scripts/update_site_stats.py
+++ b/scripts/update_site_stats.py
@@ -213,6 +213,7 @@ def patch_html_markers(
     *,
     stars: int | None = None,
     release: str | None = None,
+    last_updated: str | None = None,
 ) -> str:
     """Patch shared semantic stat markers in an HTML file."""
     content = re.sub(
@@ -238,10 +239,10 @@ def patch_html_markers(
             count=1,
         )
 
-    today = datetime.date.today().isoformat()
+    stamp = last_updated or datetime.date.today().isoformat()
     content = re.sub(
         r'(<span[^>]*id="last-updated"[^>]*>)[^<]*(</span>)',
-        rf"\g<1>{today}\g<2>",
+        rf"\g<1>{stamp}\g<2>",
         content,
         count=1,
     )
@@ -302,12 +303,13 @@ def write_stats_json(
     *,
     stars: int | None = None,
     release: str | None = None,
+    last_updated: str | None = None,
 ) -> None:
     """Write the shared JSON snapshot consumed by both pages."""
     payload = {
         "commits": commit_count,
         "languageCount": language_count,
-        "lastUpdated": datetime.date.today().isoformat(),
+        "lastUpdated": last_updated or datetime.date.today().isoformat(),
         "languages": [
             {
                 "id": css_suffix,
@@ -400,6 +402,105 @@ def update_all(
     return changed
 
 
+USER_SITE_HTML_RELPATHS = (
+    "FlexAIDdS/index.html",
+    "flexaid-ds/index.html",
+)
+USER_SITE_STATS_JSON_RELPATH = "assets/repo-stats.json"
+
+
+def snapshot_from_json_file(path: str) -> dict:
+    """Load a repo-stats.json snapshot. Raises on missing/invalid files."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict) or not data.get("commits"):
+        raise ValueError(f"{path} is not a valid repo-stats snapshot")
+    return data
+
+
+def apply_snapshot_to_tree(
+    tree: str,
+    snapshot: dict,
+    *,
+    html_relpaths: tuple[str, ...] = USER_SITE_HTML_RELPATHS,
+    json_relpath: str = USER_SITE_STATS_JSON_RELPATH,
+) -> list[str]:
+    """Patch existing HTML markers and write repo-stats.json under *tree*.
+
+    Never deletes unrelated files. Missing optional HTML targets are skipped.
+    """
+    commit_count = int(snapshot["commits"])
+    language_count = snapshot.get("languageCount")
+    if language_count is not None:
+        language_count = int(language_count)
+    stars = snapshot.get("stars")
+    if stars is not None:
+        stars = int(stars)
+    release = snapshot.get("latestRelease")
+    last_updated = snapshot.get("lastUpdated")
+    changed: list[str] = []
+
+    for relpath in html_relpaths:
+        html_path = os.path.join(tree, relpath)
+        if not os.path.isfile(html_path):
+            print(f"Warning: {html_path} not found, skipping", file=sys.stderr)
+            continue
+        with open(html_path, "r", encoding="utf-8") as f:
+            original = f.read()
+        updated = patch_html_markers(
+            original,
+            commit_count,
+            language_count,
+            stars=stars,
+            release=release,
+            last_updated=last_updated,
+        )
+        if updated != original:
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(updated)
+            changed.append(html_path)
+
+    lang_entries = [
+        (
+            str(item["id"]),
+            str(item["name"]),
+            str(item.get("color") or "#555555"),
+            float(item["percent"]),
+        )
+        for item in snapshot.get("languages") or []
+        if isinstance(item, dict) and "id" in item and "name" in item and "percent" in item
+    ]
+    if language_count is None:
+        language_count = len(lang_entries)
+
+    json_path = os.path.join(tree, json_relpath)
+    json_original = None
+    if os.path.isfile(json_path):
+        with open(json_path, "r", encoding="utf-8") as f:
+            json_original = f.read()
+    if lang_entries:
+        write_stats_json(
+            json_path,
+            commit_count,
+            language_count,
+            lang_entries,
+            stars=stars,
+            release=release,
+            last_updated=last_updated,
+        )
+        with open(json_path, "r", encoding="utf-8") as f:
+            json_updated = f.read()
+        if json_updated != json_original:
+            changed.append(json_path)
+    elif os.path.isfile(json_path):
+        print(
+            f"Warning: snapshot has no languages; leaving {json_path} unchanged",
+            file=sys.stderr,
+        )
+
+    return changed
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Update site stats across apex + FlexAIDdS pages"
@@ -407,7 +508,40 @@ def main() -> int:
     parser.add_argument(
         "--repo", default="LeBonhommePharma/FlexAIDdS", help="GitHub repo (owner/name)"
     )
+    parser.add_argument(
+        "--from-json",
+        dest="from_json",
+        help="Use an existing repo-stats.json snapshot instead of calling GitHub",
+    )
+    parser.add_argument(
+        "--patch-tree",
+        dest="patch_tree",
+        help=(
+            "Surgically patch FlexAIDdS/index.html, flexaid-ds/index.html, and "
+            "assets/repo-stats.json under this directory. Does not rsync or delete."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.patch_tree:
+        if args.from_json:
+            snapshot = snapshot_from_json_file(args.from_json)
+        else:
+            cached = load_cached_stats()
+            if not cached:
+                print(
+                    "Error: --patch-tree requires --from-json or a local snapshot",
+                    file=sys.stderr,
+                )
+                return 1
+            snapshot = cached
+        changed = apply_snapshot_to_tree(args.patch_tree, snapshot)
+        if changed:
+            for path in changed:
+                print(f"Updated {path}")
+        else:
+            print("No changes needed")
+        return 0
 
     cached = load_cached_stats()
     remote_commits = fetch_commit_count(args.repo)

--- a/scripts/verify_live_site_stats.py
+++ b/scripts/verify_live_site_stats.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Assert FlexAIDdS hidden stat markers match a repo-stats.json snapshot.
+
+Used by update-site.yml both before upload (local HTML) and after deploy-pages
+(live https://thebonhomme.com/FlexAIDdS/). Exits 0 on match.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+MARKER_IDS = (
+    "stat-commits",
+    "stat-langs",
+    "stat-stars",
+    "last-updated",
+    "latest-release",
+)
+
+
+def parse_markers(html: str) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for marker_id in MARKER_IDS:
+        match = re.search(
+            rf'id="{re.escape(marker_id)}"[^>]*>([^<]*)<',
+            html,
+        )
+        if match:
+            found[marker_id] = match.group(1).strip()
+    return found
+
+
+def load_snapshot(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict) or "commits" not in data:
+        raise SystemExit(f"{path} is not a valid repo-stats snapshot")
+    return data
+
+
+def expected_markers(snapshot: dict) -> dict[str, str]:
+    expected = {
+        "stat-commits": str(snapshot["commits"]),
+        "stat-langs": str(snapshot.get("languageCount", "")),
+    }
+    if snapshot.get("stars") is not None:
+        expected["stat-stars"] = str(snapshot["stars"])
+    if snapshot.get("latestRelease"):
+        expected["latest-release"] = str(snapshot["latestRelease"])
+    if snapshot.get("lastUpdated"):
+        expected["last-updated"] = str(snapshot["lastUpdated"])
+    return {key: value for key, value in expected.items() if value != ""}
+
+
+def compare(actual: dict[str, str], expected: dict[str, str]) -> list[str]:
+    errors: list[str] = []
+    for key, want in expected.items():
+        got = actual.get(key)
+        if got != want:
+            errors.append(f"{key}: live={got!r} expected={want!r}")
+    return errors
+
+
+def fetch_html(url: str, timeout: int) -> str:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "FlexAIDdS-site-stats-verify",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def cache_busted_url(url: str) -> str:
+    """Append a cache-buster so CDN/HTML shells are not served stale."""
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}t={int(time.time())}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", required=True, help="Path to repo-stats.json")
+    parser.add_argument("--html", help="Local HTML to check (no network)")
+    parser.add_argument("--url", help="Live URL to fetch")
+    parser.add_argument("--local-only", action="store_true")
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--interval", type=int, default=15)
+    args = parser.parse_args()
+
+    snapshot = load_snapshot(args.json)
+    expected = expected_markers(snapshot)
+    print("expected:", expected)
+
+    if args.local_only or args.html:
+        html_path = args.html
+        if not html_path:
+            print("Error: --html is required with --local-only", file=sys.stderr)
+            return 1
+        with open(html_path, encoding="utf-8") as f:
+            html = f.read()
+        errors = compare(parse_markers(html), expected)
+        if errors:
+            print("local HTML markers do not match snapshot:", file=sys.stderr)
+            print("\n".join(errors), file=sys.stderr)
+            return 1
+        print(f"local HTML markers match {html_path}")
+        if args.local_only:
+            return 0
+
+    if not args.url:
+        return 0
+
+    deadline = time.time() + args.timeout
+    last_errors: list[str] = ["live fetch not attempted"]
+    while time.time() < deadline:
+        try:
+            html = fetch_html(cache_busted_url(args.url), timeout=30)
+            last_errors = compare(parse_markers(html), expected)
+            if not last_errors:
+                print(f"live markers match {args.url}")
+                return 0
+            print("not yet:", "; ".join(last_errors), flush=True)
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+            last_errors = [str(exc)]
+            print(f"fetch failed: {exc}", flush=True)
+        time.sleep(args.interval)
+
+    print("live markers still stale after timeout:", file=sys.stderr)
+    print("\n".join(last_errors), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_site_publish_scripts.py
+++ b/tests/test_site_publish_scripts.py
@@ -1,0 +1,154 @@
+"""Guards for the FlexAIDdS → Pages / apex stats publish path.
+
+These are pure file/regex checks. They exist because a green Deploy Site
+workflow previously left https://thebonhomme.com/FlexAIDdS/ frozen: it
+pushed gh-pages (branch snapshot) but Pages build_type is "workflow",
+deploy-pages on main is rejected by the github-pages environment (allowed
+branches: gh-pages + master), and the usersite step swallowed a 403 after
+an rsync --delete of the whole apex tree.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import update_site_stats as stats  # noqa: E402
+import verify_live_site_stats as verify  # noqa: E402
+
+WORKFLOW = (REPO_ROOT / ".github/workflows/update-site.yml").read_text(encoding="utf-8")
+PAGES = (REPO_ROOT / ".github/workflows/pages.yml").read_text(encoding="utf-8")
+USERSITE = (REPO_ROOT / "scripts/sync_apex_to_usersite.sh").read_text(encoding="utf-8")
+GHPAGES = (REPO_ROOT / "scripts/sync_apex_to_ghpages.sh").read_text(encoding="utf-8")
+
+
+class TestWorkflowDeploysPages(unittest.TestCase):
+    def test_pages_workflow_calls_deploy_pages(self) -> None:
+        self.assertIn("actions/deploy-pages@", PAGES)
+        self.assertIn("actions/upload-pages-artifact@", PAGES)
+        self.assertIn("github-pages-deploy", PAGES)
+
+    def test_pages_workflow_runs_on_allowed_refs(self) -> None:
+        self.assertIn("branches: [gh-pages]", PAGES)
+        self.assertIn("workflow_dispatch:", PAGES)
+        self.assertIn("name: github-pages", PAGES)
+
+    def test_update_site_does_not_attach_github_pages_environment(self) -> None:
+        # environment: github-pages rejects branch main (policy is gh-pages + master).
+        self.assertNotIn("name: github-pages", WORKFLOW)
+        self.assertNotIn("actions/deploy-pages@", WORKFLOW)
+
+    def test_update_site_dispatches_pages_on_gh_pages_ref(self) -> None:
+        self.assertIn("gh workflow run pages.yml --ref gh-pages", WORKFLOW)
+        self.assertIn("actions: write", WORKFLOW)
+
+    def test_does_not_swallow_usersite_failure_after_destructive_rsync(self) -> None:
+        self.assertNotIn("user-site sync failed", WORKFLOW)
+
+    def test_verifies_live_markers(self) -> None:
+        self.assertIn("verify_live_site_stats.py", WORKFLOW)
+        self.assertIn("thebonhomme.com/FlexAIDdS/", WORKFLOW)
+        self.assertIn("lebonhommepharma.github.io/FlexAIDdS/", WORKFLOW)
+
+
+class TestUsersiteScriptIsSurgical(unittest.TestCase):
+    def test_does_not_rsync_delete_site_onto_usersite(self) -> None:
+        self.assertNotIn('"$SITE/" "$WORKDIR/"', USERSITE)
+        self.assertNotIn("rsync -a --delete", USERSITE)
+
+    def test_requires_explicit_usersite_token(self) -> None:
+        self.assertIn("USER_SITE_TOKEN", USERSITE)
+        self.assertNotIn('TOKEN="${GITHUB_TOKEN:-}"', USERSITE)
+
+    def test_patches_via_update_site_stats(self) -> None:
+        self.assertIn("--patch-tree", USERSITE)
+        self.assertIn("--from-json", USERSITE)
+
+
+class TestGhpagesPublish(unittest.TestCase):
+    def test_still_publishes_product_root(self) -> None:
+        self.assertIn('"$SITE/FlexAIDdS/" "$WORKTREE/"', GHPAGES)
+        self.assertIn('rm -f "$WORKTREE/CNAME"', GHPAGES)
+
+    def test_writes_nojekyll(self) -> None:
+        self.assertIn(".nojekyll", GHPAGES)
+
+    def test_installs_pages_workflow_on_gh_pages(self) -> None:
+        self.assertIn(".github/workflows/pages.yml", GHPAGES)
+        self.assertIn("pages.yml", GHPAGES)
+
+
+class TestPatchHtmlMarkers(unittest.TestCase):
+    SAMPLE = (
+        '<span id="stat-commits" hidden>1744</span>\n'
+        '<span id="stat-langs" hidden>15</span>\n'
+        '<span id="stat-stars" hidden>9</span>\n'
+        '<span id="last-updated" hidden>2026-07-14</span>\n'
+        '<span id="latest-release" hidden>v2.0.2</span>\n'
+    )
+
+    def test_replaces_every_marker(self) -> None:
+        out = stats.patch_html_markers(
+            self.SAMPLE,
+            2553,
+            15,
+            stars=11,
+            release="v2.2.0",
+            last_updated="2026-09-08",
+        )
+        self.assertIn(">2553<", out)
+        self.assertIn(">15<", out)
+        self.assertIn(">11<", out)
+        self.assertIn(">2026-09-08<", out)
+        self.assertIn(">v2.2.0<", out)
+        self.assertNotIn("1744", out)
+        self.assertNotIn("v2.0.2", out)
+
+    def test_apply_snapshot_to_tree_is_surgical(self) -> None:
+        snapshot = {
+            "commits": 2553,
+            "languageCount": 15,
+            "lastUpdated": "2026-09-08",
+            "stars": 11,
+            "latestRelease": "v2.2.0",
+            "languages": [
+                {"id": "cpp", "name": "C++", "percent": 50.7, "color": "#f34b7d"},
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "FlexAIDdS").mkdir()
+            (root / "flexaid-ds").mkdir()
+            (root / "assets").mkdir()
+            (root / "rive").mkdir()
+            (root / "FlexAIDdS" / "index.html").write_text(self.SAMPLE, encoding="utf-8")
+            (root / "flexaid-ds" / "index.html").write_text(self.SAMPLE, encoding="utf-8")
+            (root / "rive" / "keep-me.txt").write_text("atlas\n", encoding="utf-8")
+            changed = stats.apply_snapshot_to_tree(str(root), snapshot)
+            self.assertTrue(any("FlexAIDdS/index.html" in path for path in changed))
+            self.assertTrue((root / "rive" / "keep-me.txt").is_file())
+            payload = json.loads((root / "assets" / "repo-stats.json").read_text(encoding="utf-8"))
+            self.assertEqual(payload["commits"], 2553)
+            self.assertEqual(payload["stars"], 11)
+            self.assertEqual(payload["latestRelease"], "v2.2.0")
+            self.assertEqual(payload["lastUpdated"], "2026-09-08")
+            html = (root / "FlexAIDdS" / "index.html").read_text(encoding="utf-8")
+            self.assertIn(">2553<", html)
+            self.assertIn(">v2.2.0<", html)
+
+    def test_verify_parse_markers(self) -> None:
+        found = verify.parse_markers(self.SAMPLE)
+        self.assertEqual(found["stat-commits"], "1744")
+        self.assertEqual(found["stat-stars"], "9")
+        self.assertEqual(found["latest-release"], "v2.0.2")
+        self.assertEqual(found["last-updated"], "2026-07-14")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Live `https://thebonhomme.com/FlexAIDdS/` is still the **July 2026 GitHub Pages artifact** (`stat-commits=1744`, `stat-stars=9`, `latest-release=v2.0.2`, `last-updated=2026-07-14`). Apex `assets/repo-stats.json` and `/flexaid-ds/` already show GitHub truth (`2553` / `11` / `v2.2.0` / `2026-09-08`). `origin/gh-pages` already has those same current markers — Pages is simply not serving that snapshot.

Root cause (confirmed against the live Pages API and environment policy):

- This repo’s Pages `build_type` is **workflow**, so pushing `gh-pages` does not publish.
- The `github-pages` environment allows only **`gh-pages` and `master`**, not `main`. Every `deploy-pages` attempt from `main` since at least 2026-07-27 is `failure`. PR #431 removed `actions/deploy-pages` so Deploy Site could stay green; the live artifact then froze.
- Daily `update-site.yml` still tried `rsync --delete` of the whole `site/` tree onto `lebonhommepharma.github.io`, then swallowed the 403. A 2026-09-08 dispatch staged deletions of `rive/`, `transit/`, etc. before the push failed.

This PR re-implements the apex restore patch for current `main` **without** calling `deploy-pages` from `main` (that would hit the same environment policy). Instead:

1. Refresh stats in the runner workspace (still **not** committed to `main`).
2. Snapshot `site/FlexAIDdS/` to `gh-pages` (plus `.nojekyll` and a copy of `pages.yml`).
3. Dispatch **Deploy GitHub Pages** with `gh workflow run pages.yml --ref gh-pages`, then `gh run watch`. That is the allowed ref, so `actions/deploy-pages` can replace the frozen artifact.
4. Optionally patch **only** `FlexAIDdS/index.html`, `flexaid-ds/index.html`, and `assets/repo-stats.json` on the user-site when `USER_SITE_TOKEN` is set. Never rsync `--delete` the apex tree.
5. Poll live hidden markers on `lebonhommepharma.github.io/FlexAIDdS/` and `thebonhomme.com/FlexAIDdS/` against the snapshot.

`GITHUB_TOKEN` pushes do not start other workflows, which is why the explicit dispatch is required.

## Change class (pick **one** primary)

- [x] **Fix** — bug; default path unchanged, or fail-closed
- [ ] **Science enhancement** — opt-in; env-gated **OFF** (`flexaids::env_bool`)
- [ ] **Engine/code** — LIB/src behavior that is not a science gate
- [ ] **Docs / audit / swarm pack** — `docs/swarm/`, `docs/audit/` (own PR; do not mix with LIB)
- [ ] **Benchmark harness / frozen referee**
- [ ] **CI / hygiene**

`python3 scripts/classify_diff.py origin/main HEAD` → `VERDICT: CI / hygiene`.

## Science-Impact

- [x] none (cannot move docked coordinates or CF ranking)
- [ ] gated OFF — flag name: `FLEXAIDDS_…`
- [ ] default-path (requires METHODOLOGY.md §1 parity)

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [x] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

Public GitHub Pages / thebonhomme.com product page only. Apex brand routes (rive, drug-of-the-day, etc.) are not copied or deleted.

## Release impact

- [ ] affects CLI behavior
- [ ] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [ ] affects installation instructions
- [x] no user-facing release impact

(Marketing site HTML shell only.)

## Validation

- [x] unit tests — `python3 -m pytest tests/test_site_publish_scripts.py` (15 passed); wired into FlexAID CI hygiene job
- [ ] integration tests
- [ ] smoke benchmark
- [x] documentation review — `CLOUDFLARE_SETUP.md` A3 / troubleshooting
- [x] manual validation — live `/FlexAIDdS/` still 1744/v2.0.2; `/flexaid-ds/` and `origin/gh-pages` already 2553/v2.2.0; `--patch-tree` updates HTML/JSON and leaves a `rive/` file in place

Live URL after merge + Deploy Site: https://thebonhomme.com/FlexAIDdS/

Hidden markers must match GitHub truth (~2553 commits, 11 stars, v2.2.0, fresh `last-updated`).

## Security and safety

- [x] no new third-party dependency
- [ ] third-party dependency added and documented
- [x] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [x] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [ ] benchmark language remains preliminary

## Notes

- Do **not** add `environment: github-pages` to the `main` Deploy Site job. That is the freeze.
- After merge, **Deploy Site** runs on this workflow-path change and dispatches **Deploy GitHub Pages** on `gh-pages`. If that first dispatch races GitHub’s workflow index, the retry loop covers it; otherwise re-run **Deploy Site** from Actions.
- Optional: add `main` to the github-pages environment allowed branches in repo settings. This PR does not require that.
- `USER_SITE_TOKEN` is optional. Apex `/flexaid-ds/` is already current via the user-site’s own stats workflow.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49b363f7-85e7-4db5-8751-fa86bb33ff0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49b363f7-85e7-4db5-8751-fa86bb33ff0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

