### PR TITLE
validator: add FLEXAIDDS_PB_RECEPTOR=scored composition frame

### DIFF
--- a/LIB/DatasetRunner.cpp
+++ b/LIB/DatasetRunner.cpp
@@ -25,7 +25,8 @@
 #include "EnvFlags.h"       // flexaids::env_bool — one parser for FLEXAIDDS_* switches
 // Receptor-frame provenance for the validator. Gates
 // FLEXAIDDS_WRITE_FLEXED_RECEPTOR (engine writes the as-scored receptor) and
-// FLEXAIDDS_PB_RECEPTOR=crystal|flexed (which receptor PoseBusters is handed).
+// FLEXAIDDS_PB_RECEPTOR=crystal|flexed|scored (which receptor PoseBusters is
+// handed; "scored" is the as-scored WATER/composition frame, valid on a rigid arm).
 // Header-only, no flexaid.h dependency, DEFAULT crystal = today's behaviour.
 #include "flexed_receptor.h"
 #include "shell_exec.h"
@@ -283,6 +284,41 @@ static int deterministic_ga_seed(const std::string& target_id, int restart,
                                  std::uint64_t seed_base = 0) {
     const std::uint64_t stream = seed_base ^ static_cast<std::uint64_t>(restart);
     return 1 + static_cast<int>(stable_seed_hash(target_id, stream) % 2147483646ULL);
+}
+
+/// Read the as-scored companion's OWN count of residues sitting off their input
+/// rotamer (the REMARK the writer emits in cluster.cpp).
+///
+/// Returns -1 when the file cannot be opened or the REMARK is absent, which is
+/// deliberately NOT folded into 0: zero means "the engine moved no side chain",
+/// absent means "this file did not come from a writer that records it". A
+/// rigid-arm water-set verdict is only interpretable if those two are
+/// distinguishable, so the caller reports -1 as unknown rather than as rigid.
+///
+/// Reads NOTHING about receptor composition — it does not count waters and does
+/// not look at a B-factor. modify_pdb.cpp decides composition; this only echoes
+/// a number the engine already wrote. The key literal is shared with the writer
+/// via flexed_receptor.h so the two halves cannot drift.
+static int companion_n_res_off_input_rotamer(const std::string& companion_path)
+{
+    if (companion_path.empty()) return -1;
+    std::ifstream in(companion_path);
+    if (!in) return -1;
+    const std::string key =
+        flexaids::flexed_receptor::remark_key_n_res_off_rotamer();
+    std::string line;
+    // The REMARK block is the file header. Stop at the first coordinate record
+    // so this never scans thousands of ATOM lines looking for a key that a
+    // foreign PDB was never going to contain.
+    while (std::getline(in, line)) {
+        if (line.compare(0, 6, "ATOM  ") == 0 ||
+            line.compare(0, 6, "HETATM") == 0) break;
+        if (line.compare(0, key.size(), key) == 0) {
+            try { return std::stoi(line.substr(key.size())); }
+            catch (...) { return -1; }
+        }
+    }
+    return -1;
 }
 
 /// POSIX-shell single-quote escape for paths interpolated into `sh -c` strings.
@@ -6717,10 +6753,14 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 //    that writer — SCORED_ONLY=1 is precisely what suppressed these
                 //    coordinates for the whole campaign to date.
                 //
-                //  FLEXAIDDS_PB_RECEPTOR=crystal|flexed (HARNESS, this file) selects
-                //    which receptor validate_elected_pose() is handed. DEFAULT
+                //  FLEXAIDDS_PB_RECEPTOR=crystal|flexed|scored (HARNESS, this file)
+                //    selects which receptor validate_elected_pose() is handed. DEFAULT
                 //    "crystal" = entry.receptor_path, i.e. exactly today's call, so
                 //    every existing validity outcome is reproduced bit for bit.
+                //    "flexed" and "scored" both read the companion above; they differ
+                //    in the question asked and in what is recorded, not in the bytes
+                //    read. "scored" is the receptor COMPOSITION frame (the engine's
+                //    water set) and is the one that means something on a RIGID arm.
                 //
                 // WHY: PoseBusters currently judges every arm against the CRYSTAL
                 // receptor. In the flexible arm the engine moved side chains, so an
@@ -6738,7 +6778,9 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
                               << " WARNING: FLEXAIDDS_PB_RECEPTOR='"
                               << flexaids::flexed_receptor::pb_receptor_raw()
-                              << "' is not one of crystal|flexed; falling back to"
+                              << "' is not one of "
+                              << flexaids::flexed_receptor::pb_receptor_modes_csv()
+                              << "; falling back to"
                                  " crystal and recording crystal here too.\n";
                 }
                 if (write_flexed_receptor) {
@@ -6751,9 +6793,20 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
                                   << " NOTE: autoflex_max=" << autoflex_max
                                   << " -> the receptor is RIGID, so every companion"
-                                     " will equal the input receptor conformation"
+                                     " will equal the input receptor CONFORMATION"
                                      " (REMARK n_residues_off_input_rotamer 0). That is"
                                      " a useful NULL control, not an error.\n";
+                        std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
+                                  << " NOTE: equal conformation is NOT an equal FILE."
+                                     " The companion carries the receptor COMPOSITION"
+                                     " the engine scored — waters filtered by"
+                                     " protein.structural_water_bfactor_max, altloc 'A'"
+                                     " only, hydrogens removed — while the cache"
+                                     " receptor still carries all of them."
+                                     " On a rigid arm that difference is the entire"
+                                     " content of the companion, and it is what"
+                                     " FLEXAIDDS_PB_RECEPTOR=scored exists to"
+                                     " validate against.\n";
                     }
                 }
                 if (pb_receptor_cfg == "flexed") {
@@ -6783,9 +6836,69 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                         std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
                                   << " NOTE: autoflex_max=" << autoflex_max
                                   << " -> the receptor is RIGID, so the flexed frame and"
-                                     " the crystal frame are the same conformation and"
-                                     " this arm is a structural no-op. Set"
-                                     " FLEXAIDDS_AUTOFLEX_MAX>0 for the flexible arm.\n";
+                                     " the crystal frame are the same CONFORMATION, and"
+                                     " no side-chain overlap can be reattributed. Set"
+                                     " FLEXAIDDS_AUTOFLEX_MAX>0 for the flexible arm."
+                                     " This is NOT a total no-op: the two frames still"
+                                     " differ in their WATER set, so if that is what you"
+                                     " are after, ask for it by name with"
+                                     " FLEXAIDDS_PB_RECEPTOR=scored, which records"
+                                     " pb_receptor_used=scored instead of flexed.\n";
+                    }
+                }
+                // ── FLEXAIDDS_PB_RECEPTOR=scored ────────────────────────────
+                // Same companion file as "flexed", different question and a
+                // different record. See flexed_receptor.h "THE WATER SET".
+                // Valid on EVERY arm: unlike "flexed" there is no autoflex
+                // precondition, because the receptor COMPOSITION differs from
+                // the crystal file whether or not a side chain moved.
+                if (pb_receptor_cfg == "scored") {
+                    std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
+                              << " FLEXAIDDS_PB_RECEPTOR=scored -> PoseBusters judges"
+                                 " the pose against the receptor COMPOSITION the engine"
+                                 " scored, i.e. the receptor as modify_pdb() produced"
+                                 " it: waters filtered by"
+                                 " protein.structural_water_bfactor_max, alternate"
+                                 " conformation 'A' only, hydrogens removed, cofactors"
+                                 " and metals kept. The cache receptor used by default"
+                                 " carries every water and every alt-conformer, so"
+                                 " ligand-water checks there are scored against waters"
+                                 " the engine had already removed. This CHANGES validity"
+                                 " numbers by design and must be reported as its own"
+                                 " arm.\n";
+                    std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
+                              << " NOTE: this mode does no filtering of its own. It"
+                                 " selects the file the engine wrote; modify_pdb.cpp"
+                                 " remains the only place receptor composition is"
+                                 " decided.\n";
+                    if (!write_flexed_receptor) {
+                        std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
+                                  << " WARNING: FLEXAIDDS_PB_RECEPTOR=scored with"
+                                     " FLEXAIDDS_WRITE_FLEXED_RECEPTOR unset -> no"
+                                     " as-scored receptor will exist, every case will"
+                                     " fall back to the crystal receptor, and"
+                                     " validator_provenance.json will read"
+                                     " pb_receptor_used="
+                                     "\"crystal_fallback_no_scored_receptor\". Set BOTH."
+                                     " Retro-fitting an ALREADY-RUN arm is not possible"
+                                     " from here: no companion was written, so a"
+                                     " re-validation of existing poses has to be done"
+                                     " offline.\n";
+                    }
+                    if (autoflex_max <= 0) {
+                        std::cout << tui::strawberry() << "[DatasetRunner]" << tui::reset()
+                                  << " NOTE: autoflex_max=" << autoflex_max
+                                  << " -> RIGID receptor, which is the CLEANEST case for"
+                                     " this mode, not a degenerate one: side chains are"
+                                     " identical to the crystal frame, so any validity"
+                                     " delta is attributable to COMPOSITION rather than"
+                                     " to motion. Composition is not waters alone —"
+                                     " alt-conformers and hydrogens are also absent"
+                                     " (e.g. 1GPK: 529 waters AND 91 non-'A' altloc"
+                                     " atoms), so do not report a flip as water-only"
+                                     " without checking the structure. The companion's"
+                                     " REMARK n_residues_off_input_rotamer will be 0 and"
+                                     " is echoed per case on the [PB-RECEPTOR] line.\n";
                     }
                 }
                 std::ofstream jf(config_path);
@@ -6934,7 +7047,15 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                    // WHICH RECEPTOR THE VALIDATOR JUDGES THE POSE AGAINST.
                    // "crystal" (DEFAULT) = entry.receptor_path, exactly today's
                    // call, so existing validity outcomes are unchanged.
-                   // "flexed" = the as-scored companion above. Read by the HARNESS
+                   // "flexed" = the as-scored companion above, asked for as a
+                   // SIDE-CHAIN frame (needs FLEXAIDDS_AUTOFLEX_MAX>0 to mean
+                   // anything).
+                   // "scored" = the same companion, asked for as the receptor
+                   // COMPOSITION the engine scored — the waters that survived
+                   // protein.structural_water_bfactor_max above, not the full
+                   // water set of the cache receptor. Valid on a rigid arm,
+                   // where it is the only difference between the two frames.
+                   // Read by the HARNESS
                    // (this file), not by the engine, and echoed here because a
                    // validity verdict whose receptor is unrecorded is not
                    // interpretable. The per-case ground truth of what was actually
@@ -8714,18 +8835,46 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                 // scoring in the other frame would make an arm uninterpretable.
                 pb_receptor_path = entry.receptor_path;
                 pb_receptor_used = "crystal";
-                if (pb_receptor_requested == "flexed") {
+                //
+                // "scored" reads the SAME companion as "flexed" — the water-set
+                // correction was already reachable under the "flexed" name,
+                // because neither this selection nor the companion discovery
+                // above is gated on autoflex_max. What "scored" adds is a name
+                // for the water question and a distinguishable record; see
+                // flexed_receptor.h "THE WATER SET".
+                if (flexaids::flexed_receptor::pb_receptor_uses_companion(
+                        pb_receptor_requested)) {
                     if (!flexed_receptor_path.empty() &&
                         fs::exists(flexed_receptor_path)) {
                         pb_receptor_path = flexed_receptor_path;
-                        pb_receptor_used = "flexed";
+                        // Record the mode ASKED FOR, not a single shared label:
+                        // a rigid water-set arm and a flexible side-chain arm
+                        // read the same file but are not the same measurement,
+                        // and pooling them under "flexed" would make neither
+                        // recoverable from the record.
+                        pb_receptor_used = pb_receptor_requested;
                     } else {
-                        pb_receptor_used = "crystal_fallback_no_flexed_receptor";
+                        // Built from the requested mode so a new mode cannot
+                        // land without its own fallback label. For "flexed"
+                        // this yields "crystal_fallback_no_flexed_receptor",
+                        // byte-identical to HEAD, which stored arms carry.
+                        pb_receptor_used = "crystal_fallback_no_" +
+                                           pb_receptor_requested + "_receptor";
                         if (pb_receptor_note.empty()) {
+                            // Per-mode advice: AUTOFLEX_MAX>0 is a precondition
+                            // for "flexed" only. Telling a "scored" user to set
+                            // it would send them after the wrong variable.
                             pb_receptor_note =
-                                "FLEXAIDDS_PB_RECEPTOR=flexed but no as-scored "
-                                "receptor was written; is FLEXAIDDS_WRITE_FLEXED_"
-                                "RECEPTOR=1 set and FLEXAIDDS_AUTOFLEX_MAX>0?";
+                                (pb_receptor_requested == "scored")
+                                    ? "FLEXAIDDS_PB_RECEPTOR=scored but no as-scored "
+                                      "receptor was written; FLEXAIDDS_WRITE_FLEXED_"
+                                      "RECEPTOR=1 must be set on the ENGINE run that "
+                                      "produced these poses. An arm already on disk "
+                                      "cannot be retro-fitted here; re-validate its "
+                                      "poses offline instead."
+                                    : "FLEXAIDDS_PB_RECEPTOR=flexed but no as-scored "
+                                      "receptor was written; is FLEXAIDDS_WRITE_FLEXED_"
+                                      "RECEPTOR=1 set and FLEXAIDDS_AUTOFLEX_MAX>0?";
                         }
                     }
                 }
@@ -8782,6 +8931,29 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                     std::cerr << " CAVEAT=\"flexed-frame overlap does NOT check"
                                  " receptor internal geometry; read with"
                                  " FLEXAIDDS_RECEPTOR_STRAIN\"";
+                // For the water-set mode, the companion's own REMARK is what
+                // says whether this verdict is a clean water-only delta or a
+                // water delta mixed with side-chain motion. Printing the mode
+                // without that number would leave the two indistinguishable in
+                // a stderr log.
+                if (pb_receptor_used == "scored") {
+                    const int n_off =
+                        companion_n_res_off_input_rotamer(pb_receptor_path);
+                    std::cerr << " n_residues_off_input_rotamer=" << n_off;
+                    if (n_off == 0)
+                        std::cerr << " CAVEAT=\"side chains identical to the crystal"
+                                     " frame, so any validity delta is the"
+                                     " water/heteroatom set alone\"";
+                    else if (n_off > 0)
+                        std::cerr << " CAVEAT=\"" << n_off << " residue(s) off input"
+                                     " rotamer, so this verdict MIXES a water-set"
+                                     " delta with side-chain motion, and receptor"
+                                     " internal geometry is not checked; read with"
+                                     " FLEXAIDDS_RECEPTOR_STRAIN\"";
+                    else
+                        std::cerr << " CAVEAT=\"companion REMARK absent or unreadable:"
+                                     " cannot say whether side chains moved\"";
+                }
                 std::cerr << "\n";
             }
 
@@ -8895,8 +9067,10 @@ BenchmarkReport DatasetRunner::run(const std::vector<DatasetEntry>& entries,
                    // the two candidate receptors give different answers by
                    // construction. requested = the FLEXAIDDS_PB_RECEPTOR gate;
                    // used = what was actually handed to PoseBusters, which
-                   // differs when "flexed" was asked for and the engine wrote
-                   // no as-scored receptor. flexed_receptor_* are present iff
+                   // differs when a companion mode ("flexed" or "scored") was
+                   // asked for and the engine wrote no as-scored receptor — the
+                   // COMMON case on any arm run before the writer existed, not
+                   // an edge case. flexed_receptor_* are present iff
                    // the engine ran with FLEXAIDDS_WRITE_FLEXED_RECEPTOR=1.
                    << "  \"pb_receptor_requested\": \"" << pb_receptor_requested
                    << "\",\n"

--- a/LIB/cluster.cpp
+++ b/LIB/cluster.cpp
@@ -137,7 +137,13 @@ static bool write_flexed_receptor_companion(const FA_Global* FA,
 	// The one number that says whether this file differs from the input
 	// receptor at all. 0 means the search never moved a side chain, so a
 	// crystal-frame and a flexed-frame validity verdict must agree.
-	fprintf(f, "REMARK n_residues_off_input_rotamer %d\n", n_res_off_rot0);
+	// ONE literal for this key, shared with the harness reader — see
+	// flexed_receptor.h::remark_key_n_res_off_rotamer(). The key carries its own
+	// trailing space, so the emitted bytes are unchanged from the hand-written
+	// "REMARK n_residues_off_input_rotamer %d\n" this replaced.
+	fprintf(f, "%s%d\n",
+	        flexaids::flexed_receptor::remark_key_n_res_off_rotamer(),
+	        n_res_off_rot0);
 	fprintf(f, "REMARK NOTE this file records the receptor STATE only; it makes"
 	           " no claim that the state is physical. Read a flexed-frame"
 	           " validity verdict together with FLEXAIDDS_RECEPTOR_STRAIN.\n");

--- a/LIB/flexaidds_flags.cpp
+++ b/LIB/flexaidds_flags.cpp
@@ -206,7 +206,15 @@ void seed_runtime_gates() {
         // Receptor frame handed to PoseBusters (DatasetRunner.cpp).
         // "crystal" (default) = entry.receptor_path, i.e. today's behaviour and
         // today's validity numbers; "flexed" = the as-scored receptor written by
-        // FLEXAIDDS_WRITE_FLEXED_RECEPTOR. Any other value falls back to crystal.
+        // FLEXAIDDS_WRITE_FLEXED_RECEPTOR, asked for as a SIDE-CHAIN frame;
+        // "scored" = that same file, asked for as the receptor COMPOSITION the
+        // engine scored — the receptor as modify_pdb() produced it: waters
+        // filtered by protein.structural_water_bfactor_max, altloc 'A' only,
+        // hydrogens removed. On a rigid arm that composition is the ONLY
+        // difference from the crystal receptor. Any other value falls back to
+        // crystal. Both non-default modes require FLEXAIDDS_WRITE_FLEXED_RECEPTOR
+        // on the engine run, else every case falls back and says so in
+        // validator_provenance.json -> pb_receptor_used.
         "FLEXAIDDS_PB_RECEPTOR",
         "FLEXAIDDS_CLUSTER_REP",
         "FLEXAIDDS_FITNESS_MODEL",

--- a/LIB/flexed_receptor.h
+++ b/LIB/flexed_receptor.h
@@ -3,7 +3,7 @@
 //                     choose which receptor frame it judges the pose in
 //
 //   gates: FLEXAIDDS_WRITE_FLEXED_RECEPTOR  (engine, DEFAULT OFF)
-//          FLEXAIDDS_PB_RECEPTOR=crystal|flexed (harness, DEFAULT crystal)
+//          FLEXAIDDS_PB_RECEPTOR=crystal|flexed|scored (harness, DEFAULT crystal)
 //
 // Apache-2.0 (c) 2026 Le Bonhomme Pharma
 //
@@ -33,6 +33,75 @@
 // 2. FLEXAIDDS_PB_RECEPTOR selects which of those two receptors the validator
 //    is handed. It defaults to "crystal", so today's validity outcomes are
 //    reproduced EXACTLY and no published number moves.
+//
+// THE WATER SET — why "flexed" was not enough, and what "scored" is for
+// ---------------------------------------------------------------------
+// The header above frames the crystal/as-scored difference as a SIDE-CHAIN
+// difference, and concludes that on a RIGID arm the two frames are the same
+// conformation and selecting the companion is a structural no-op. The
+// conformation claim is true. The no-op conclusion is FALSE, and it hid a
+// measured defect for an entire campaign.
+//
+// The receptor the engine scores is not the receptor file on disk. Every Astex
+// arm runs with protein.remove_water=true, keep_structural_waters=true,
+// structural_water_bfactor_max=20, so modify_pdb() (modify_pdb.cpp:157-166)
+// drops every water with B > 20 while writing the temp receptor that read_pdb()
+// then parses into atoms[]/residue[]. The validator, meanwhile, was handed
+// entry.receptor_path — the cache receptor, with EVERY water still in it.
+//
+// So on a rigid arm the two frames differ by exactly the discarded waters, and
+// PoseBusters was scoring ligand-water clashes against waters the engine had
+// already removed. Measured over 84 Astex targets per arm, water checks were
+// 45 of 70 failures (guard) and 50 of 67 (seed2): minimum_distance_to_waters
+// 38/41 and volume_overlap_with_waters 7/9. Re-validating offline against a
+// B<=20-filtered receptor flipped 6 targets per arm from fail to pass. The cut
+// is structure-dependent and large: 1GPK keeps 0 of 529 waters, 2BSM 0 of 247,
+// 1XOZ 36 of 352, 1K3U 123 of 712, 1JD0 156 of 504.
+//
+// The companion already carries the right water set, because it serialises the
+// in-memory atoms[] the filtered temp file produced — verified on the one
+// rigid-arm companion that exists on this box: 1JD0_1_receptor.pdb has 156 HOH
+// atom lines and 4325 atom lines total, against 504 HOH and 4673 total in
+// cache_v2/astex_diverse/1JD0/1JD0_apo.pdb, and 504-156 = 4673-4325 = 348. The
+// companion IS the apo file minus precisely the waters the engine discarded.
+//
+// WATERS ARE NOT THE ONLY COMPOSITION DIFFERENCE. modify_pdb() also strips
+// hydrogens and keeps only alternate conformation 'A' (see its own banner:
+// "Hydrogens are removed", "'A' alternate conformation ONLY is chosen"), and
+// that is measurable: 1GPK's cache receptor carries 91 atoms with an altloc
+// other than 'A', and the companion carries none of them. On 1GPK the companion
+// is 4162 atoms against the apo's 4782 = 529 waters + 91 alt-conformers + 4162.
+// Both files then agree atom-for-atom on the remainder (C 2683, N 702, O 755,
+// S 22). 1JD0 has no altlocs and no hydrogens, which is why its arithmetic is
+// water-only.
+//
+// So the honest statement of what "scored" gives you is the receptor
+// COMPOSITION as modify_pdb produced it — water-filtered by B-factor, altloc-A
+// only, hydrogen-free — not "the same file minus some waters". On a structure
+// with alternate conformations, attributing a validity flip to waters alone
+// would be wrong; the attributable quantity is the composition, and the water
+// term is merely the largest part of it on most Astex targets.
+//
+// Mode "scored" is therefore not a new mechanism — it selects the same
+// companion file "flexed" selects. It exists because:
+//   * the two modes answer different questions. "flexed" asks "did this pose
+//     clash in the side-chain state it was scored in", which is a FLEXIBLE-arm
+//     question and needs FLEXAIDDS_AUTOFLEX_MAX>0 to mean anything. "scored"
+//     asks "was this pose judged against the receptor composition the engine
+//     actually saw", which is a question on EVERY arm, rigid included.
+//   * the announce text for "flexed" tells a rigid-arm user the mode is a
+//     no-op and to go set AUTOFLEX_MAX. That advice is correct for attributing
+//     a side-chain overlap and wrong for the water confound, and a user
+//     chasing water failures has no reason to reach for a flag called
+//     "flexed".
+//   * pb_receptor_used must distinguish them in the record. A rigid arm
+//     validated against the engine's water set is not a flexed-side-chain arm,
+//     and labelling it "flexed" would make the two uncombinable in analysis.
+// What "scored" does NOT do: it does not filter anything itself. modify_pdb.cpp
+// remains the single source of truth for receptor composition; a second
+// B-factor comparison in the harness is the defect that let this project's
+// Cartesian and torsional entropy bases drift apart, and it is not repeated
+// here.
 //
 // NEITHER GATE TOUCHES SCORING. No CF channel, no REMARK on the pose, no
 // existing artifact. With both unset the engine and the harness are
@@ -104,22 +173,56 @@ inline std::string pb_receptor_raw()
     return v;
 }
 
+/// The mode set this build understands, as one string, for every human-facing
+/// message. Warning text that lists the modes by hand drifts the moment a mode
+/// is added — that is exactly how "crystal|flexed" survived the addition of a
+/// third mode in the first draft of this change.
+inline const char* pb_receptor_modes_csv() noexcept { return "crystal|flexed|scored"; }
+
 /// True only when FLEXAIDDS_PB_RECEPTOR names a mode this build understands.
 /// An unset variable is "recognised" (it selects the documented default).
 inline bool pb_receptor_recognised()
 {
     const std::string v = pb_receptor_raw();
-    return v.empty() || v == "crystal" || v == "flexed";
+    return v.empty() || v == "crystal" || v == "flexed" || v == "scored";
 }
 
 /// Harness gate: which receptor the validator is handed.
 /// "crystal" (DEFAULT, and the value returned for any unrecognised input, so a
-/// typo can never silently move a validity number) or "flexed".
+/// typo can never silently move a validity number), "flexed", or "scored".
 inline std::string pb_receptor_mode()
 {
     const std::string v = pb_receptor_raw();
     if (v == "flexed") return "flexed";
+    if (v == "scored") return "scored";
     return "crystal";
+}
+
+/// True for the modes whose receptor is the ENGINE'S as-scored companion rather
+/// than the crystal input file. Both "flexed" and "scored" select the same
+/// file — they differ in intent and in what gets recorded, not in the bytes
+/// they read (see THE WATER SET, above).
+///
+/// This predicate exists so the selection site, the announce block and the
+/// provenance writer cannot disagree about which modes need a companion. A
+/// fourth mode added to pb_receptor_mode() without being added here is a
+/// half-wired mode that silently validates against the crystal receptor, which
+/// is the failure shape this whole file exists to prevent.
+inline bool pb_receptor_uses_companion(const std::string& mode)
+{
+    return mode == "flexed" || mode == "scored";
+}
+
+/// The REMARK key carrying the number of residues sitting off their input
+/// rotamer, written by the companion writer (cluster.cpp) and read back by the
+/// harness. ONE literal, shared by writer and reader, including the trailing
+/// space: a companion whose key the reader cannot find is indistinguishable
+/// from a companion with zero moved side chains, and those two mean opposite
+/// things when you are deciding whether a validity delta came from the water
+/// set or from side-chain motion.
+inline const char* remark_key_n_res_off_rotamer() noexcept
+{
+    return "REMARK n_residues_off_input_rotamer ";
 }
 
 /// Directory that holds the as-scored receptor companion for `pose_pdb_path`.


### PR DESCRIPTION
## Summary

Adds `FLEXAIDDS_PB_RECEPTOR=scored` — the as-scored receptor **composition** frame (waters + altloc-A), gated by Science Option A child after seed3 completed 84/84.

Science gates: **32/32 PASS**. Case A holds: companion is already post-water-filter; no pose-writer change. `scored` is not water-only. Existing guard/seed2/seed3 arms cannot be retro-fixed with this flag (offline revalidation only).

Commit: `0e28352d` (rebased onto current main).

Gate artifacts also copied to `~/Downloads/pb_receptor_scored_gates/`.

## Change class

- [x] **Science enhancement** — opt-in; env-gated **OFF** by default

## Science-Impact

- [x] gated OFF — `FLEXAIDDS_PB_RECEPTOR=scored`

## Test plan

- [ ] Confirm default path unchanged when flag unset
- [ ] Re-run / review `pb_receptor_gates.sh` results (32/32)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in only, but when enabled it changes PoseBusters validity outcomes and provenance semantics; harness validation path must stay consistent with companion availability from engine runs.
> 
> **Overview**
> Adds **`FLEXAIDDS_PB_RECEPTOR=scored`**, an opt-in PoseBusters receptor frame that judges poses against the **as-scored receptor composition** (the same companion PDB as `flexed`, but named and recorded for the water/altloc/hydrogen set the engine actually scored—not the full cache receptor).
> 
> **`flexed_receptor.h`** now recognizes `scored`, exposes `pb_receptor_modes_csv()`, `pb_receptor_uses_companion()` (both `flexed` and `scored` share companion selection), and a shared **`remark_key_n_res_off_rotamer()`** so writer and reader cannot drift.
> 
> **`DatasetRunner`** unifies companion picking for both modes, records **`pb_receptor_used`** as the requested mode (`scored` vs `flexed`), uses mode-specific **`crystal_fallback_no_<mode>_receptor`** labels and tailored warnings, adds startup/config commentary for `scored`, and logs **`n_residues_off_input_rotamer`** on `[PB-RECEPTOR]` when `scored` is used so rigid water-only deltas are separable from mixed side-chain motion.
> 
> **`cluster.cpp`** emits the rotamer-off count REMARK via the shared key literal (byte-identical output). Flag registry docs in **`flexaidds_flags.cpp`** document the third enum value. Default **`crystal`** behavior is unchanged when the env var is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625576af2f01ec138661052dd175d5eb1304b91e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `scored` receptor mode for PoseBusters validation, representing the receptor composition used during scoring, including the selected water set and structural details.
  * Validation output now reports how many residues differ from their input rotamer in scored mode, helping distinguish water-only changes from side-chain changes.
  * Improved fallback reporting identifies the requested receptor mode when the corresponding receptor data is unavailable.

* **Documentation**
  * Updated configuration and provenance documentation to describe all supported receptor modes and their requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->