### PR TITLE
Docs: Unify public vehicles on proxy_only claim language

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Astex-85](https://img.shields.io/badge/Astex--85-unverified%20%7C%20pending%20receipt-lightgrey.svg)](#benchmark-astex-85)
 [![DOI](https://img.shields.io/badge/DOI-10.1021%2Facs.jcim.5b00078-blue)](https://doi.org/10.1021/acs.jcim.5b00078)
 
-**[Installation](docs/INSTALLATION.md)** ·
+**[Installation](docs/INSTALL.md)** ·
 **[User Guide](docs/USERGUIDE.md)** ·
 **[Scoring](docs/SCORING.md)** ·
 **[Atom Types](docs/ATOM_TYPES.md)** ·
@@ -32,7 +32,7 @@ FlexAID∆S descends from [FlexAID](https://doi.org/10.1021/acs.jcim.5b00078) (G
 
 ### The Contact Function
 
-The genetic algorithm searches ligand pose space — six rigid-body degrees of freedom plus all rotatable torsions — and evaluates each pose with the **Voronoi contact function** (CF). CF measures shape complementarity by decomposing the molecular surface into Voronoi polyhedra and integrating the contact area between atom pairs, weighted by a 40×40 energy matrix (`MC_st0r5.2_6.dat`) trained on PDB-derived contact statistics across 40 SYBYL atom types. Lower CF is better — a perfect complementary fit between a ligand and its receptor pocket approaches the global minimum.
+The genetic algorithm searches ligand pose space — six rigid-body degrees of freedom plus all rotatable torsions — and evaluates each pose with the **CF/contact-function scoring proxy** (Voronoi contact function). CF measures shape complementarity by decomposing the molecular surface into Voronoi polyhedra and integrating the contact area between atom pairs, weighted by a 40×40 energy matrix (`MC_st0r5.2_6.dat`) trained on PDB-derived contact statistics across 40 SYBYL atom types. Lower CF is better — a perfect complementary fit between a ligand and its receptor pocket approaches the global minimum. Ensemble fields emitted after search are `proxy_only` diagnostics in arbitrary CF units: they are not a physical binding free energy, `Kd`, or `Ki`. Astex-85 accuracy is **unverified / pending receipt**.
 
 The total CF for a pose is:
 
@@ -93,10 +93,10 @@ flag therefore does not currently enforce a physics filter on the elected pose.
 | Intermolecular clash detection | Approximated (23× undercounting) | ✓ Optional all-pairs clash *penalty* in CF (`pb_clash`, default off); post-election PoseBusters `bust` is the S2 gate |
 | Receptor clash grid | Rebuilt every CF eval | ✓ Loop-invariant hoist (once per dock) |
 | Spread guard (false-minima demotion) | ✗ | ✓ Two-gate: distance + frequency + consensus |
-| Atom type: N.2 (sp2 imine) | → N.am (donor, wrong sign) | → N.ar (acceptor, correct) |
-| Atom type: N.3 (amine) | → N.3/type-8 (dead matrix row) | → N.am/type-11 (live) |
-| Atom type: C.1 (sp carbon) | → C.1/type-1 (sparse) | → C.2/type-2 (better sampled) |
-| Atom type: I (iodine) | → type-26 (3 live entries) | → BR/type-25 (full halogen row) |
+| Atom type: N.2 (sp2 imine) | → N.am (donor, wrong sign) | N.2→N.ar (acceptor, correct) |
+| Atom type: N.3 (amine) | → N.3/type-8 (dead matrix row) | N.3→N.am (type-11, live) |
+| Atom type: C.1 (sp carbon) | → C.1/type-1 (sparse) | C.1→C.2 (type-2, better sampled) |
+| Atom type: I (iodine) | → type-26 (3 live entries) | I→BR (type-25, full halogen row) |
 | WAL repulsion | Unbounded (SIGSEGV on extreme clashes) | ✓ Capped at 50 CF units per contact |
 | Vibrational diagnostic (tENCoM) | ✗ | ✓ torsional elastic-network model scale |
 | Astex-85 success rate | unverified / pending receipt | unverified / pending receipt |

--- a/VERSION.md
+++ b/VERSION.md
@@ -8,6 +8,29 @@
 
 ---
 
+## Unreleased (post-v2.0.3) — public surface honesty
+
+Tagged version remains **2.0.3**. These notes record user-facing work that has
+already landed on `main`. This is **not** a new release and does **not**
+publish an Astex-85 success rate.
+
+### Claim language
+- Search ranks poses with the **CF/contact-function scoring proxy**.
+- Ensemble diagnostics are `proxy_only` in arbitrary CF units — not a physical
+  binding free energy, `Kd`, or `Ki`.
+- Astex-85 accuracy is **unverified / pending receipt**. Withdrawn session
+  rates stay withdrawn.
+
+### Install how-to
+- Canonical landing how-to is [`docs/INSTALL.md`](docs/INSTALL.md): native
+  engine (CMake / Homebrew / Docker) and the `flexaidds` Python package are
+  **separate**. Header Installation and Quick Start now share that one file.
+- Build identity: `FlexAIDdS --version` and `flexaidds-build-provenance.json`.
+
+### Atom types
+- Documented NRGDock 40-type remaps as implemented: N.2→N.ar, N.3→N.am,
+  C.1→C.2, I→BR (`MC_st0r5.2_6.dat`).
+
 ## v2.0.3 (2026-07-15) — Homebrew Metal link fix
 
 Patch release so stable Homebrew `brew install --with-metal` can build from a fixed source tag.
@@ -61,7 +84,7 @@ Production docking matrix and installer fixes for out-of-the-box Homebrew / PyPI
 
 ## v2.0.0 (2026-04-04) — Stable Release
 
-First stable release of FlexAID∆S, the entropy-driven molecular docking engine. This is a ground-up rewrite of FlexAID combining genetic algorithms with statistical mechanics thermodynamics for accurate binding free energy prediction. 655 commits ahead of the v1.5 legacy tag. All development phases complete.
+First stable release of FlexAID∆S, the entropy-aware molecular docking engine. This is a ground-up rewrite of FlexAID combining genetic algorithms with a score-space ensemble diagnostic layer (`proxy_only`; not a physical binding free energy, `Kd`, or `Ki`). 655 commits ahead of the v1.5 legacy tag. All development phases complete. Current public Astex-85 status is unverified / pending receipt.
 
 ### Post-release fixes (2026-04-14)
 

--- a/docs/ATOM_TYPES.md
+++ b/docs/ATOM_TYPES.md
@@ -1,8 +1,10 @@
 # Atom Types in FlexAID∆S: The 40-Type NRGDock System
 
-FlexAID∆S uses a 40-type atom classification system derived from the SYBYL forcefield types. Each heavy atom in a receptor or ligand is assigned one of these 40 types, and that type is used as the row and column index into the 40×40 NRGDock energy matrix (`MC_st0r5.2_6.dat`). Getting the type right is essential: a mis-typed atom scores against the wrong row of the matrix and contributes either noise or the wrong sign to CF.
+FlexAID∆S uses a 40-type atom classification system derived from the SYBYL forcefield types. Each heavy atom in a receptor or ligand is assigned one of these 40 types, and that type is used as the row and column index into the 40×40 NRGDock energy matrix (`MC_st0r5.2_6.dat`). Getting the type right is essential: a mis-typed atom scores against the wrong row of the matrix and contributes either noise or the wrong sign to the **CF/contact-function scoring proxy**. CF and any ensemble transform over it are `proxy_only` diagnostics — not a physical binding free energy, `Kd`, or `Ki`. Astex-85 accuracy is **unverified / pending receipt**.
 
 This document describes all 40 types, explains the biological and chemical rationale for each, and documents the four type assignments that were incorrect in the original FlexAID and have been fixed in FlexAID∆S.
+
+**FlexAID∆S remaps** (MOL2 `sybyl_to_flexaid_type`, SDF `element_to_flexaid_type` for I, and `sybyl_name_to_canonical_vct`): N.2→N.ar, N.3→N.am, C.1→C.2, I→BR. Same four rows as the README remap table.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,14 @@
 # Installing FlexAID∆S
 
+This is the canonical install how-to linked from the GitHub landing page.
+Native engine (CMake / Homebrew / Docker) and the `flexaidds` Python package
+are **separate**. Extra platform notes live in [INSTALLATION.md](INSTALLATION.md);
+do not treat that page as a second Quick Start.
+
+FlexAID∆S ranks poses with the **CF/contact-function scoring proxy**. Ensemble
+fields are `proxy_only` diagnostics in arbitrary CF units — not a physical
+binding free energy, `Kd`, or `Ki`. Astex-85 accuracy is **unverified / pending receipt**.
+
 Two separate things ship from this repo, and conflating them is the most common
 install failure:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,5 +1,16 @@
 # Installation Guide
 
+> **Canonical how-to:** [INSTALL.md](INSTALL.md). The GitHub landing page
+> Installation link and Quick Start both resolve there. Native engine (CMake /
+> Homebrew / Docker) and the `flexaidds` Python package are **separate** —
+> installing one does not give you the other. This page is extra platform
+> detail (Homebrew recovery, Windows, conda internals), not a second install
+> story.
+>
+> FlexAID∆S ranks poses with the **CF/contact-function scoring proxy**. Ensemble
+> fields are `proxy_only` diagnostics — not a physical binding free energy,
+> `Kd`, or `Ki`. Astex-85 accuracy is **unverified / pending receipt**.
+
 Complete build and installation instructions for FlexAID∆S on all supported platforms.
 
 ---

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -6,14 +6,15 @@ Complete reference for using FlexAID∆S — from zero-config docking to advance
 
 ## Overview
 
-FlexAID∆S is an entropy-aware molecular docking engine. It extends the
+FlexAID∆S is a thermodynamically-aware molecular docking engine. It extends the
 FlexAID genetic algorithm with ensemble diagnostics and a schema-v2 scientific
-provenance gate. Standard docking uses arbitrary-unit CF scores and
-optimizer-selected samples, so its thermodynamic-looking fields are
-`proxy_only` unless an explicit calibrated energy domain and ensemble measure
-are supplied.
+provenance gate. Search ranks poses with the **CF/contact-function scoring proxy**.
+Standard docking uses arbitrary-unit CF scores and optimizer-selected
+samples, so its thermodynamic-looking fields are `proxy_only` — not a physical
+binding free energy, `Kd`, or `Ki` — unless an explicit calibrated energy
+domain and ensemble measure are supplied. Astex-85 accuracy is **unverified / pending receipt**.
 
-**Design philosophy**: All parameters have sensible defaults. A typical docking run requires only a receptor and a ligand — no configuration needed. Arguments are auto-detected from file content, so order doesn't matter.
+**Design philosophy**: All parameters have sensible defaults. A typical docking run requires only a receptor and a ligand — no configuration needed. Arguments are auto-detected from file content, so order doesn't matter. JSON `thermodynamics.temperature` is a **score-scale parameter**, not kelvin.
 
 ---
 
@@ -22,14 +23,14 @@ are supplied.
 ### Command Line
 
 ```bash
-# Full flexibility + entropy at 300 K (all defaults)
+# Flexible docking with default score-scale temperature (not kelvin)
 ./FlexAIDdS receptor.pdb ligand.mol2
 ```
 
 This single command:
 1. Detects binding site automatically (SURFNET cavity detection)
 2. Runs genetic algorithm with full ligand flexibility
-3. Computes score-space Shannon and optional model-scale tENCoM diagnostics
+3. Computes score-space Shannon and optional model-scale tENCoM diagnostics (`proxy_only`)
 4. Clusters poses and ranks them on the configured CF/election path
 5. Outputs ranked binding modes as PDB files
 
@@ -62,7 +63,7 @@ Inputs are auto-detected from file content — argument order doesn't matter. Ac
 |:-----|:------------|
 | `-c <file>` | JSON config file (overrides defaults) |
 | `-o <prefix>` | Output prefix for result files |
-| `--rigid` | Disable all flexibility and entropy (enthalpy-only scoring) |
+| `--rigid` | Disable ligand torsions and the ensemble diagnostic (CF-only ranking) |
 | `--folded` | Skip NATURaL co-translational chain growth |
 | `--legacy` | Legacy 3-argument mode: `config.inp ga.inp output_prefix` |
 | `--version` | Print version and exit |
@@ -79,7 +80,7 @@ is supplied.
 
 | Flag | Description |
 |:-----|:------------|
-| `-T <temp>` | Temperature in Kelvin (default: 300) |
+| `-T <temp>` | Model temperature parameter (default: 300); not a measured laboratory temperature |
 | `-r <cutoff>` | Contact distance cutoff in Å |
 | `-k <k0>` | Spring constant |
 | `-o <prefix>` | Output prefix |
@@ -97,7 +98,13 @@ python -m flexaidds /path/to/results/ --csv out.csv  # CSV export
 
 ## JSON Configuration
 
-All keys are optional — defaults enable full flexibility at 300 K. Override only what you need.
+All keys are optional — defaults enable full ligand flexibility with a score-scale
+`thermodynamics.temperature` of 300 (not kelvin). Override only what you need.
+
+Every key below is read by `LIB/config_parser.cpp`. Unknown keys — including
+`flexibility.ring_conformers` and `flexibility.chirality` — are silently ignored
+(fail-open). Ring-pucker sampling is `FLEXAIDDS_RING_FLEX`; restart count is
+`FLEXAIDDS_RESTARTS`. Neither is a JSON key.
 
 ### Complete Example
 
@@ -118,8 +125,6 @@ All keys are optional — defaults enable full flexibility at 300 K. Override on
   "flexibility": {
     "ligand_torsions": true,
     "intramolecular": true,
-    "ring_conformers": true,
-    "chirality": true,
     "permeability": 1.0,
     "dee_clash": 0.5
   },
@@ -130,10 +135,10 @@ All keys are optional — defaults enable full flexibility at 300 K. Override on
   },
   "ga": {
     "num_chromosomes": 1000,
-    "num_generations": 500,
+    "num_generations": 2000,
     "crossover_rate": 0.8,
     "mutation_rate": 0.03,
-    "fitness_model": "PSHARE",
+    "fitness_model": "SMFREE",
     "reproduction_model": "BOOM",
     "seed": 0
   },
@@ -178,16 +183,17 @@ All keys are optional — defaults enable full flexibility at 300 K. Override on
 |:----|:--------|:------------|
 | `ligand_torsions` | `true` | DEE torsion sampling |
 | `intramolecular` | `true` | Intramolecular scoring |
-| `ring_conformers` | `true` | Chair/boat/twist ring sampling |
-| `chirality` | `true` | Explicit R/S discrimination |
 | `permeability` | `1.0` | VDW permeability factor |
 | `dee_clash` | `0.5` | DEE clash threshold |
+
+Ring-pucker sampling and explicit R/S genes are **not** JSON keys. Enable ring
+pucker with `FLEXAIDDS_RING_FLEX`. Unknown JSON keys stay fail-open / ignored.
 
 #### `thermodynamics`
 
 | Key | Default | Description |
 |:----|:--------|:------------|
-| `temperature` | `300` | Temperature in K (0 disables entropy) |
+| `temperature` | `300` | Score-scale parameter for the CF ensemble diagnostic (0 disables it). Not kelvin. |
 | `clustering_algorithm` | `"CF"` | Clustering: `CF` (centroid-first), `DP` (Density Peak), or `FO` (FastOPTICS) |
 | `cluster_rmsd` | `2.0` | RMSD threshold for clustering (Å) |
 
@@ -196,10 +202,10 @@ All keys are optional — defaults enable full flexibility at 300 K. Override on
 | Key | Default | Description |
 |:----|:--------|:------------|
 | `num_chromosomes` | `1000` | Population size |
-| `num_generations` | `500` | Number of generations |
+| `num_generations` | `2000` | Number of generations |
 | `crossover_rate` | `0.8` | Crossover probability |
 | `mutation_rate` | `0.03` | Mutation probability |
-| `fitness_model` | `"PSHARE"` | Fitness sharing model |
+| `fitness_model` | `"SMFREE"` | Fitness model (`PSHARE` is also applied if set) |
 | `reproduction_model` | `"BOOM"` | Reproduction strategy |
 | `seed` | `0` | RNG seed (0 = time-based) |
 
@@ -309,17 +315,17 @@ for lig in ligands/*.mol2; do
 done
 ```
 
-### Accurate Binding Mode (Full Entropy)
+### Accurate Binding Mode (full flexibility)
 
 ```json
 {
   "ga": { "num_chromosomes": 2000, "num_generations": 1000 },
   "thermodynamics": { "temperature": 300, "clustering_algorithm": "DP" },
-  "flexibility": { "ring_conformers": true, "chirality": true }
+  "flexibility": { "ligand_torsions": true, "intramolecular": true }
 }
 ```
 
-### Enthalpy-Only Ranking (No Entropy)
+### CF-Only Ranking (no ensemble diagnostic)
 
 ```bash
 ./FlexAIDdS receptor.pdb ligand.mol2 --rigid
@@ -411,8 +417,8 @@ engine.add_samples(pose_scores)
 thermo = engine.compute()
 
 print(f"F  = {thermo.free_energy:.2f} [input-domain units]")
-print(f"S  = {thermo.entropy:.4f} [input-domain units / K]")
-print(f"Cv = {thermo.heat_capacity:.4f} [input-domain units / K]")
+print(f"S  = {thermo.entropy:.4f} [input-domain units / score-scale T]")
+print(f"Cv = {thermo.heat_capacity:.4f} [input-domain units / score-scale T]")
 print(thermo.claim_validity.value)   # proxy_only for CF scores
 ```
 
@@ -518,7 +524,7 @@ TypeScript PWA remain experimental clients of this file contract.
 
 ### Accuracy
 
-- **Always use entropy** — the `--rigid` flag is for quick screening only; entropy recovers correct binding modes that enthalpy-only scoring misses
+- **Prefer the default flexible path** — `--rigid` is for quick screening only; it drops torsion sampling and the score-space ensemble diagnostic. It does not compute a physical binding free energy, and the default path is still `proxy_only` CF ranking plus diagnostics
 - **Keep structural waters** — ordered waters mediate real contacts, and removing them changes the
   pocket shape the contact function sees. FlexAID∆S makes no calibrated kcal/mol claim about their
   energetic contribution
@@ -540,6 +546,6 @@ TypeScript PWA remain experimental clients of this file contract.
 
 ## Next Steps
 
-- [Installation Guide](INSTALLATION.md) — build instructions and troubleshooting
-- [Benchmarks](BENCHMARKS.md) — performance and accuracy data
-- [Configuration Reference](../README.md#json-config) — full JSON config schema in README
+- [Installation how-to](INSTALL.md) — native engine vs Python package (canonical)
+- [Benchmarks](BENCHMARK.md) — dataset provenance; Astex-85 unverified / pending receipt
+- [Configuration Reference](../README.md#example-json-configuration) — JSON keys the engine actually applies

--- a/tests/test_check_published_astex_rates.py
+++ b/tests/test_check_published_astex_rates.py
@@ -20,6 +20,11 @@ ROOT = Path(__file__).resolve().parents[1]
 
 SURFACES = (
     ROOT / "README.md",
+    ROOT / "docs" / "INSTALL.md",
+    ROOT / "docs" / "INSTALLATION.md",
+    ROOT / "docs" / "USERGUIDE.md",
+    ROOT / "VERSION.md",
+    ROOT / "docs" / "ATOM_TYPES.md",
     ROOT / "docs" / "BENCHMARK.md",
     ROOT / "REPRODUCIBILITY.md",
     ROOT / "scripts" / "reproduce_astex85.sh",

--- a/tests/test_public_docs_vehicles.py
+++ b/tests/test_public_docs_vehicles.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Public-vehicle honesty: landing README, install how-to, user guide, changelog, atom types.
+
+Drives the shipped docs and the shipped config parser / typing functions.
+Does not re-implement mapping tables or invent JSON keys.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PUBLIC_VEHICLES = (
+    ROOT / "README.md",
+    ROOT / "docs" / "INSTALL.md",
+    ROOT / "docs" / "USERGUIDE.md",
+    ROOT / "VERSION.md",
+    ROOT / "docs" / "ATOM_TYPES.md",
+)
+
+REMAP_STRINGS = ("N.2→N.ar", "N.3→N.am", "C.1→C.2", "I→BR")
+
+# Live VCT rows returned by the mapping *functions* (not comments).
+MOL2_TOP_REMAPS = (("N.2", 10), ("N.3", 11), ("C.1", 2), ("I", 25))
+SDF_IODINE_REMAP = ("I", 25)
+
+JSON_FENCE_RE = re.compile(r"```json\s*\n(.*?)```", re.S)
+APPLIED_KEY_RE = re.compile(
+    r"j(?:bool|int|dbl|flt|str)\(\s*config\s*,\s*\"([A-Za-z0-9_]+)\"\s*,\s*\"([A-Za-z0-9_]+)\""
+)
+APPLIED_INDEX_RE = re.compile(
+    r"config\[\"([A-Za-z0-9_]+)\"\]\[\"([A-Za-z0-9_]+)\"\]"
+)
+STRCMP_RETURN_RE = re.compile(
+    r"strcmp\([^,]+,\s*\"([^\"]+)\"\)\)\s*return\s+(\d+)"
+)
+DEAD_JSON_KEYS = frozenset({"ring_conformers", "chirality"})
+KELVIN_DEFAULT_RE = re.compile(
+    r"(?:entropy at 300\s*K|300\s*K entropy|flexibility at 300\s*K|"
+    r"Temperature in K(?:elvin)?(?:\s|\||$)|"
+    r"defaults enable full flexibility at 300\s*K)",
+)
+
+
+def _applied_parser_keys(parser_src: str) -> set[tuple[str, str]]:
+    keys = set(APPLIED_KEY_RE.findall(parser_src))
+    keys.update(APPLIED_INDEX_RE.findall(parser_src))
+    return keys
+
+
+def _function_body(source: str, name: str) -> str:
+    match = re.search(rf"\b{re.escape(name)}\s*\([^;]*?\)\s*\{{", source)
+    assert match, f"missing function {name}"
+    start = match.end() - 1
+    depth = 0
+    for index in range(start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unclosed function {name}")
+
+
+def _strip_cpp_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//.*?$", "", text, flags=re.M)
+
+
+def _mapping_returns(path: Path, func_name: str) -> dict[str, int]:
+    body = _strip_cpp_comments(_function_body(path.read_text(encoding="utf-8"), func_name))
+    found = {key: int(val) for key, val in STRCMP_RETURN_RE.findall(body)}
+    assert found, f"no strcmp/return pairs in {path.name}:{func_name}"
+    return found
+
+
+def test_landing_readme_install_links_share_one_howto() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    header = re.search(r"\*\*\[Installation\]\(([^)]+)\)\*\*", readme)
+    assert header, "GitHub landing README is missing the header Installation link"
+    header_target = header.group(1)
+
+    quick = re.search(
+        r"## Quick Start.*?\[`([^`]+)`\]\(([^)]+)\)",
+        readme,
+        flags=re.S,
+    )
+    assert quick, "Quick Start is missing an install how-to path"
+    label, quick_target = quick.group(1), quick.group(2)
+
+    assert header_target == quick_target, (
+        f"header Installation={header_target!r} vs Quick Start={quick_target!r}"
+    )
+    assert label == header_target, (
+        f"Quick Start label {label!r} must match the how-to path {header_target!r}"
+    )
+    assert "INSTALLATION.md" not in header_target
+
+    howto = ROOT / header_target
+    assert howto.is_file(), f"install how-to does not exist: {header_target}"
+    text = howto.read_text(encoding="utf-8")
+    assert "Python package" in text
+    assert "separate" in text.lower()
+    assert (
+        "does **not** contain the docking engine" in text
+        or "does not contain the docking engine" in text
+    )
+    assert "CMake" in text and "Homebrew" in text and "Docker" in text
+    assert "pip" in text.lower()
+
+
+def test_user_guide_json_examples_use_only_applied_parser_keys() -> None:
+    guide = (ROOT / "docs" / "USERGUIDE.md").read_text(encoding="utf-8")
+    parser_src = (ROOT / "LIB" / "config_parser.cpp").read_text(encoding="utf-8")
+    applied = _applied_parser_keys(parser_src)
+    assert ("ga", "num_chromosomes") in applied
+    assert ("thermodynamics", "temperature") in applied
+    assert ("flexibility", "ring_conformers") not in applied
+    assert ("flexibility", "chirality") not in applied
+
+    fences = JSON_FENCE_RE.findall(guide)
+    assert fences, "user guide has no fenced JSON examples"
+    unknown: list[str] = []
+    for block in fences:
+        payload = json.loads(block)
+        assert isinstance(payload, dict), "JSON examples must be objects"
+        for section, body in payload.items():
+            assert isinstance(body, dict), f"section {section!r} must be an object"
+            for key in body:
+                assert key not in DEAD_JSON_KEYS, (
+                    f"user guide advertises ignored JSON key {section}.{key}"
+                )
+                if (section, key) not in applied:
+                    unknown.append(f"{section}.{key}")
+    assert unknown == [], (
+        "user guide JSON keys not applied by LIB/config_parser.cpp: "
+        + ", ".join(unknown)
+    )
+
+
+def test_user_guide_does_not_call_default_temperature_kelvin() -> None:
+    text = (ROOT / "docs" / "USERGUIDE.md").read_text(encoding="utf-8")
+    match = KELVIN_DEFAULT_RE.search(text)
+    assert match is None, (
+        "user guide still describes default docking temperature as Kelvin / "
+        f"300 K entropy: {match.group(0)!r}"
+    )
+    assert "300 K" not in text
+    assert "score-scale" in text.lower()
+
+
+def test_four_remaps_match_mapping_functions_and_readme_table() -> None:
+    mol2 = _mapping_returns(ROOT / "LIB" / "Mol2Reader.cpp", "sybyl_to_flexaid_type")
+    top = _mapping_returns(ROOT / "LIB" / "top_helpers.cpp", "sybyl_name_to_canonical_vct")
+    sdf = _mapping_returns(ROOT / "LIB" / "SdfReader.cpp", "element_to_flexaid_type")
+
+    for key, expected in MOL2_TOP_REMAPS:
+        assert mol2[key] == expected, f"Mol2Reader {key} -> {mol2.get(key)}"
+        assert top[key] == expected, f"sybyl_name_to_canonical_vct {key} -> {top.get(key)}"
+    assert sdf[SDF_IODINE_REMAP[0]] == SDF_IODINE_REMAP[1]
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    atom_types = (ROOT / "docs" / "ATOM_TYPES.md").read_text(encoding="utf-8")
+    for remap in REMAP_STRINGS:
+        assert remap in readme, f"README remap table missing {remap}"
+        assert remap in atom_types, f"atom-types page missing {remap}"
+    assert "MC_st0r5.2_6.dat" in atom_types
+    assert "40" in atom_types
+
+
+def test_python_package_version_remains_2_0_3() -> None:
+    version_py = (ROOT / "python" / "flexaidds" / "__version__.py").read_text(
+        encoding="utf-8"
+    )
+    changelog = (ROOT / "VERSION.md").read_text(encoding="utf-8")
+    assert '__version__ = "2.0.3"' in version_py
+    assert "**Current Version**: 2.0.3" in changelog
+    assert "Unreleased (post-v2.0.3)" in changelog
+
+
+def test_public_vehicles_exist() -> None:
+    for path in PUBLIC_VEHICLES:
+        assert path.is_file(), f"missing public vehicle {path}"

--- a/tests/test_thermo_claim_firewall.py
+++ b/tests/test_thermo_claim_firewall.py
@@ -310,6 +310,17 @@ def test_fake_digest_inside_a_list_is_not_invisible(tmp_path: Path) -> None:
     assert any("placeholder/fake digest is forbidden" in e for e in errors)
 
 
+# GitHub landing README + the other named public vehicles Copilot was asked
+# to finish. Keep this list in sync with tests/test_public_docs_vehicles.py.
+PUBLIC_VEHICLES = (
+    "README.md",
+    "docs/INSTALL.md",
+    "docs/USERGUIDE.md",
+    "VERSION.md",
+    "docs/ATOM_TYPES.md",
+)
+
+
 def test_primary_docs_do_not_claim_unwired_physical_election() -> None:
     root = Path(__file__).resolve().parents[1]
     surfaces = {
@@ -318,6 +329,13 @@ def test_primary_docs_do_not_claim_unwired_physical_election() -> None:
             encoding="utf-8"
         ),
         "docs/USERGUIDE.md": (root / "docs" / "USERGUIDE.md").read_text(
+            encoding="utf-8"
+        ),
+        "docs/INSTALL.md": (root / "docs" / "INSTALL.md").read_text(
+            encoding="utf-8"
+        ),
+        "VERSION.md": (root / "VERSION.md").read_text(encoding="utf-8"),
+        "docs/ATOM_TYPES.md": (root / "docs" / "ATOM_TYPES.md").read_text(
             encoding="utf-8"
         ),
     }
@@ -331,6 +349,19 @@ def test_primary_docs_do_not_claim_unwired_physical_election() -> None:
     for name, text in surfaces.items():
         for phrase in forbidden:
             assert phrase not in text, f"{name} retains unsupported claim: {phrase}"
+
+    for rel in PUBLIC_VEHICLES:
+        text = surfaces[rel]
+        assert "CF/contact-function scoring proxy" in text, (
+            f"{rel} missing frozen CF/contact-function scoring proxy language"
+        )
+        assert "proxy_only" in text, f"{rel} missing proxy_only"
+        assert "unverified" in text and "pending receipt" in text, (
+            f"{rel} missing Astex-85 unverified / pending receipt"
+        )
+        assert "Kd" in text and "Ki" in text, (
+            f"{rel} must name Kd / Ki as things it does not claim"
+        )
 
     ranking = (root / "docs" / "classic_entropy_ranking.md").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Why

Copilot was asked to finish the public-docs update (GitHub landing README, install how-to, user guide, changelog, atom types) and did not land it. This PR does that work against the frozen claim language and the shipped parser / remap functions.

## What changed

- Landing header **Installation** and Quick Start now both resolve to `docs/INSTALL.md` (engine vs Python package are separate). `docs/INSTALLATION.md` is extra platform detail, not a second how-to.
- User guide: temperature is a score-scale parameter (not kelvin / 300 K entropy). JSON examples only use keys `LIB/config_parser.cpp` actually applies (`ring_conformers` / `chirality` are fail-open and no longer advertised as live).
- Changelog: unreleased post-v2.0.3 notes. Tagged version remains **2.0.3**. No Astex-85 rates.
- Atom types + README remap table: N.2→N.ar, N.3→N.am, C.1→C.2, I→BR, matching `sybyl_to_flexaid_type` / `element_to_flexaid_type` / `sybyl_name_to_canonical_vct`.

## Tests

```
python3 -m pytest tests/test_thermo_claim_firewall.py tests/test_check_published_astex_rates.py tests/test_public_docs_vehicles.py -q --tb=short
```

33 passed. `python/flexaidds/__version__.py` remains `2.0.3`.

No engine, ranking, or scoring-code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no runtime docking, ranking, or scoring behavior is modified.
> 
> **Overview**
> This PR finishes the **public-docs honesty** pass: README, install pages, user guide, changelog, and atom-types docs now share one claim story, with **no engine or scoring code changes**.
> 
> **Install navigation** — The landing **Installation** link and Quick Start both point at `docs/INSTALL.md` as the single how-to; `docs/INSTALLATION.md` is labeled extra platform detail only. Both paths stress that the **native engine and `flexaidds` Python package are separate**.
> 
> **Claim language** — Public surfaces consistently describe **CF/contact-function scoring proxy** ranking, **`proxy_only`** ensemble diagnostics (not physical ΔG, **Kd**, or **Ki**), and **Astex-85 unverified / pending receipt**. README physics and comparison tables get the same wording; atom-type rows use explicit remap notation (N.2→N.ar, etc.).
> 
> **User guide accuracy** — Default **`thermodynamics.temperature`** is documented as a **score-scale parameter**, not kelvin; **`--rigid`** is CF-only (no ensemble diagnostic). JSON examples drop ignored keys (`ring_conformers`, `chirality`) and align defaults with the parser (**2000** generations, **SMFREE** fitness). Ring flex and restarts are pointed at env vars.
> 
> **Changelog** — `VERSION.md` adds an **Unreleased (post-v2.0.3)** section while tagged version stays **2.0.3**.
> 
> **Tests** — New `test_public_docs_vehicles.py` and extended thermo/Astex scanners enforce install link parity, parser-only JSON keys, remap strings vs C++ mappers, frozen disclaimer phrases, and expanded Astex-rate scan surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f42b34c8882d706f16551bbab9bb8d65267e20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation guidance and navigation, clarifying separate native-engine and Python-package setup.
  - Clarified that CF/contact-function scores and ensemble diagnostics are proxy-only, arbitrary score-scale values—not physical binding energies, Kd, or Ki.
  - Marked Astex-85 accuracy as unverified/pending receipt.
  - Documented atom-type remappings and updated configuration, terminology, defaults, rigid-mode behavior, and workflow examples.

- **Tests**
  - Added coverage validating public documentation links, configuration examples, atom-type mappings, package version consistency, and accuracy disclaimers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->