### PR TITLE
Add: working first-shot install on Pages and in the repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+# Dev Container for the flexaidds Python package (analysis CLI).
+# The native C++ engine is optional here; Codespaces users get a working
+# `flexaidds --help` without a C++26 toolchain (FLEXAIDDS_SKIP_CORE=1).
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git cmake ninja-build libeigen3-dev libomp-dev g++ wget curl \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspaces/FlexAIDdS

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "FlexAIDdS",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "FLEXAIDDS_SKIP_CORE=1 pip install -e ./python && python -c 'import flexaidds as fd; print(fd.__version__)' && python -m flexaidds --help",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-vscode.cmake-tools"
+      ]
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.github/actions/setup-flexaidds/action.yml
+++ b/.github/actions/setup-flexaidds/action.yml
@@ -1,0 +1,42 @@
+name: Setup FlexAIDdS
+description: >
+  Install the flexaidds Python package (analysis CLI). The native docking
+  engine is separate and is not installed by this action.
+inputs:
+  from-checkout:
+    description: Install ./python from this repository checkout (PR CI). Set false to use git+subdirectory.
+    required: false
+    default: "true"
+  skip-core:
+    description: Set FLEXAIDDS_SKIP_CORE=1 (pure-Python; no C++26 compiler required).
+    required: false
+    default: "true"
+  ref:
+    description: Git ref for git+subdirectory installs when from-checkout is false.
+    required: false
+    default: "main"
+runs:
+  using: composite
+  steps:
+    - name: Install flexaidds
+      shell: bash
+      env:
+        FLEXAIDDS_SKIP_CORE: ${{ inputs.skip-core == 'true' && '1' || '' }}
+        FROM_CHECKOUT: ${{ inputs.from-checkout }}
+        GIT_REF: ${{ inputs.ref }}
+      run: |
+        set -euo pipefail
+        python -m pip install -U pip
+        if [ "${FROM_CHECKOUT}" = "true" ]; then
+          test -f python/pyproject.toml
+          spec="./python"
+        else
+          spec="git+https://github.com/LeBonhommePharma/FlexAIDdS.git@${GIT_REF}#subdirectory=python"
+        fi
+        if [ "${FLEXAIDDS_SKIP_CORE:-}" = "1" ]; then
+          FLEXAIDDS_SKIP_CORE=1 python -m pip install "$spec"
+        else
+          python -m pip install "$spec"
+        fi
+        python -c "import flexaidds as fd; print('flexaidds', fd.__version__)"
+        python -m flexaidds --help

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,51 @@
+name: GHCR
+
+# Publish ghcr.io/lebonhommepharma/flexaidds from containers/Dockerfile.locked.
+# First-shot `docker pull` is live only after this workflow has succeeded on
+# a tag or workflow_dispatch. Until then the documented path is `docker build`.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ghcr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build and push GHCR image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
+            -u "${{ github.actor }}" --password-stdin
+
+      - name: Build locked image
+        run: |
+          set -euo pipefail
+          COMMIT="$(git rev-parse --short HEAD)"
+          IMAGE="ghcr.io/lebonhommepharma/flexaidds"
+          docker build -f containers/Dockerfile.locked \
+            --build-arg FLEXAIDS_GIT_COMMIT="${COMMIT}" \
+            -t "${IMAGE}:${COMMIT}" \
+            -t "${IMAGE}:${GITHUB_REF_NAME}" \
+            -t "${IMAGE}:latest" \
+            .
+
+      - name: Push
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/lebonhommepharma/flexaidds"
+          docker push "${IMAGE}:${GITHUB_REF_NAME}"
+          docker push "ghcr.io/lebonhommepharma/flexaidds:$(git rev-parse --short HEAD)"
+          docker push "${IMAGE}:latest"

--- a/.github/workflows/homebrew-bottle.yml
+++ b/.github/workflows/homebrew-bottle.yml
@@ -1,0 +1,46 @@
+name: Homebrew bottle
+
+# Produce a bottle from `brew install --build-bottle`. Bottles attach to a
+# *stable* tag that can emit provenance JSON. Current stable v2.0.3 cannot
+# (formula odie); this workflow is for the next tag. It never invents a
+# bottle do { } block with a URL that does not exist.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  bottle:
+    name: bottle macOS ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+
+      - name: Tap this checkout
+        run: |
+          set -euo pipefail
+          brew tap lebonhommepharma/flexaidds "${GITHUB_WORKSPACE}"
+          brew trust --formula lebonhommepharma/flexaidds/flexaidds || true
+
+      - name: Build bottle from HEAD (until a provenance-capable stable tag)
+        run: |
+          set -euo pipefail
+          brew install --build-bottle --HEAD lebonhommepharma/flexaidds/flexaidds
+          brew bottle --json --skip-relocation lebonhommepharma/flexaidds/flexaidds
+          ls -l flexaidds--*.tar.gz flexaidds--*.json 2>/dev/null || ls -l *.tar.gz
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: bottle-${{ matrix.os }}
+          path: |
+            flexaidds*.tar.gz
+            flexaidds*.json

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -427,3 +427,34 @@ jobs:
               print("unpinned run deps (reproducibility):", unpinned); sys.exit(1)
           print("all run deps carry a version constraint")
           PY
+
+  setup-action-smoke:
+    name: composite action installs flexaidds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.11"
+      - uses: ./.github/actions/setup-flexaidds
+        with:
+          from-checkout: "true"
+          skip-core: "true"
+      - name: CLI works
+        run: python -m flexaidds --help
+
+
+  setup-action-smoke:
+    name: composite action installs flexaidds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.11"
+      - uses: ./.github/actions/setup-flexaidds
+        with:
+          from-checkout: "true"
+          skip-core: "true"
+      - name: CLI works
+        run: python -m flexaidds --help

--- a/.github/workflows/release-all.yml
+++ b/.github/workflows/release-all.yml
@@ -1,0 +1,41 @@
+name: Release all channels
+
+# One button to refresh binaries, GHCR, and Homebrew bottles together.
+# PyPI stays opt-in (unpublished today; trusted publishing is a separate event).
+#
+#   gh workflow run release-all.yml
+# On a v* tag, release.yml / ghcr.yml / homebrew-bottle.yml also fire on their
+# own; this workflow is the explicit simultaneous kick for workflow_dispatch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      include_pypi:
+        description: Also dispatch pypi-release.yml (default false; package unpublished)
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+  actions: write
+  id-token: write
+
+jobs:
+  kick:
+    name: Dispatch channel workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sibling workflows on this ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ref="${GITHUB_REF_NAME}"
+          gh workflow run release.yml --ref "$ref"
+          gh workflow run ghcr.yml --ref "$ref"
+          gh workflow run homebrew-bottle.yml --ref "$ref"
+          if [ "${{ inputs.include_pypi }}" = "true" ]; then
+            gh workflow run pypi-release.yml --ref "$ref" -f target=pypi
+          fi
+          echo "kicked release.yml ghcr.yml homebrew-bottle.yml on $ref"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,36 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.artifact_name }}.zip
+
+  # Attach tarballs + SHA256SUMS.txt to the GitHub Release so
+  # `scripts/install.sh --from-release` can fail-closed on a checksum.
+  # Previous tags (through v2.2.0) have zero release assets — this job is
+  # why the next tag can be a first-shot binary install.
+  publish_release_assets:
+    name: Attach checksummed binaries to the GitHub Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          path: artifacts
+      - name: Flatten artifacts and write SHA256SUMS.txt
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          find artifacts -type f \( -name 'flexaidds-*.tar.gz' -o -name 'flexaidds-*.zip' \) \
+            -exec cp -f {} dist/ \;
+          ls -l dist
+          (cd dist && sha256sum flexaidds-*.tar.gz flexaidds-*.zip > SHA256SUMS.txt)
+          cat dist/SHA256SUMS.txt
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "${GITHUB_REF_NAME}" dist/* --clobber \
+            --repo "${GITHUB_REPOSITORY}"
+

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -22,6 +22,10 @@ class Flexaidds < Formula
   # links Metal bridges via flexaid_core (PR #260).
   option "with-metal", "Build with Metal GPU acceleration (macOS; needs Metal toolchain)"
 
+  # No `bottle do` block: a bottle URL that 404s is worse than compiling
+  # --HEAD. Bottles are produced by .github/workflows/homebrew-bottle.yml on a
+  # provenance-capable tag. Do not paste a fabricated cellar URL here.
+
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "eigen"

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -297,7 +297,9 @@ class Flexaidds < Formula
     assert Dir["#{libexec}/share/MC_*.dat"].any?, "expected MC_*.dat in libexec/share"
 
     # Wrapper must advertise the Cellar data dir, not /opt/homebrew/bin.
-    output = shell_output(bin/"FlexAIDdS", "--help")
+    # shell_output(cmd, result=0): 2nd arg is the expected exit status, not argv.
+    # A Pathname cmd is exec'd with no argv — flags must live in the string.
+    output = shell_output("#{bin/"FlexAIDdS"} --help")
     assert_match "base path", output
 
     system bin/"tENCoM", "--help"
@@ -314,7 +316,7 @@ class Flexaidds < Formula
     # buildinfo begins by printing that same JSON, so the assertion compared a
     # string to itself and could not fail. Assert against the cross-check line,
     # which is derived from the binary.
-    info = shell_output(bin/"flexaidds-buildinfo")
+    info = shell_output("#{bin/"flexaidds-buildinfo"}")
     assert_match "provenance_json_commit=#{prov["git_commit"]}", info
     refute_match "status=MISMATCH", info
   end

--- a/Formula/flexaidds.rb
+++ b/Formula/flexaidds.rb
@@ -28,6 +28,22 @@ class Flexaidds < Formula
   depends_on "libomp" if OS.mac?
 
   def install
+    # v2.0.3 tarball predates flexaidds-build-provenance.json. Building it
+    # wastes ~20 min then `odie`s. Fail immediately so first-shot users are
+    # pointed at --HEAD (the command that actually installs today).
+    unless build.head?
+      odie <<~EOS
+        Stable v#{version} cannot produce flexaidds-build-provenance.json.
+        First-shot macOS install until the next tagged release:
+
+          brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
+          brew trust --formula lebonhommepharma/flexaidds/flexaidds
+          brew install --HEAD lebonhommepharma/flexaidds/flexaidds
+
+        Then: FlexAIDdS --help
+      EOS
+    end
+
     # Metal OFF by default for CLT-only SDKs without a working metalc; use
     # --with-metal when Xcode/Metal toolchain is present. v2.0.3+ attaches
     # OBJCXX bridges + frameworks PUBLIC on flexaid_core so every consumer
@@ -231,25 +247,29 @@ class Flexaidds < Formula
         FlexAIDdS, FlexAID, tENCoM, tencom_entropy_diff
 
       It does *not* install the Python analysis package. Those are separate:
-        # Python CLI + load_results / StatMech (GitHub until public PyPI):
-        pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+        # First-shot (not on public PyPI yet):
+        FLEXAIDDS_SKIP_CORE=1 pip install \
+          "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+        flexaidds --help
         # After the first PyPI release: pip install flexaidds
-        # Then: flexaidds --help   or   python -m flexaidds --help
 
       Wrappers under #{bin} set FLEXAIDDS_DATA_DIR=#{libexec}/share so PATH
       symlinks still find MC matrices and AMINO.def.
 
       Stable v2.0.3+ includes the production docking matrix (atom typing works
-      out of the box). Upgrade from broken v2.0.0 / stale HEAD installs with:
-        brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
+      out of the box). Homebrew 6 treats `--HEAD` as install-only; upgrade with:
+        brew uninstall --force lebonhommepharma/flexaidds/flexaidds
+        brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
-      Install / reinstall path (Homebrew 6+ requires a real tap; raw URL installs
-      are rejected). The tap is this monorepo — keep the tap checkout on main:
+      First-shot install (Homebrew 6+ requires a real tap; raw URL installs
+      are rejected). Stable v2.0.3 is not installable: that tarball cannot
+      emit build provenance, so the formula refuses it. Use --HEAD until the
+      next tag. The tap is this monorepo — keep the tap checkout on main:
         brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
         # Prefer formula-scoped trust when HOMEBREW_REQUIRE_TAP_TRUST is set
         # (https://docs.brew.sh/Tap-Trust). Do not use HOMEBREW_NO_REQUIRE_TAP_TRUST.
         brew trust --formula lebonhommepharma/flexaidds/flexaidds
-        brew install lebonhommepharma/flexaidds/flexaidds
+        brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
       Default brew build uses CPU + OpenMP (no Metal) and is the portable path.
       Formula head tracks main only (never ephemeral fix/* branches).
@@ -259,13 +279,10 @@ class Flexaidds < Formula
         cd "$(brew --repository lebonhommepharma/flexaidds)"
         git fetch --prune && git checkout main && git reset --hard origin/main
         brew uninstall --force lebonhommepharma/flexaidds/flexaidds
-        brew install --build-from-source lebonhommepharma/flexaidds/flexaidds
+        brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 
-      Metal GPU (macOS + Xcode Metal toolchain). Stable v2.0.3+ links Metal
-      bridges via flexaid_core (PR #260); no special git branch required:
-        brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
-      Or after tap update if already installed:
-        brew reinstall --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
+      Metal GPU (macOS + Xcode Metal toolchain). Not the first-shot path:
+        brew install --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
 
       Example:
         FlexAIDdS receptor.pdb ligand.sdf --rigid -o /tmp/out
@@ -280,7 +297,7 @@ class Flexaidds < Formula
     assert Dir["#{libexec}/share/MC_*.dat"].any?, "expected MC_*.dat in libexec/share"
 
     # Wrapper must advertise the Cellar data dir, not /opt/homebrew/bin.
-    output = shell_output("#{bin}/FlexAIDdS --help")
+    output = shell_output(bin/"FlexAIDdS", "--help")
     assert_match "base path", output
 
     system bin/"tENCoM", "--help"
@@ -297,8 +314,8 @@ class Flexaidds < Formula
     # buildinfo begins by printing that same JSON, so the assertion compared a
     # string to itself and could not fail. Assert against the cross-check line,
     # which is derived from the binary.
-    info = shell_output("#{bin}/flexaidds-buildinfo")
-    assert_match "provenance_json_commit=#{prov['git_commit']}", info
+    info = shell_output(bin/"flexaidds-buildinfo")
+    assert_match "provenance_json_commit=#{prov["git_commit"]}", info
     refute_match "status=MISMATCH", info
   end
 end

--- a/README.md
+++ b/README.md
@@ -118,9 +118,18 @@ flag therefore does not currently enforce a physics filter on the elected pose.
 curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash
 ```
 
-Review first with `| less`. Flags: `| bash -s -- --python-only` or `--engine-only`.
+Review first with `| less`. Same script via `wget -qO- … | bash`.
+Flags: `--python-only`, `--engine-only`, `--uv`, `--pipx`, `--from-release`.
 macOS installs the Homebrew engine (`--HEAD`) plus the Python package; other
 platforms get the Python package and print the CMake/Docker engine path.
+
+Update every front already on the machine:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh | bash
+python -m flexaidds --self-update
+```
+
 Details: [`docs/INSTALL.md`](docs/INSTALL.md#one-liner-curl--bash).
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ flag therefore does not currently enforce a physics filter on the elected pose.
 > The native engine and the `flexaidds` Python package are **separate**.
 > Installing one does not give you the other.
 
+### curl (first shot)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash
+```
+
+Review first with `| less`. Flags: `| bash -s -- --python-only` or `--engine-only`.
+macOS installs the Homebrew engine (`--HEAD`) plus the Python package; other
+platforms get the Python package and print the CMake/Docker engine path.
+Details: [`docs/INSTALL.md`](docs/INSTALL.md#one-liner-curl--bash).
+
 ### Build
 
 ```bash

--- a/conda/conda-forge.md
+++ b/conda/conda-forge.md
@@ -1,0 +1,20 @@
+# conda-forge (not a feedstock yet)
+
+The in-repo recipe is [`conda/meta.yaml`](meta.yaml). It installs the
+**Python** package (`flexaidds`), not the native engine.
+
+This is **not** `conda install -c conda-forge flexaidds`. That channel does
+not carry the package until a feedstock is accepted. First-shot today:
+
+```bash
+git clone https://github.com/LeBonhommePharma/FlexAIDdS.git
+cd FlexAIDdS
+conda env create -f environment.yml
+conda activate flexaidds
+python -c "import flexaidds as fd; print(fd.__version__)"
+```
+
+To publish on conda-forge later: open a staged-recipes PR using this
+`meta.yaml` (version still derived from `python/flexaidds/__version__.py`).
+Do not document `conda-forge` as a working first-shot until that feedstock
+exists and `conda search -c conda-forge flexaidds` returns a version.

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -142,8 +142,10 @@ The benchmark reports three scores for each run. **This repository currently pub
 ## Astex-85 success rate — WITHDRAWN pending verification
 
 > **No Astex-85 success rate is published by this repository at present.**
+> Benchmarks are still rolling. Do not cite a former numerical FlexAID∆S rate
+> (including any figure at or above 90%) as current docking power.
 >
-> The figures previously stated here (78/85 = 91.8%) are **withdrawn**. They could not be
+> Previously stated numerical rates on this page are **withdrawn**. They could not be
 > reproduced from a receipted, blind, unseeded run on the current engine, and the
 > reproduction path they referenced (`scripts/run_dataset.py`, `scripts/analyze_affinity.py`)
 > does not exist in the tree. This matches the status already stated in `README.md`:
@@ -153,10 +155,10 @@ The benchmark reports three scores for each run. **This repository currently pub
 > `METHODOLOGY.md` §0 — blind, `native_pose_seeded=0`, no seed elitism, a fixed 85-target
 > denominator, and a provenance receipt pinning engine hash, matrix hash, and input hashes.
 >
-> Do not cite 91.8%, 94.1%, or 88.2% as current FlexAID(∆S) docking power. The 88.2%
-> (75/85) figure previously listed as FlexAID 2015 S1 is a **literature misquote**;
+> The figure previously listed as FlexAID 2015 S1 is a **literature misquote**;
 > Gaudreault & Najmanovich 2015 JCIM **Table 2** is **top-1 45.2% / top-10 66.7%**
-> (`METHODOLOGY.md` §3). 94.1% (80/85) was an oracle ceiling (`REPRODUCIBILITY.md`).
+> (`METHODOLOGY.md` §3). The former oracle-ceiling arm is documented in
+> `REPRODUCIBILITY.md` and is not docking power.
 >
 > The methodology, diagnostics and failure-mode *categories* below remain valid as *method*
 > documentation. Any number appearing in them is illustrative of the analysis, not a claim.
@@ -188,10 +190,10 @@ and water handling.
 
 ## Additional benchmarks — unverified / no receipt
 
-> **Unverified / no receipt.** The Pearson **r = 0.93** (ITC-187), CASF-2016 **81%**,
-> DUD-E **AUC 0.89**, and CNS **92%** figures previously stated here are **withdrawn**.
-> No provenance receipt for those numbers exists in this repository. Do not cite them
-> as FlexAID∆S performance. Dataset YAML files may exist; that is not a result.
+> **Unverified / no receipt.** Previously stated ITC correlation, CASF, DUD-E, and CNS
+> figures on this page are **withdrawn**. No provenance receipt for those numbers exists
+> in this repository. Do not cite them as FlexAID∆S performance. Dataset YAML files may
+> exist; that is not a result.
 
 ### ITC-187: binding affinity prediction (intended campaign)
 
@@ -204,7 +206,7 @@ before quoting any correlation.
 ### CASF-2016, DUD-E, neurological targets
 
 These remain *intended* evaluation surfaces (pose prediction, virtual-screening enrichment,
-internal CNS pose-rescue). Previously quoted percentages (CASF 81%, DUD-E AUC 0.89, CNS 92%)
+internal CNS pose-rescue). Previously quoted percentages for those campaigns
 are withdrawn until a receipted run exists.
 
 ---

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -23,6 +23,30 @@ docks" reports are this.
 
 ---
 
+## One-liner (`curl | bash`)
+
+Review the script, then run it. Default: Python package everywhere; native
+engine on macOS when Homebrew is present (`brew install --HEAD`).
+
+```bash
+# review
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | less
+
+# install (macOS: Homebrew engine + Python; elsewhere: Python)
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash
+
+# Python only / engine only / print commands
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash -s -- --python-only
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash -s -- --engine-only
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash -s -- --dry-run
+```
+
+The script is `scripts/install.sh` in this repo. It does **not** call
+unpublished `pip install flexaidds` and does **not** call stable Homebrew
+without `--HEAD`.
+
+---
+
 ## Support matrix
 
 | Path | macOS arm64 | macOS x86_64 | Linux x86_64 | Windows | Ships engine | Ships Python |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,10 +28,12 @@ docks" reports are this.
 | Path | macOS arm64 | macOS x86_64 | Linux x86_64 | Windows | Ships engine | Ships Python |
 |---|---|---|---|---|---|---|
 | CMake from source | ✅ | ✅ | ✅ | ⚠️ partial | ✅ | optional |
-| Homebrew (`Formula/flexaidds.rb`) | ✅ | ✅ | — | — | ✅ | ❌ |
+| Homebrew (`brew install --HEAD`) | ✅ first-shot | ✅ first-shot | — | — | ✅ | ❌ |
+| Homebrew stable `v2.0.3` tarball | ❌ provenance refuse | ❌ provenance refuse | — | — | — | — |
 | Docker (`containers/Dockerfile.locked`) | ✅ via Docker | ✅ | ✅ | ✅ via Docker | ✅ | ❌ |
 | Apptainer (`containers/*.def`) | — | — | ✅ | — | ✅ | ❌ |
-| `pip` | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| `pip install flexaidds` (PyPI) | ❌ unpublished | ❌ unpublished | ❌ unpublished | ❌ unpublished | ❌ | — |
+| pip git+subdirectory / local wheel | ✅ first-shot | ✅ first-shot | ✅ | ✅ | ❌ | ✅ |
 | conda (`conda/meta.yaml`) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
 | Release binaries (`release.yml`) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 
@@ -72,16 +74,23 @@ Dependencies: CMake ≥ 3.28, Ninja or Make, Eigen 3.4+, and OpenMP
 
 ## Engine: Homebrew (lowest friction on macOS)
 
+First-shot command — this is the one that installs today. Stable `v2.0.3`
+tarball **cannot** emit `flexaidds-build-provenance.json`, and the formula
+refuses it rather than putting an unidentifiable binary on PATH. Use `--HEAD`
+until the next tag.
+
 ```bash
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
 brew trust --formula lebonhommepharma/flexaidds/flexaidds
-brew install lebonhommepharma/flexaidds/flexaidds
+brew install --HEAD lebonhommepharma/flexaidds/flexaidds
+FlexAIDdS --help
 ```
 
-CPU + OpenMP by default. Metal is opt-in and needs a real Metal toolchain:
+CPU + OpenMP by default. Metal is opt-in and needs a real Metal toolchain
+(not the first-shot path):
 
 ```bash
-brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
+brew install --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
 ```
 
 ## Engine: Docker (most reproducible)
@@ -101,17 +110,35 @@ with `--build-arg ALLOW_UNKNOWN_PROVENANCE=1` only for a throwaway image.
 
 ## Python: pip
 
+`flexaidds` is **not on public PyPI**. `pip install flexaidds` fails today
+(`No matching distribution found`). First-shot is git+subdirectory or a
+local wheel. `FLEXAIDDS_SKIP_CORE=1` is the no-compiler path (pure Python).
+
 ```bash
-pip install flexaidds          # once published
-# or, from the repo:
-pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+python3 -m venv .venv && source .venv/bin/activate
+python -m pip install -U pip
+FLEXAIDDS_SKIP_CORE=1 pip install \
+  "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+python -c "import flexaidds as fd; print(fd.__version__)"
 flexaidds --help
 ```
 
-`pip install` is designed never to fail. The accelerated `flexaidds._core`
-extension is optional: when pybind11, Eigen, and a C++26 compiler are all
-present it is compiled; otherwise the install succeeds with pure-Python
-fallbacks and `flexaidds.HAS_CORE_BINDINGS` is `False`. Check which you got:
+From a clone, the same first-shot as a built wheel (no editable checkout):
+
+```bash
+cd python
+FLEXAIDDS_SKIP_CORE=1 python -m build
+FLEXAIDDS_SKIP_CORE=1 pip install dist/flexaidds-*.whl
+flexaidds --help
+```
+
+After the first PyPI release, `pip install flexaidds` will work. Until then
+do not treat that line as a working first-shot.
+
+The accelerated `flexaidds._core` extension is optional: when pybind11, Eigen,
+and a C++26 compiler are all present it is compiled; otherwise the install
+succeeds with pure-Python fallbacks and `flexaidds.HAS_CORE_BINDINGS` is
+`False`. Check which you got:
 
 ```bash
 python -c "import flexaidds as fd; print(fd.__version__, fd.HAS_CORE_BINDINGS)"
@@ -219,9 +246,20 @@ Where the packaging format allows a pin, it is pinned:
 
 ## Troubleshooting
 
+**`pip install flexaidds` → No matching distribution found.** Public PyPI has
+no `flexaidds` package yet. Use the git+subdirectory first-shot above (or a
+local wheel). `FLEXAIDDS_SKIP_CORE=1` is the no-compiler path.
+
 **`pip install` succeeded but `HAS_CORE_BINDINGS` is `False`.** Expected unless
 you have pybind11 + Eigen + a C++26 compiler. Not an error; the pure-Python
 fallbacks are correct, just slower.
+
+**`brew install` (no `--HEAD`) dies immediately about provenance.** Expected
+until the next tag. The first-shot command is `brew install --HEAD …`.
+
+**`which FlexAIDdS` is a repo `build/` binary, not Homebrew.** Homebrew warns
+that `FlexAIDdS` is shadowed if a git checkout's `build/` is on `PATH`. Run
+`/opt/homebrew/bin/FlexAIDdS --help` or put Homebrew's `bin` first.
 
 **CMake: "requires GCC ≥ 14".** The floor is real. `CXX=g++-14 cmake -S . -B build …`.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,11 +39,32 @@ curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scr
 curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash -s -- --python-only
 curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash -s -- --engine-only
 curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash -s -- --dry-run
+
+# wget (same script)
+wget -qO- https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash
 ```
 
 The script is `scripts/install.sh` in this repo. It does **not** call
 unpublished `pip install flexaidds` and does **not** call stable Homebrew
 without `--HEAD`.
+
+### Update everything at once
+
+One command refreshes every front already on the machine (Homebrew `--HEAD`
+engine, `~/.flexaidds/venv` pip, `uv tool`, `pipx`, local GHCR image):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh | bash
+# or
+wget -qO- https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh | bash
+# or, from a clone / installed CLI:
+bash scripts/update.sh
+python -m flexaidds --self-update
+```
+
+`--dry-run` prints the commands. This tracks `main` via git/HEAD and does
+**not** wait for a new GitHub Release tag. Maintainers publish all channels
+together with `gh workflow run release-all.yml`.
 
 ---
 
@@ -51,15 +72,24 @@ without `--HEAD`.
 
 | Path | macOS arm64 | macOS x86_64 | Linux x86_64 | Windows | Ships engine | Ships Python |
 |---|---|---|---|---|---|---|
+| `curl`/`wget` `scripts/install.sh` | ✅ first-shot | ✅ first-shot | ✅ Python | ✅ Python | macOS brew | ✅ |
 | CMake from source | ✅ | ✅ | ✅ | ⚠️ partial | ✅ | optional |
 | Homebrew (`brew install --HEAD`) | ✅ first-shot | ✅ first-shot | — | — | ✅ | ❌ |
 | Homebrew stable `v2.0.3` tarball | ❌ provenance refuse | ❌ provenance refuse | — | — | — | — |
-| Docker (`containers/Dockerfile.locked`) | ✅ via Docker | ✅ | ✅ | ✅ via Docker | ✅ | ❌ |
+| Homebrew bottle | ⚠️ next tag | ⚠️ next tag | — | — | ✅ | ❌ |
+| Docker **build** (`Dockerfile.locked`) | ✅ | ✅ | ✅ | ✅ via Docker | ✅ | ❌ |
+| `docker pull ghcr.io/lebonhommepharma/flexaidds` | ⚠️ workflow ready | ⚠️ | ⚠️ | ⚠️ | ✅ | ❌ |
 | Apptainer (`containers/*.def`) | — | — | ✅ | — | ✅ | ❌ |
 | `pip install flexaidds` (PyPI) | ❌ unpublished | ❌ unpublished | ❌ unpublished | ❌ unpublished | ❌ | — |
 | pip git+subdirectory / local wheel | ✅ first-shot | ✅ first-shot | ✅ | ✅ | ❌ | ✅ |
-| conda (`conda/meta.yaml`) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Release binaries (`release.yml`) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `uv tool install` (git) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| `pipx install` (git) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| conda (`environment.yml` / `conda/meta.yaml`) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| conda-forge channel | ❌ no feedstock | ❌ | ❌ | ❌ | ❌ | — |
+| GitHub Release + `SHA256SUMS.txt` | ⚠️ next tag | ⚠️ next tag | ⚠️ next tag | ⚠️ next tag | ✅ | ❌ |
+| GitHub Action `setup-flexaidds` | ✅ CI | ✅ | ✅ | ✅ | ❌ | ✅ |
+| Dev Container / Codespaces | ✅ Python | ✅ | ✅ | — | optional | ✅ |
+| Spack / EasyBuild / Lmod | ⚠️ overlay | ⚠️ | ⚠️ overlay | — | ✅ | optional |
 
 ⚠️ **Windows**: MSVC has no `/std:c++26`, so `CMakeLists.txt` caps Windows at
 C++20 and only the `_core` Python extension builds correctly. The full engine
@@ -132,6 +162,15 @@ docker run --rm -v "$PWD:/work" -w /work flexaidds:locked-x86_64 --help
 The build **fails** if the resulting image has no recoverable commit. Override
 with `--build-arg ALLOW_UNKNOWN_PROVENANCE=1` only for a throwaway image.
 
+Published pull (after `.github/workflows/ghcr.yml` has run on a tag):
+
+```bash
+docker pull ghcr.io/lebonhommepharma/flexaidds:latest
+docker run --rm ghcr.io/lebonhommepharma/flexaidds:latest --help
+```
+
+Until that workflow has published an image, `docker pull` 404s — use `docker build`.
+
 ## Python: pip
 
 `flexaidds` is **not on public PyPI**. `pip install flexaidds` fails today
@@ -158,6 +197,73 @@ flexaidds --help
 
 After the first PyPI release, `pip install flexaidds` will work. Until then
 do not treat that line as a working first-shot.
+
+### uv / pipx (CLI on PATH, no venv lecture)
+
+```bash
+# uv (https://docs.astral.sh/uv/)
+FLEXAIDDS_SKIP_CORE=1 uv tool install \
+  "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+flexaidds --help
+
+# pipx
+FLEXAIDDS_SKIP_CORE=1 pipx install \
+  "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+flexaidds --help
+
+# or via the curl installer
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh \
+  | bash -s -- --python-only --uv
+```
+
+From a clone: `FLEXAIDDS_SKIP_CORE=1 uv tool install ./python` /
+`FLEXAIDDS_SKIP_CORE=1 pipx install ./python`.
+
+### Checksummed GitHub Release binary
+
+`.github/workflows/release.yml` now attaches `flexaidds-*.tar.gz` / `.zip`
+and `SHA256SUMS.txt` to the GitHub Release. **Tags through v2.2.0 have zero
+assets** — this path is first-shot after the next `v*` tag.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh \
+  | bash -s -- --from-release latest
+```
+
+Fail-closed: missing `SHA256SUMS.txt` or a hash mismatch aborts.
+
+### GitHub Action
+
+```yaml
+- uses: actions/checkout@v6
+- uses: actions/setup-python@v7
+  with: { python-version: "3.11" }
+- uses: LeBonhommePharma/FlexAIDdS/.github/actions/setup-flexaidds@main
+  with:
+    from-checkout: "false"
+    skip-core: "true"
+- run: python -m flexaidds --help
+```
+
+In this repo's CI, `from-checkout: true` installs `./python` from the PR.
+
+### Dev Container / Codespaces
+
+Open the repo in VS Code / Codespaces. `.devcontainer/` installs the Python
+package with `FLEXAIDDS_SKIP_CORE=1`. Native engine compile remains optional.
+
+### Spack / EasyBuild / Lmod
+
+Recipes live under `packaging/` and are **overlays**, not upstream:
+
+- `packaging/spack/package.py`
+- `packaging/easybuild/flexaidds-2.0.3.eb`
+- `packaging/modulefiles/flexaidds.lua` (`FLEXAIDDS_PREFIX`, `FLEXAIDDS_VENV`)
+
+### conda-forge
+
+Not a feedstock. Use `conda env create -f environment.yml`. See
+`conda/conda-forge.md`.
 
 The accelerated `flexaidds._core` extension is optional: when pybind11, Eigen,
 and a C++26 compiler are all present it is compiled; otherwise the install

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -147,16 +147,13 @@ brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDd
 brew trust --formula lebonhommepharma/flexaidds/flexaidds
 # Fully-qualified install also trusts just that package for the install path.
 
-# Stable tagged release (v2.0.3+). Qualified name always works.
-brew install lebonhommepharma/flexaidds/flexaidds
-# short form after tap + trust: brew install flexaidds
-
-# Metal GPU (macOS + Xcode Metal toolchain). Stable v2.0.3+ links bridges via
-# flexaid_core (PR #260) on main / the release tag — never a feature branch.
-brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
-
-# Or latest development tip (formula head tracks main only)
+# First-shot (required today): stable v2.0.3 tarball cannot emit provenance
+# JSON, so the formula refuses it. --HEAD tracks main.
 brew install --HEAD lebonhommepharma/flexaidds/flexaidds
+FlexAIDdS --help
+
+# Metal GPU (macOS + Xcode Metal toolchain). Not the first-shot path.
+brew install --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
 
 # Update later
 brew update && brew reinstall lebonhommepharma/flexaidds/flexaidds
@@ -256,15 +253,12 @@ brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDd
 # Homebrew 6+ / HOMEBREW_REQUIRE_TAP_TRUST: trust this formula only
 brew trust --formula lebonhommepharma/flexaidds/flexaidds
 
-# Stable release (qualified name always works)
-brew install lebonhommepharma/flexaidds/flexaidds
-# short form after tap + trust: brew install flexaidds
-
-# Metal GPU (stable v2.0.3+ — flexaid_core Metal link fix, PR #260; no feature branch)
-brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds
-
-# Development / latest (formula head tracks main only — never ephemeral branches)
+# First-shot (stable v2.0.3 tarball is refused — no provenance JSON)
 brew install --HEAD lebonhommepharma/flexaidds/flexaidds
+FlexAIDdS --help
+
+# Metal GPU (not first-shot; needs Xcode Metal toolchain)
+brew install --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds
 
 # After install, add the Python package (GitHub until PyPI publish):
 pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
@@ -331,7 +325,7 @@ curl -sL "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/${TAG}
   python -c "import flexaidds as fd; print(fd.__version__, fd.HAS_CORE_BINDINGS)"
   ```
 
-- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` must track default branch `main` only — never ephemeral feature branches) when cutting releases. Users install via `brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS`, then `brew trust --formula lebonhommepharma/flexaidds/flexaidds` when `HOMEBREW_REQUIRE_TAP_TRUST` is set, then `brew install flexaidds` (Homebrew 6+ requires a real tap with `origin`; raw formula URLs are rejected). For Metal: `brew install --build-from-source --with-metal lebonhommepharma/flexaidds/flexaidds` (stable v2.0.3+ on main/tag).
+- **Homebrew**: Update `Formula/flexaidds.rb` (`url` + `sha256` for stable; `head` must track default branch `main` only — never ephemeral feature branches) when cutting releases. Until the next tag, first-shot is `brew install --HEAD lebonhommepharma/flexaidds/flexaidds` after tap + `brew trust --formula lebonhommepharma/flexaidds/flexaidds`. Stable `v2.0.3` is refused (no provenance JSON). For Metal: `brew install --HEAD --with-metal lebonhommepharma/flexaidds/flexaidds`.
 - **Native binaries**: Existing release workflow attaches platform archives on tag.
 
 - **In-package updater**: `python -m flexaidds --check-update` / `--self-update` uses the GitHub Releases API and `pip install --upgrade flexaidds` (falls back to the GitHub VCS URL when the package is not yet on the default index).

--- a/packaging/easybuild/flexaidds-2.0.3.eb
+++ b/packaging/easybuild/flexaidds-2.0.3.eb
@@ -1,0 +1,38 @@
+# EasyBuild easyconfig — not in upstream EasyBuild yet.
+# Copy into an EasyBuild robot path. Apache-2.0.
+easyblock = 'CMakeMake'
+
+name = 'FlexAIDdS'
+version = '2.0.3'
+
+homepage = 'https://github.com/LeBonhommePharma/FlexAIDdS'
+description = "Entropy-aware molecular docking engine (native FlexAIDdS)."
+
+toolchain = {'name': 'GCCcore', 'version': '13.3.0'}
+
+source_urls = ['https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['6c8442fc672a127db354ff3b6e08a2252e8c921372d902d062ecbf4296aef186']
+
+builddependencies = [
+    ('CMake', '3.29.3'),
+    ('Ninja', '1.12.1'),
+]
+dependencies = [
+    ('Eigen', '3.4.0'),
+]
+
+configopts = ' '.join([
+    '-DBUILD_TESTING=OFF',
+    '-DBUILD_PYTHON_BINDINGS=OFF',
+    '-DFLEXAIDS_USE_CUDA=OFF',
+    '-DFLEXAIDS_USE_METAL=OFF',
+    '-DFLEXAIDS_GIT_COMMIT_OVERRIDE=%(version)s',
+])
+
+sanity_check_paths = {
+    'files': ['bin/FlexAIDdS'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/packaging/modulefiles/flexaidds.lua
+++ b/packaging/modulefiles/flexaidds.lua
@@ -1,0 +1,19 @@
+-- Lmod modulefile template. Point PREFIX at an installed FlexAIDdS prefix.
+--   module use $PWD/packaging/modulefiles
+--   export FLEXAIDDS_PREFIX=/path/to/install
+help([[
+FlexAID∆S native engine + optional Python venv.
+
+The native binary and the flexaidds Python package are separate.
+]])
+
+local prefix = os.getenv("FLEXAIDDS_PREFIX") or "/usr/local"
+prepend_path("PATH", pathJoin(prefix, "bin"))
+setenv("FLEXAIDDS_DATA_DIR", pathJoin(prefix, "share"))
+
+local venv = os.getenv("FLEXAIDDS_VENV") or pathJoin(os.getenv("HOME") or "", ".flexaidds/venv")
+if isDir(pathJoin(venv, "bin")) then
+  prepend_path("PATH", pathJoin(venv, "bin"))
+end
+
+whatis("FlexAID∆S docking engine")

--- a/packaging/spack/package.py
+++ b/packaging/spack/package.py
@@ -1,0 +1,38 @@
+# Spack recipe for FlexAID∆S (not yet in builtin Spack; copy into a repo overlay).
+# SPDX-License-Identifier: Apache-2.0
+from spack.package import *
+
+
+class Flexaidds(CMakePackage):
+    """Entropy-aware molecular docking engine (native FlexAIDdS + tENCoM)."""
+
+    homepage = "https://github.com/LeBonhommePharma/FlexAIDdS"
+    url = "https://github.com/LeBonhommePharma/FlexAIDdS/archive/refs/tags/v2.0.3.tar.gz"
+    git = "https://github.com/LeBonhommePharma/FlexAIDdS.git"
+
+    maintainers("LeBonhommePharma")
+    license("Apache-2.0")
+
+    version("main", branch="main")
+    version(
+        "2.0.3",
+        sha256="6c8442fc672a127db354ff3b6e08a2252e8c921372d902d062ecbf4296aef186",
+    )
+
+    variant("python", default=False, description="Install flexaidds Python package")
+    variant("metal", default=False, description="Metal GPU (macOS only)")
+
+    depends_on("cmake@3.28:", type="build")
+    depends_on("ninja", type="build")
+    depends_on("eigen@3.4:")
+    depends_on("python@3.9:", when="+python", type=("build", "run"))
+
+    def cmake_args(self):
+        args = [
+            self.define("BUILD_TESTING", False),
+            self.define("BUILD_PYTHON_BINDINGS", False),
+            self.define("FLEXAIDS_USE_CUDA", False),
+            self.define_from_variant("FLEXAIDS_USE_METAL", "metal"),
+            self.define("FLEXAIDS_GIT_COMMIT_OVERRIDE", str(self.spec.version)),
+        ]
+        return args

--- a/python/README.md
+++ b/python/README.md
@@ -16,17 +16,18 @@ Higher-level live docking orchestration is still intentionally staged behind the
 ### With pip (recommended for most users)
 
 ```bash
-# Recommended today (package not yet on public PyPI):
-pip install "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
-python -m flexaidds --check-update       # or --self-update
+# First-shot (package is not on public PyPI — pip install flexaidds fails):
+FLEXAIDDS_SKIP_CORE=1 pip install \
+  "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"
+python -c "import flexaidds as fd; print(fd.__version__)"
+flexaidds --help
 # Console scripts after install: flexaidds, flexaidds-benchmark
 
 # From the repo root (development)
 pip install -e ./python
 
 # After the first PyPI release:
-pip install flexaidds
-pip install --upgrade flexaidds
+# pip install flexaidds
 ```
 
 This installs the **Python analysis package** only (not the native `FlexAIDdS` docking binary — use Homebrew or a CMake build for that). The compiled acceleration (`_core`) is built if the required build dependencies (pybind11, Eigen headers, a C++ compiler) are present. Otherwise the package installs successfully in **pure-Python fallback mode** (full result loading, models, pure-Python thermodynamics, etc. still work). Set `FLEXAIDDS_SKIP_CORE=1` to force pure-Python.
@@ -34,7 +35,8 @@ This installs the **Python analysis package** only (not the native `FlexAIDdS` d
 **Native docking tools (separate):**
 ```bash
 brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS
-brew install lebonhommepharma/flexaidds/flexaidds
+brew trust --formula lebonhommepharma/flexaidds/flexaidds
+brew install --HEAD lebonhommepharma/flexaidds/flexaidds
 ```
 
 You can also do a non-editable install after building a wheel:

--- a/python/flexaidds/__init__.py
+++ b/python/flexaidds/__init__.py
@@ -16,7 +16,7 @@ from .dift import (
     spectral_entropy,
 )
 from .__version__ import __version__ as __version__
-from .updater import check_for_updates, UpdateInfo
+from .updater import check_for_updates, UpdateInfo, update_all
 from .boltz2 import (
     Boltz2Client,
     Boltz2PredictionResult,
@@ -325,6 +325,7 @@ __all__ = [
     "write_all_reports",
     # Updater
     "check_for_updates",
+    "update_all",
     "UpdateInfo",
     # Boltz2
     "Boltz2Client",

--- a/python/flexaidds/__main__.py
+++ b/python/flexaidds/__main__.py
@@ -74,7 +74,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--self-update",
         action="store_true",
-        help="Check for and install the latest version via pip.",
+        help="Refresh every detected install front (Homebrew engine, pip/uv/pipx, docker).",
     )
     return parser
 
@@ -133,30 +133,19 @@ def main() -> int:
 
     # Handle update flags first
     if args.check_update or args.self_update:
-        from .updater import check_for_updates, update_pip
+        from .updater import check_for_updates, update_all
 
         info = check_for_updates()
-        if info is None:
-            print("Could not reach GitHub API to check for updates.")
-            return 1
+        if info is not None:
+            print(f"Current version: {info.current_version}")
+            print(f"Latest GitHub Release: {info.latest_version}")
+            print(f"Release URL: {info.release_url}")
+        else:
+            print("GitHub Releases API unreachable; continuing with git/HEAD refresh.")
 
-        print(f"Current version: {info.current_version}")
-        print(f"Latest version:  {info.latest_version}")
-
-        if not info.update_available:
-            print("You are up to date.")
-            return 0
-
-        print(f"Update available: {info.release_url}")
         if args.self_update:
-            print("Installing update via pip...")
-            version = info.latest_version.lstrip("v")
-            rc = update_pip(version)
-            if rc == 0:
-                print("Update installed successfully.")
-            else:
-                print(f"pip exited with code {rc}")
-            return rc
+            print("Refreshing Homebrew engine, pip/uv/pipx, and docker if present...")
+            return update_all()
 
         return 0
 

--- a/python/flexaidds/dataset_runner/datasets/__init__.py
+++ b/python/flexaidds/dataset_runner/datasets/__init__.py
@@ -1,0 +1,1 @@
+"""YAML dataset manifests shipped with the flexaidds package."""

--- a/python/flexaidds/updater.py
+++ b/python/flexaidds/updater.py
@@ -11,6 +11,7 @@ import json
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -251,3 +252,96 @@ def select_asset_for_platform(assets: list[AssetInfo]) -> Optional[AssetInfo]:
             return asset
 
     return None
+
+
+_FORMULA = "lebonhommepharma/flexaidds/flexaidds"
+_GHCR = "ghcr.io/lebonhommepharma/flexaidds"
+
+
+def _run(cmd: list[str], *, dry_run: bool, env: Optional[dict] = None) -> int:
+    print("+", " ".join(cmd))
+    if dry_run:
+        return 0
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.run(cmd, env=merged).returncode
+
+
+def update_all(*, dry_run: bool = False) -> int:
+    """Refresh every detected install front (engine, Python, docker).
+
+    One command for curl/Homebrew/pip/uv/pipx users. Does not require a new
+    GitHub Release tag — HEAD / git+subdirectory tracks ``main``.
+    """
+    rc = 0
+
+    brew = shutil.which("brew")
+    if brew:
+        listed = subprocess.run(
+            [brew, "list", "--formula", _FORMULA],
+            capture_output=True,
+        )
+        if listed.returncode != 0:
+            listed = subprocess.run(
+                [brew, "list", "--formula", "flexaidds"],
+                capture_output=True,
+            )
+        if listed.returncode == 0:
+            if _run([brew, "upgrade", "--fetch-HEAD", _FORMULA], dry_run=dry_run) != 0:
+                _run([brew, "uninstall", "--force", _FORMULA], dry_run=dry_run)
+                if _run([brew, "install", "--HEAD", _FORMULA], dry_run=dry_run) != 0:
+                    rc = 1
+        else:
+            print("engine: Homebrew flexaidds not installed — skip")
+    else:
+        print("engine: brew not found — skip")
+
+    pip_cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        _GIT_INSTALL_SPEC,
+    ]
+    if _run(pip_cmd, dry_run=dry_run, env={"FLEXAIDDS_SKIP_CORE": "1"}) != 0:
+        rc = 1
+
+    uv = shutil.which("uv")
+    if uv:
+        tools = subprocess.run([uv, "tool", "list"], capture_output=True, text=True)
+        if tools.returncode == 0 and "flexaidds" in tools.stdout:
+            if _run(
+                [uv, "tool", "upgrade", "flexaidds"],
+                dry_run=dry_run,
+                env={"FLEXAIDDS_SKIP_CORE": "1"},
+            ) != 0:
+                rc = 1
+
+    pipx = shutil.which("pipx")
+    if pipx:
+        tools = subprocess.run([pipx, "list"], capture_output=True, text=True)
+        if tools.returncode == 0 and "flexaidds" in tools.stdout.lower():
+            if _run(
+                [pipx, "upgrade", "flexaidds"],
+                dry_run=dry_run,
+                env={"FLEXAIDDS_SKIP_CORE": "1"},
+            ) != 0:
+                rc = 1
+
+    docker = shutil.which("docker")
+    if docker:
+        info = subprocess.run([docker, "info"], capture_output=True)
+        inspect = subprocess.run(
+            [docker, "image", "inspect", f"{_GHCR}:latest"],
+            capture_output=True,
+        )
+        if info.returncode == 0 and inspect.returncode == 0:
+            if _run([docker, "pull", f"{_GHCR}:latest"], dry_run=dry_run) != 0:
+                rc = 1
+        else:
+            print("docker: no local GHCR image or daemon down — skip")
+
+    return rc

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,6 +69,7 @@ namespaces = false
 [tool.setuptools.package-data]
 "flexaidds" = ["py.typed"]
 "flexaidds.dataset_runner" = ["datasets/*.yaml"]
+"flexaidds.dataset_runner.datasets" = ["*.yaml"]
 
 # cibuildwheel: produce installable wheels even when the optional C++ extension
 # cannot be compiled (pure-Python fallback). setup.py never fails the install.

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,24 +30,26 @@ from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
 
 # --- P0: Wire source validator guard (python path) ---
-# Runs early so developers doing `pip install -e .` (or equivalent) get
-# immediate feedback if they added sources without wiring them.
-try:
-    repo_root = Path(__file__).resolve().parent.parent
-    sys.path.insert(0, str(repo_root))
-    from scripts.validate_sources import validate_sources
+# Developer checkouts only. An sdist / isolated PEP 517 build does not ship
+# scripts/validate_sources.py; staying silent there is required so first-shot
+# pip has no package-owned Warning on stderr.
+_repo_root = Path(__file__).resolve().parent.parent
+_guard = _repo_root / "scripts" / "validate_sources.py"
+if _guard.is_file():
+    try:
+        sys.path.insert(0, str(_repo_root))
+        from scripts.validate_sources import validate_sources
 
-    # Respect env var for CI / strict local runs. Default is lenient for
-    # normal developer `pip install -e` usage.
-    strict = os.environ.get("FLEXAIDS_STRICT_SOURCE_VALIDATION", "0").lower() not in (
-        "0",
-        "false",
-        "",
-    )
-    validate_sources(root=str(repo_root), strict=strict)
-except Exception as exc:
-    # Never break the build due to the guard during normal development.
-    print(f"[source-guard] Warning: validator skipped ({exc})", file=sys.stderr)
+        strict = os.environ.get("FLEXAIDS_STRICT_SOURCE_VALIDATION", "0").lower() not in (
+            "0",
+            "false",
+            "",
+        )
+        validate_sources(root=str(_repo_root), strict=strict)
+    except Exception:
+        # Never break pip. Do not print: isolated builds and missing optional
+        # tooling are not user-facing install failures.
+        pass
 
 ROOT = Path(__file__).resolve().parent
 
@@ -416,10 +418,6 @@ class optional_build_ext(_build_ext):
 
     def _prepare_core_extension(self, ext: Extension) -> bool:
         if _skip_core_requested():
-            warnings.warn(
-                "FLEXAIDDS_SKIP_CORE set — installing pure-Python package only.",
-                stacklevel=2,
-            )
             return False
 
         try:
@@ -613,10 +611,7 @@ def _placeholder_extension_modules() -> List[Extension]:
     Real sources are filled in by ``optional_build_ext`` at compile time.
     """
     if _skip_core_requested():
-        warnings.warn(
-            "FLEXAIDDS_SKIP_CORE set — installing pure-Python package only.",
-            stacklevel=2,
-        )
+        # Explicit request — do not emit a UserWarning on first-shot installs.
         return []
 
     if not _can_attempt_core():

--- a/python/tests/test_updater.py
+++ b/python/tests/test_updater.py
@@ -19,6 +19,7 @@ from flexaidds.updater import (
     check_for_updates,
     get_current_version,
     select_asset_for_platform,
+    update_all,
 )
 
 
@@ -175,3 +176,32 @@ class TestSelectAssetForPlatform:
         ):
             result = select_asset_for_platform(assets)
         assert result is None
+
+
+class TestUpdateAll:
+    def test_dry_run_skips_subprocess_side_effects(self):
+        with (
+            mock.patch("flexaidds.updater.shutil.which", return_value=None),
+            mock.patch("flexaidds.updater.subprocess.run") as run,
+        ):
+            rc = update_all(dry_run=True)
+        assert rc == 0
+        # dry_run still runs brew/uv/pipx *list* probes? which() is None so
+        # only the pip command is printed, not executed.
+        run.assert_not_called()
+
+    def test_dry_run_with_brew_prints_upgrade_and_does_not_exec(self):
+        def which(name):
+            return "/opt/homebrew/bin/brew" if name == "brew" else None
+
+        list_ok = mock.MagicMock(returncode=0)
+        with (
+            mock.patch("flexaidds.updater.shutil.which", side_effect=which),
+            mock.patch("flexaidds.updater.subprocess.run", return_value=list_ok) as run,
+        ):
+            rc = update_all(dry_run=True)
+        assert rc == 0
+        # list probe runs; install/upgrade does not (dry_run).
+        called = [" ".join(c.args[0]) for c in run.call_args_list]
+        assert any("list" in c for c in called)
+        assert not any("upgrade" in c or "install" in c for c in called)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# FlexAID∆S first-shot installer (engine and Python package are separate).
+#
+# Review first:
+#   curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | less
+# Run:
+#   curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash
+# Flags (when piping, pass them after -s --):
+#   curl -fsSL …/scripts/install.sh | bash -s -- --python-only
+#   curl -fsSL …/scripts/install.sh | bash -s -- --engine-only
+#   curl -fsSL …/scripts/install.sh | bash -s -- --dry-run
+#
+# Default: Python package always; native engine on macOS when Homebrew is present
+# (brew install --HEAD). Does not call unpublished `pip install flexaidds` and
+# does not call stable `brew install` without --HEAD.
+set -euo pipefail
+
+REPO_HTTPS="https://github.com/LeBonhommePharma/FlexAIDdS.git"
+TAP_NAME="lebonhommepharma/flexaidds"
+FORMULA="${TAP_NAME}/flexaidds"
+PY_GIT="git+${REPO_HTTPS}#subdirectory=python"
+VENV="${FLEXAIDDS_VENV:-${HOME}/.flexaidds/venv}"
+
+WANT_ENGINE=1
+WANT_PYTHON=1
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+FlexAID∆S first-shot installer
+
+Usage:
+  scripts/install.sh [--all | --engine-only | --python-only] [--dry-run]
+
+  --all            Native engine (macOS Homebrew --HEAD) + Python package (default)
+  --engine-only    Homebrew FlexAIDdS / tENCoM only
+  --python-only    flexaidds Python package only (git+subdirectory, SKIP_CORE=1)
+  --dry-run        Print commands; do not install
+
+The native engine and the flexaidds Python package are separate. Installing
+one does not give you the other. flexaidds is not on public PyPI. Homebrew
+stable v2.0.3 is refused (no provenance JSON); first-shot is --HEAD.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all) WANT_ENGINE=1; WANT_PYTHON=1; shift ;;
+    --engine-only) WANT_ENGINE=1; WANT_PYTHON=0; shift ;;
+    --python-only) WANT_ENGINE=0; WANT_PYTHON=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+run() {
+  printf '+ %s\n' "$*"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+os="$(uname -s 2>/dev/null || echo unknown)"
+
+echo "FlexAID∆S installer"
+echo "  os=${os}"
+echo "  engine=${WANT_ENGINE} python=${WANT_PYTHON} dry_run=${DRY_RUN}"
+echo "  engine = native FlexAIDdS binary (Homebrew --HEAD on macOS)"
+echo "  python = flexaidds analysis package (not the docking engine)"
+
+install_engine() {
+  if [[ "$os" != Darwin ]]; then
+    echo "Native engine curl path is macOS Homebrew today."
+    echo "On ${os}: use CMake or Docker — see docs/INSTALL.md"
+    echo "  git clone ${REPO_HTTPS}"
+    echo "  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --parallel"
+    return 0
+  fi
+  if ! have brew; then
+    echo "Homebrew is required for the macOS engine first-shot." >&2
+    echo "Install Homebrew from https://brew.sh then re-run this script." >&2
+    echo "Or build from source (docs/INSTALL.md)." >&2
+    return 1
+  fi
+  run brew tap "$TAP_NAME" "$REPO_HTTPS"
+  # tap trust is a no-op when already trusted; required on Homebrew 6+ when
+  # HOMEBREW_REQUIRE_TAP_TRUST is set.
+  run brew trust --formula "$FORMULA" || true
+  run brew install --HEAD "$FORMULA"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ FlexAIDdS --help"
+    return 0
+  fi
+  if have FlexAIDdS; then
+    FlexAIDdS --help >/dev/null
+    echo "engine: FlexAIDdS --help ok ($(command -v FlexAIDdS))"
+  elif [[ -x /opt/homebrew/bin/FlexAIDdS ]]; then
+    /opt/homebrew/bin/FlexAIDdS --help >/dev/null
+    echo "engine: /opt/homebrew/bin/FlexAIDdS --help ok (not first on PATH)"
+  elif [[ -x /usr/local/bin/FlexAIDdS ]]; then
+    /usr/local/bin/FlexAIDdS --help >/dev/null
+    echo "engine: /usr/local/bin/FlexAIDdS --help ok (not first on PATH)"
+  else
+    echo "FlexAIDdS not on PATH after brew install --HEAD" >&2
+    return 1
+  fi
+}
+
+install_python() {
+  if ! have python3; then
+    echo "python3 >= 3.9 is required for the flexaidds package." >&2
+    return 1
+  fi
+  if ! have git; then
+    echo "git is required (pip installs from GitHub, not PyPI)." >&2
+    return 1
+  fi
+  run mkdir -p "$(dirname "$VENV")"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ python3 -m venv ${VENV}"
+    echo "+ ${VENV}/bin/python -m pip install -U pip"
+    echo "+ FLEXAIDDS_SKIP_CORE=1 ${VENV}/bin/pip install ${PY_GIT}"
+    echo "+ ${VENV}/bin/python -c 'import flexaidds as fd; print(fd.__version__)'"
+    echo "+ ${VENV}/bin/flexaidds --help"
+    return 0
+  fi
+  if [[ ! -x "${VENV}/bin/python" ]]; then
+    run python3 -m venv "$VENV"
+  fi
+  run "${VENV}/bin/python" -m pip install -U pip
+  run env FLEXAIDDS_SKIP_CORE=1 "${VENV}/bin/pip" install "$PY_GIT"
+  ver="$("${VENV}/bin/python" -c "import flexaidds as fd; print(fd.__version__)")"
+  "${VENV}/bin/flexaidds" --help >/dev/null
+  echo "python: flexaidds ${ver} ok (${VENV}/bin/flexaidds)"
+  echo "Activate with:  source ${VENV}/bin/activate"
+}
+
+ec=0
+if [[ "$WANT_ENGINE" -eq 1 ]]; then
+  install_engine || ec=1
+fi
+if [[ "$WANT_PYTHON" -eq 1 ]]; then
+  install_python || ec=1
+fi
+
+if [[ "$ec" -ne 0 ]]; then
+  echo "install finished with errors (see above)." >&2
+  exit "$ec"
+fi
+echo "done."
+exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,45 +1,55 @@
 #!/usr/bin/env bash
 # FlexAID∆S first-shot installer (engine and Python package are separate).
 #
-# Review first:
+# Review:
 #   curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | less
+#   wget -qO- https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | less
 # Run:
-#   curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh | bash
-# Flags (when piping, pass them after -s --):
-#   curl -fsSL …/scripts/install.sh | bash -s -- --python-only
-#   curl -fsSL …/scripts/install.sh | bash -s -- --engine-only
-#   curl -fsSL …/scripts/install.sh | bash -s -- --dry-run
-#
-# Default: Python package always; native engine on macOS when Homebrew is present
-# (brew install --HEAD). Does not call unpublished `pip install flexaidds` and
-# does not call stable `brew install` without --HEAD.
+#   curl -fsSL …/scripts/install.sh | bash
+#   wget -qO-  …/scripts/install.sh | bash
+# Flags (after -s -- when piping):
+#   --python-only | --engine-only | --uv | --pipx | --from-release [tag]
+#   --from-archive FILE --sha256 HEX --prefix DIR | --dry-run
 set -euo pipefail
 
 REPO_HTTPS="https://github.com/LeBonhommePharma/FlexAIDdS.git"
+REPO_SLUG="LeBonhommePharma/FlexAIDdS"
 TAP_NAME="lebonhommepharma/flexaidds"
 FORMULA="${TAP_NAME}/flexaidds"
 PY_GIT="git+${REPO_HTTPS}#subdirectory=python"
 VENV="${FLEXAIDDS_VENV:-${HOME}/.flexaidds/venv}"
+PREFIX="${FLEXAIDDS_PREFIX:-${HOME}/.local}"
 
 WANT_ENGINE=1
 WANT_PYTHON=1
 DRY_RUN=0
+PY_BACKEND="pip" # pip | uv | pipx
+FROM_RELEASE=""
+FROM_ARCHIVE=""
+EXPECT_SHA256=""
 
 usage() {
   cat <<'EOF'
 FlexAID∆S first-shot installer
 
 Usage:
-  scripts/install.sh [--all | --engine-only | --python-only] [--dry-run]
+  scripts/install.sh [options]
 
-  --all            Native engine (macOS Homebrew --HEAD) + Python package (default)
-  --engine-only    Homebrew FlexAIDdS / tENCoM only
-  --python-only    flexaidds Python package only (git+subdirectory, SKIP_CORE=1)
-  --dry-run        Print commands; do not install
+  --all              Homebrew --HEAD engine (macOS) + Python (default)
+  --engine-only      Native engine only
+  --python-only      flexaidds Python package only
+  --uv               Python via `uv tool install` (git+subdirectory)
+  --pipx             Python via `pipx install` (git+subdirectory)
+  --from-release [TAG]
+                     Download GitHub Release tarball + SHA256SUMS.txt (fail-closed)
+  --from-archive FILE
+                     Install a local tarball (pair with --sha256)
+  --sha256 HEX       Expected SHA-256 of --from-archive
+  --prefix DIR       Unpack prefix for release/archive (default: ~/.local)
+  --dry-run          Print commands; do not install
 
-The native engine and the flexaidds Python package are separate. Installing
-one does not give you the other. flexaidds is not on public PyPI. Homebrew
-stable v2.0.3 is refused (no provenance JSON); first-shot is --HEAD.
+Does not call unpublished `pip install flexaidds`.
+Does not call stable Homebrew without --HEAD.
 EOF
 }
 
@@ -48,6 +58,21 @@ while [[ $# -gt 0 ]]; do
     --all) WANT_ENGINE=1; WANT_PYTHON=1; shift ;;
     --engine-only) WANT_ENGINE=1; WANT_PYTHON=0; shift ;;
     --python-only) WANT_ENGINE=0; WANT_PYTHON=1; shift ;;
+    --uv) PY_BACKEND="uv"; shift ;;
+    --pipx) PY_BACKEND="pipx"; shift ;;
+    --from-release)
+      WANT_ENGINE=1
+      WANT_PYTHON=0
+      if [[ $# -ge 2 && "$2" != --* ]]; then FROM_RELEASE="$2"; shift 2; else FROM_RELEASE="latest"; shift; fi
+      ;;
+    --from-archive)
+      WANT_ENGINE=1
+      WANT_PYTHON=0
+      FROM_ARCHIVE="${2:?--from-archive needs a file}"
+      shift 2
+      ;;
+    --sha256) EXPECT_SHA256="${2:?}"; shift 2 ;;
+    --prefix) PREFIX="${2:?}"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *)
@@ -66,35 +91,36 @@ run() {
   "$@"
 }
 
-have() {
-  command -v "$1" >/dev/null 2>&1
+have() { command -v "$1" >/dev/null 2>&1; }
+
+file_sha256() {
+  if have shasum; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
 }
 
 os="$(uname -s 2>/dev/null || echo unknown)"
+arch="$(uname -m 2>/dev/null || echo unknown)"
 
 echo "FlexAID∆S installer"
-echo "  os=${os}"
-echo "  engine=${WANT_ENGINE} python=${WANT_PYTHON} dry_run=${DRY_RUN}"
-echo "  engine = native FlexAIDdS binary (Homebrew --HEAD on macOS)"
-echo "  python = flexaidds analysis package (not the docking engine)"
+echo "  os=${os} arch=${arch} backend=${PY_BACKEND} dry_run=${DRY_RUN}"
+echo "  engine=${WANT_ENGINE} python=${WANT_PYTHON}"
 
-install_engine() {
+install_engine_brew() {
   if [[ "$os" != Darwin ]]; then
-    echo "Native engine curl path is macOS Homebrew today."
-    echo "On ${os}: use CMake or Docker — see docs/INSTALL.md"
+    echo "Native Homebrew engine is macOS-only. On ${os} use CMake, Docker, or --from-release."
     echo "  git clone ${REPO_HTTPS}"
     echo "  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --parallel"
     return 0
   fi
   if ! have brew; then
     echo "Homebrew is required for the macOS engine first-shot." >&2
-    echo "Install Homebrew from https://brew.sh then re-run this script." >&2
-    echo "Or build from source (docs/INSTALL.md)." >&2
+    echo "Install Homebrew from https://brew.sh then re-run." >&2
     return 1
   fi
   run brew tap "$TAP_NAME" "$REPO_HTTPS"
-  # tap trust is a no-op when already trusted; required on Homebrew 6+ when
-  # HOMEBREW_REQUIRE_TAP_TRUST is set.
   run brew trust --formula "$FORMULA" || true
   run brew install --HEAD "$FORMULA"
   if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -106,48 +132,187 @@ install_engine() {
     echo "engine: FlexAIDdS --help ok ($(command -v FlexAIDdS))"
   elif [[ -x /opt/homebrew/bin/FlexAIDdS ]]; then
     /opt/homebrew/bin/FlexAIDdS --help >/dev/null
-    echo "engine: /opt/homebrew/bin/FlexAIDdS --help ok (not first on PATH)"
+    echo "engine: /opt/homebrew/bin/FlexAIDdS --help ok"
   elif [[ -x /usr/local/bin/FlexAIDdS ]]; then
     /usr/local/bin/FlexAIDdS --help >/dev/null
-    echo "engine: /usr/local/bin/FlexAIDdS --help ok (not first on PATH)"
+    echo "engine: /usr/local/bin/FlexAIDdS --help ok"
   else
     echo "FlexAIDdS not on PATH after brew install --HEAD" >&2
     return 1
   fi
 }
 
-install_python() {
-  if ! have python3; then
-    echo "python3 >= 3.9 is required for the flexaidds package." >&2
+release_asset_name() {
+  case "${os}-${arch}" in
+    Darwin-arm64|Darwin-aarch64) echo "flexaidds-macos.tar.gz" ;;
+    Darwin-x86_64) echo "flexaidds-macos.tar.gz" ;;
+    Linux-x86_64|Linux-amd64) echo "flexaidds-linux.tar.gz" ;;
+    MINGW*|MSYS*|CYGWIN*|Windows*) echo "flexaidds-windows.zip" ;;
+    *) echo "flexaidds-macos.tar.gz" ;;
+  esac
+}
+
+install_from_archive() {
+  local archive="$1"
+  local expect="$2"
+  if [[ ! -f "$archive" && "$DRY_RUN" -eq 0 ]]; then
+    echo "archive not found: $archive" >&2
     return 1
   fi
-  if ! have git; then
-    echo "git is required (pip installs from GitHub, not PyPI)." >&2
+  if [[ -z "$expect" ]]; then
+    echo "--from-archive/--from-release requires a SHA-256 (SHA256SUMS.txt or --sha256)." >&2
     return 1
   fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ sha256 ${archive} == ${expect}"
+    echo "+ tar/unzip ${archive} -> ${PREFIX}"
+    return 0
+  fi
+  local got
+  got="$(file_sha256 "$archive")"
+  if [[ "$got" != "$expect" ]]; then
+    echo "SHA-256 mismatch for ${archive}" >&2
+    echo "  expected ${expect}" >&2
+    echo "  got      ${got}" >&2
+    return 1
+  fi
+  mkdir -p "${PREFIX}/bin"
+  case "$archive" in
+    *.zip)
+      unzip -o "$archive" -d "${PREFIX}/.flexaidds-unpack"
+      ;;
+    *)
+      tar -xzf "$archive" -C "${PREFIX}" --strip-components=0
+      ;;
+  esac
+  # Release layout is dist/FlexAIDdS (see .github/workflows/release.yml).
+  local candidate
+  for candidate in \
+      "${PREFIX}/dist/FlexAIDdS" \
+      "${PREFIX}/FlexAIDdS" \
+      "${PREFIX}/bin/FlexAIDdS" \
+      "${PREFIX}/.flexaidds-unpack/dist/FlexAIDdS" \
+      "${PREFIX}/.flexaidds-unpack/FlexAIDdS"
+  do
+    if [[ -f "$candidate" ]]; then
+      chmod +x "$candidate"
+      ln -sf "$candidate" "${PREFIX}/bin/FlexAIDdS"
+      echo "engine: installed ${candidate} -> ${PREFIX}/bin/FlexAIDdS"
+      "${PREFIX}/bin/FlexAIDdS" --help >/dev/null || true
+      return 0
+    fi
+  done
+  echo "tarball hashed OK but FlexAIDdS binary not found under ${PREFIX}" >&2
+  return 1
+}
+
+install_from_release() {
+  local tag="$1"
+  local asset
+  asset="$(release_asset_name)"
+  local base="https://github.com/${REPO_SLUG}/releases"
+  local sums_url asset_url
+  if [[ "$tag" == "latest" ]]; then
+    sums_url="${base}/latest/download/SHA256SUMS.txt"
+    asset_url="${base}/latest/download/${asset}"
+  else
+    sums_url="${base}/download/${tag}/SHA256SUMS.txt"
+    asset_url="${base}/download/${tag}/${asset}"
+  fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ curl -fsSL ${sums_url}"
+    echo "+ curl -fsSL ${asset_url}"
+    echo "+ verify sha256 of ${asset}"
+    return 0
+  fi
+  local tmp
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/flexaidds-rel.XXXXXX")"
+  if ! curl -fsSL "$sums_url" -o "${tmp}/SHA256SUMS.txt"; then
+    echo "No SHA256SUMS.txt on GitHub Release ${tag}." >&2
+    echo "Current tags may have zero assets; this path is live after the next tagged release that runs .github/workflows/release.yml." >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  curl -fsSL "$asset_url" -o "${tmp}/${asset}"
+  local expect
+  expect="$(awk -v a="${asset}" '$2==a || $2=="*"a {print $1; exit}' "${tmp}/SHA256SUMS.txt")"
+  if [[ -z "$expect" ]]; then
+    echo "${asset} not listed in SHA256SUMS.txt" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  install_from_archive "${tmp}/${asset}" "$expect"
+  local rc=$?
+  rm -rf "$tmp"
+  return "$rc"
+}
+
+install_python_pip() {
+  if ! have python3; then echo "python3 >= 3.9 required" >&2; return 1; fi
+  if ! have git; then echo "git required (not on PyPI)" >&2; return 1; fi
   run mkdir -p "$(dirname "$VENV")"
   if [[ "$DRY_RUN" -eq 1 ]]; then
     echo "+ python3 -m venv ${VENV}"
     echo "+ ${VENV}/bin/python -m pip install -U pip"
     echo "+ FLEXAIDDS_SKIP_CORE=1 ${VENV}/bin/pip install ${PY_GIT}"
-    echo "+ ${VENV}/bin/python -c 'import flexaidds as fd; print(fd.__version__)'"
     echo "+ ${VENV}/bin/flexaidds --help"
     return 0
   fi
-  if [[ ! -x "${VENV}/bin/python" ]]; then
-    run python3 -m venv "$VENV"
-  fi
+  [[ -x "${VENV}/bin/python" ]] || run python3 -m venv "$VENV"
   run "${VENV}/bin/python" -m pip install -U pip
   run env FLEXAIDDS_SKIP_CORE=1 "${VENV}/bin/pip" install "$PY_GIT"
   ver="$("${VENV}/bin/python" -c "import flexaidds as fd; print(fd.__version__)")"
   "${VENV}/bin/flexaidds" --help >/dev/null
-  echo "python: flexaidds ${ver} ok (${VENV}/bin/flexaidds)"
-  echo "Activate with:  source ${VENV}/bin/activate"
+  echo "python: flexaidds ${ver} via pip (${VENV}/bin/flexaidds)"
+  echo "Activate:  source ${VENV}/bin/activate"
+}
+
+install_python_uv() {
+  if ! have uv; then
+    echo "uv not on PATH. Install from https://docs.astral.sh/uv/ then re-run --uv" >&2
+    return 1
+  fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ FLEXAIDDS_SKIP_CORE=1 uv tool install ${PY_GIT}"
+    echo "+ uvx --from ${PY_GIT} flexaidds --help"
+    return 0
+  fi
+  run env FLEXAIDDS_SKIP_CORE=1 uv tool install --force "$PY_GIT"
+  uv tool run --from "$PY_GIT" flexaidds --help >/dev/null || \
+    flexaidds --help >/dev/null
+  echo "python: flexaidds via uv tool"
+}
+
+install_python_pipx() {
+  if ! have pipx; then
+    echo "pipx not on PATH. pip install pipx  OR  brew install pipx" >&2
+    return 1
+  fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ FLEXAIDDS_SKIP_CORE=1 pipx install ${PY_GIT}"
+    echo "+ flexaidds --help"
+    return 0
+  fi
+  run env FLEXAIDDS_SKIP_CORE=1 pipx install --force "$PY_GIT"
+  flexaidds --help >/dev/null
+  echo "python: flexaidds via pipx"
+}
+
+install_python() {
+  case "$PY_BACKEND" in
+    uv) install_python_uv ;;
+    pipx) install_python_pipx ;;
+    *) install_python_pip ;;
+  esac
 }
 
 ec=0
-if [[ "$WANT_ENGINE" -eq 1 ]]; then
-  install_engine || ec=1
+if [[ -n "$FROM_ARCHIVE" ]]; then
+  install_from_archive "$FROM_ARCHIVE" "$EXPECT_SHA256" || ec=1
+elif [[ -n "$FROM_RELEASE" ]]; then
+  install_from_release "$FROM_RELEASE" || ec=1
+elif [[ "$WANT_ENGINE" -eq 1 ]]; then
+  install_engine_brew || ec=1
 fi
 if [[ "$WANT_PYTHON" -eq 1 ]]; then
   install_python || ec=1

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Refresh every FlexAID∆S front that is already on this machine.
+#
+#   curl -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh | bash
+#   wget -qO-  https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh | bash
+#   bash scripts/update.sh --dry-run
+#   python -m flexaidds --self-update
+#
+# Detects Homebrew HEAD engine, ~/.flexaidds/venv, uv tool, pipx, and a local
+# GHCR image. Updates all of them in one invocation. Does not invent a PyPI
+# upgrade while the package is unpublished.
+set -euo pipefail
+
+REPO_HTTPS="https://github.com/LeBonhommePharma/FlexAIDdS.git"
+TAP_NAME="lebonhommepharma/flexaidds"
+FORMULA="${TAP_NAME}/flexaidds"
+PY_GIT="git+${REPO_HTTPS}#subdirectory=python"
+VENV="${FLEXAIDDS_VENV:-${HOME}/.flexaidds/venv}"
+GHCR="ghcr.io/lebonhommepharma/flexaidds"
+
+DRY_RUN=0
+DO_ENGINE=1
+DO_PYTHON=1
+DO_DOCKER=1
+
+usage() {
+  cat <<'EOF'
+FlexAID∆S unified updater
+
+Usage: scripts/update.sh [--dry-run] [--engine-only] [--python-only] [--docker-only]
+
+Refreshes every detected install front:
+  - macOS Homebrew engine: brew upgrade --fetch-HEAD (fallback: uninstall + --HEAD)
+  - Python: venv pip, uv tool, and/or pipx (git+subdirectory, SKIP_CORE=1)
+  - Docker: docker pull ghcr.io/lebonhommepharma/flexaidds:latest if that image exists locally
+
+Does not call unpublished `pip install --upgrade flexaidds` as the only path.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --engine-only) DO_PYTHON=0; DO_DOCKER=0; shift ;;
+    --python-only) DO_ENGINE=0; DO_DOCKER=0; shift ;;
+    --docker-only) DO_ENGINE=0; DO_PYTHON=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+run() {
+  printf '+ %s\n' "$*"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+echo "FlexAID∆S updater  dry_run=${DRY_RUN}"
+
+ec=0
+
+update_engine() {
+  [[ "$DO_ENGINE" -eq 1 ]] || return 0
+  if ! have brew; then
+    echo "engine: brew not found — skip"
+    return 0
+  fi
+  if ! brew list --formula lebonhommepharma/flexaidds/flexaidds >/dev/null 2>&1 \
+     && ! brew list --formula flexaidds >/dev/null 2>&1; then
+    echo "engine: flexaidds formula not installed — skip (install: scripts/install.sh --engine-only)"
+    return 0
+  fi
+  run brew tap "$TAP_NAME" "$REPO_HTTPS" || true
+  run brew update || true
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "+ brew upgrade --fetch-HEAD ${FORMULA}"
+    echo "+ FlexAIDdS --help"
+    return 0
+  fi
+  if ! brew upgrade --fetch-HEAD "$FORMULA"; then
+    echo "engine: upgrade --fetch-HEAD failed; reinstall --HEAD"
+    run brew uninstall --force "$FORMULA" || true
+    run brew install --HEAD "$FORMULA"
+  fi
+  if have FlexAIDdS; then
+    FlexAIDdS --help >/dev/null
+  elif [[ -x /opt/homebrew/bin/FlexAIDdS ]]; then
+    /opt/homebrew/bin/FlexAIDdS --help >/dev/null
+  fi
+  echo "engine: updated"
+}
+
+update_python() {
+  [[ "$DO_PYTHON" -eq 1 ]] || return 0
+  local did=0
+  if [[ -x "${VENV}/bin/pip" ]]; then
+    run env FLEXAIDDS_SKIP_CORE=1 "${VENV}/bin/pip" install --upgrade --force-reinstall "$PY_GIT"
+    did=1
+  fi
+  if have uv && uv tool list 2>/dev/null | grep -q '^flexaidds '; then
+    run env FLEXAIDDS_SKIP_CORE=1 uv tool upgrade flexaidds || \
+      run env FLEXAIDDS_SKIP_CORE=1 uv tool install --force "$PY_GIT"
+    did=1
+  fi
+  if have pipx && pipx list 2>/dev/null | grep -qi flexaidds; then
+    run env FLEXAIDDS_SKIP_CORE=1 pipx upgrade flexaidds || \
+      run env FLEXAIDDS_SKIP_CORE=1 pipx install --force "$PY_GIT"
+    did=1
+  fi
+  if [[ "$did" -eq 0 ]]; then
+    echo "python: no venv/uv/pipx flexaidds detected — skip"
+    echo "        install: scripts/install.sh --python-only"
+    return 0
+  fi
+  echo "python: updated"
+}
+
+update_docker() {
+  [[ "$DO_DOCKER" -eq 1 ]] || return 0
+  if ! have docker; then
+    echo "docker: docker not on PATH — skip"
+    return 0
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "docker: daemon not running — skip"
+    return 0
+  fi
+  if ! docker image inspect "${GHCR}:latest" >/dev/null 2>&1; then
+    echo "docker: ${GHCR}:latest not present locally — skip (no unpublished pull)"
+    return 0
+  fi
+  run docker pull "${GHCR}:latest"
+  echo "docker: pulled ${GHCR}:latest"
+}
+
+update_engine || ec=1
+update_python || ec=1
+update_docker || ec=1
+
+if [[ "$ec" -ne 0 ]]; then
+  echo "update finished with errors." >&2
+  exit "$ec"
+fi
+echo "done."
+exit 0

--- a/scripts/validate_install_patterns.sh
+++ b/scripts/validate_install_patterns.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Live checks for extra install fronts. Writes a log path if given as $1.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+LOG="${1:-}"
+if [[ -n "$LOG" ]]; then mkdir -p "$(dirname "$LOG")"; fi
+log() {
+  printf '%s\n' "$*"
+  if [[ -n "$LOG" ]]; then printf '%s\n' "$*" >>"$LOG"; fi
+}
+
+log "=== wget HTTPS fetch of installer (raw.githubusercontent.com) ==="
+# wget prepends http:// to local paths; the documented one-liner is HTTPS.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+wget_url="https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/${branch}/scripts/install.sh"
+if wget -qO- "$wget_url" 2>/dev/null | grep -q "FlexAID"; then
+  log "wget_https_ok ${wget_url}"
+else
+  log "wget_https_branch_not_pushed; proving wget + local script pipe"
+  log "wget=$(command -v wget)"
+fi
+log "=== local script --dry-run --python-only ==="
+bash scripts/install.sh --dry-run --python-only | tee -a "${LOG:-/dev/null}" | tail -8
+
+log "=== from-release v2.2.0 (expect fail-closed) ==="
+set +e
+bash scripts/install.sh --from-release v2.2.0 >"${TMPDIR:-/tmp}/fr.out" 2>"${TMPDIR:-/tmp}/fr.err"
+rc=$?
+set -e
+cat "${TMPDIR:-/tmp}/fr.err" "${TMPDIR:-/tmp}/fr.out" | tee -a "${LOG:-/dev/null}" | tail -20
+if [[ "$rc" -eq 0 ]]; then
+  log "UNEXPECTED success: v2.2.0 has no SHA256SUMS"
+  exit 1
+fi
+log "from_release_fail_closed_ok rc=$rc"
+
+log "=== uv tool install ./python ==="
+export UV_TOOL_DIR="${HOME}/.flexaidds/uv-tools-validate"
+export UV_TOOL_BIN_DIR="${HOME}/.flexaidds/uv-tools-validate/bin"
+mkdir -p "$UV_TOOL_BIN_DIR"
+FLEXAIDDS_SKIP_CORE=1 uv tool install --force ./python
+"$UV_TOOL_BIN_DIR/flexaidds" --help >/dev/null
+log "uv_flexaidds_ok"
+
+log "=== pipx install ./python ==="
+export PIPX_HOME="${HOME}/.flexaidds/pipx-validate"
+export PIPX_BIN_DIR="${HOME}/.flexaidds/pipx-validate/bin"
+mkdir -p "$PIPX_BIN_DIR"
+FLEXAIDDS_SKIP_CORE=1 pipx install --force ./python
+"$PIPX_BIN_DIR/flexaidds" --help >/dev/null
+log "pipx_flexaidds_ok"
+
+log "=== conda recipe ==="
+python3 -c "
+import pathlib, re
+recipe = pathlib.Path('conda/meta.yaml').read_text()
+ver = re.search(r'__version__\\s*=\\s*\"([^\"]+)\"', pathlib.Path('python/flexaidds/__version__.py').read_text()).group(1)
+assert 'load_file_regex' in recipe
+print('conda_version_source_ok', ver)
+"
+
+log "=== workflow YAML parse ==="
+python3 -c "
+import pathlib, yaml
+n=0
+for f in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
+    d = yaml.safe_load(f.read_text())
+    assert isinstance(d, dict) and 'jobs' in d, f
+    n += 1
+print('workflows_parse_ok', n)
+"
+
+log "=== ruby -c formula ==="
+ruby -c Formula/flexaidds.rb
+log "ALL_EXTRA_PATTERNS_OK"

--- a/site/FlexAIDdS/sections.jsx
+++ b/site/FlexAIDdS/sections.jsx
@@ -432,8 +432,6 @@ function InstallSection() {
             <div className="cmt"># first shot — review, then run</div>
             <div><span className="plain">$</span> <span className="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span className="plain">| bash</span></div>
             <div><span className="plain">$</span> <span className="cmd">wget</span> -qO- https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span className="plain">| bash</span></div>
-            <div style={{ marginTop: "8px" }} className="cmt"># checksummed GitHub Release + SHA256SUMS.txt — after the next v* tag (v2.2.0 has zero assets)</div>
-            <div><span className="plain">$</span> <span className="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span className="plain">| bash -s -- --from-release latest</span></div>
             <div style={{ marginTop: "8px" }} className="cmt"># update every front already on the machine</div>
             <div><span className="plain">$</span> <span className="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh <span className="plain">| bash</span></div>
             <div><span className="plain">$</span> <span className="cmd">python</span> -m flexaidds --self-update</div>
@@ -447,7 +445,6 @@ function InstallSection() {
             <div><span className="plain">$</span> <span className="cmd">brew trust</span> --formula lebonhommepharma/flexaidds/flexaidds</div>
             <div><span className="plain">$</span> <span className="cmd">brew install</span> --HEAD lebonhommepharma/flexaidds/flexaidds</div>
             <div><span className="plain">$</span> <span className="cmd">FlexAIDdS</span> --help</div>
-            <div style={{ marginTop: "8px" }} className="cmt"># bottles land on the next provenance-capable tag; formula has no bottle do</div>
           </pre>
         )}
 
@@ -467,8 +464,6 @@ function InstallSection() {
             <div className="cmt"># native engine — build works today</div>
             <div><span className="plain">$</span> <span className="cmd">docker build</span> -f containers/Dockerfile.locked --build-arg FLEXAIDS_GIT_COMMIT="$(git rev-parse --short HEAD)" -t flexaidds:locked .</div>
             <div><span className="plain">$</span> <span className="cmd">docker run</span> --rm flexaidds:locked --help</div>
-            <div style={{ marginTop: "8px" }} className="cmt"># GHCR pull — after ghcr.yml has published a tag; 404 until then</div>
-            <div><span className="plain">$</span> <span className="cmd">docker pull</span> ghcr.io/lebonhommepharma/flexaidds:latest</div>
           </pre>
         )}
 

--- a/site/FlexAIDdS/sections.jsx
+++ b/site/FlexAIDdS/sections.jsx
@@ -409,20 +409,103 @@ function Footer() {
 
 // ─── INSTALL ───
 function InstallSection() {
-  const [tab, setTab] = useStateS("cli");
+  const [tab, setTab] = useStateS("curl");
   return (
     <section id="install" className="section alt">
       <div className="container" style={{ maxWidth: "896px" }}>
         <SectionHeader eyebrow="get started">
           Installation
         </SectionHeader>
+        <p className="binding-blurb">
+          Two separate things: the native <span className="kw">FlexAIDdS</span> engine
+          (Homebrew / CMake / Docker) and the <span className="kw">flexaidds</span> Python
+          package (analysis CLI). Installing one does not give you the other.
+        </p>
         <div className="install-tabs">
-          {[["cli", "CLI Build"], ["python", "Python"]].map(([k, l]) => (
+          {[["curl", "curl"], ["brew", "Homebrew"], ["python", "Python"], ["docker", "Docker"], ["conda", "conda"], ["ci", "CI"], ["hpc", "HPC"], ["cmake", "CMake"]].map(([k, l]) => (
             <button key={k} className={"install-tab" + (tab === k ? " active" : "")} onClick={() => setTab(k)}>{l}</button>
           ))}
         </div>
 
-        {tab === "cli" && (
+        {tab === "curl" && (
+          <pre className="code-box">
+            <div className="cmt"># first shot — review, then run</div>
+            <div><span className="plain">$</span> <span className="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span className="plain">| bash</span></div>
+            <div><span className="plain">$</span> <span className="cmd">wget</span> -qO- https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span className="plain">| bash</span></div>
+            <div style={{ marginTop: "8px" }} className="cmt"># checksummed GitHub Release + SHA256SUMS.txt — after the next v* tag (v2.2.0 has zero assets)</div>
+            <div><span className="plain">$</span> <span className="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span className="plain">| bash -s -- --from-release latest</span></div>
+            <div style={{ marginTop: "8px" }} className="cmt"># update every front already on the machine</div>
+            <div><span className="plain">$</span> <span className="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh <span className="plain">| bash</span></div>
+            <div><span className="plain">$</span> <span className="cmd">python</span> -m flexaidds --self-update</div>
+          </pre>
+        )}
+
+        {tab === "brew" && (
+          <pre className="code-box">
+            <div className="cmt"># native engine only — macOS. first-shot is --HEAD</div>
+            <div><span className="plain">$</span> <span className="cmd">brew tap</span> lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS</div>
+            <div><span className="plain">$</span> <span className="cmd">brew trust</span> --formula lebonhommepharma/flexaidds/flexaidds</div>
+            <div><span className="plain">$</span> <span className="cmd">brew install</span> --HEAD lebonhommepharma/flexaidds/flexaidds</div>
+            <div><span className="plain">$</span> <span className="cmd">FlexAIDdS</span> --help</div>
+            <div style={{ marginTop: "8px" }} className="cmt"># bottles land on the next provenance-capable tag; formula has no bottle do</div>
+          </pre>
+        )}
+
+        {tab === "python" && (
+          <pre className="code-box">
+            <div className="cmt"># not on PyPI — git+subdirectory (or uv / pipx)</div>
+            <div><span className="plain">$</span> <span className="cmd">FLEXAIDDS_SKIP_CORE=1 pip install</span> <span className="str">"git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"</span></div>
+            <div><span className="plain">$</span> <span className="cmd">FLEXAIDDS_SKIP_CORE=1 uv tool install</span> <span className="str">"git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"</span></div>
+            <div><span className="plain">$</span> <span className="cmd">FLEXAIDDS_SKIP_CORE=1 pipx install</span> <span className="str">"git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"</span></div>
+            <div style={{ marginTop: "8px" }}><span className="kw">import</span> flexaidds <span className="kw">as</span> fd</div>
+            <div>results = fd.<span className="cmd">dock</span>(receptor=<span className="str">'receptor.pdb'</span>, ligand=<span className="str">'ligand.mol2'</span>, compute_entropy=<span className="kw">True</span>)</div>
+          </pre>
+        )}
+
+        {tab === "docker" && (
+          <pre className="code-box">
+            <div className="cmt"># native engine — build works today</div>
+            <div><span className="plain">$</span> <span className="cmd">docker build</span> -f containers/Dockerfile.locked --build-arg FLEXAIDS_GIT_COMMIT="$(git rev-parse --short HEAD)" -t flexaidds:locked .</div>
+            <div><span className="plain">$</span> <span className="cmd">docker run</span> --rm flexaidds:locked --help</div>
+            <div style={{ marginTop: "8px" }} className="cmt"># GHCR pull — after ghcr.yml has published a tag; 404 until then</div>
+            <div><span className="plain">$</span> <span className="cmd">docker pull</span> ghcr.io/lebonhommepharma/flexaidds:latest</div>
+          </pre>
+        )}
+
+        {tab === "conda" && (
+          <pre className="code-box">
+            <div className="cmt"># Python package — not a conda-forge feedstock</div>
+            <div><span className="plain">$</span> <span className="cmd">git clone</span> https://github.com/LeBonhommePharma/FlexAIDdS.git <span className="plain">&amp;&amp; cd FlexAIDdS</span></div>
+            <div><span className="plain">$</span> <span className="cmd">conda env create</span> -f environment.yml <span className="plain">&amp;&amp; conda activate flexaidds</span></div>
+            <div><span className="plain">$</span> <span className="cmd">python</span> -c <span className="str">"import flexaidds as fd; print(fd.__version__)"</span></div>
+          </pre>
+        )}
+
+        {tab === "ci" && (
+          <pre className="code-box">
+            <div className="cmt"># GitHub Action — Python package, not the engine</div>
+            <div>- uses: LeBonhommePharma/FlexAIDdS/.github/actions/setup-flexaidds@main</div>
+            <div>  with:</div>
+            <div>    from-checkout: <span className="str">"false"</span></div>
+            <div>    skip-core: <span className="str">"true"</span></div>
+            <div style={{ marginTop: "8px" }} className="cmt"># Dev Container / Codespaces — .devcontainer/ with FLEXAIDDS_SKIP_CORE=1</div>
+            <div><span className="plain">$</span> <span className="cmd">code</span> --reopen-in-container</div>
+          </pre>
+        )}
+
+        {tab === "hpc" && (
+          <pre className="code-box">
+            <div className="cmt"># overlays, not upstream Spack / EasyBuild</div>
+            <div className="cmt"># copy packaging/spack/package.py into a Spack repo overlay</div>
+            <div className="cmt"># copy packaging/easybuild/flexaidds-2.0.3.eb into an EasyBuild robot path</div>
+            <div><span className="plain">$</span> <span className="cmd">eb</span> packaging/easybuild/flexaidds-2.0.3.eb</div>
+            <div><span className="plain">$</span> <span className="cmd">module use</span> $PWD/packaging/modulefiles</div>
+            <div><span className="plain">$</span> <span className="cmd">export</span> FLEXAIDDS_PREFIX=/path/to/install</div>
+            <div><span className="plain">$</span> <span className="cmd">module load</span> flexaidds</div>
+          </pre>
+        )}
+
+        {tab === "cmake" && (
           <>
             <pre className="code-box">
               <div><span className="plain">$</span> <span className="cmd">git clone</span> https://github.com/LeBonhommePharma/FlexAIDdS.git <span className="plain">&amp;&amp; cd FlexAIDdS</span></div>
@@ -444,14 +527,6 @@ function InstallSection() {
             </table>
           </>
         )}
-
-        {tab === "python" && (
-          <pre className="code-box">
-            <div><span className="plain">$</span> <span className="cmd">cd</span> python <span className="plain">&amp;&amp; pip install -e .</span></div>
-            <div style={{ marginTop: "8px" }}><span className="kw">import</span> flexaidds <span className="kw">as</span> fd</div>
-            <div>results = fd.<span className="cmd">dock</span>(receptor=<span className="str">'receptor.pdb'</span>, ligand=<span className="str">'ligand.mol2'</span>, compute_entropy=<span className="kw">True</span>)</div>
-          </pre>
-        )}
       </div>
     </section>
   );
@@ -466,7 +541,7 @@ function BenchmarksSection() {
           Benchmark <span className="t-gold">status</span>
         </SectionHeader>
         <p className="binding-blurb">
-          This site publishes <span className="kw">no validated FlexAID∆S success rate</span>. Astex-85, ITC-187, CASF, and CNS figures are <span className="kw">unverified / pending receipt</span> until a METHODOLOGY.md §0 receipted blind campaign exists. Literature comparators (JCIM 2015 Table 2 top-1 45.2% / top-10 66.7%) are someone else’s published numbers, not ours.
+          This site publishes <span className="kw">no validated FlexAID∆S success rate</span>. Benchmarks are still rolling — do not cite a former rate at or above 90%. Astex-85, ITC-187, CASF, and CNS figures are <span className="kw">unverified / pending receipt</span> until a METHODOLOGY.md §0 receipted blind campaign exists. Literature comparators (JCIM 2015 Table 2 top-1 45.2% / top-10 66.7%) are someone else’s published numbers, not ours.
         </p>
       </div>
     </section>

--- a/site/entropy-driven/index.html
+++ b/site/entropy-driven/index.html
@@ -463,11 +463,15 @@
     .install-tabs {
       display: flex; gap: 0; border-bottom: 1px solid var(--teal-alpha-15);
       margin-bottom: 1.5rem;
+      overflow-x: auto; -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
     }
+    .install-tabs::-webkit-scrollbar { display: none; }
     .install-tab {
       font-family: 'JetBrains Mono', monospace; font-size: 12px;
       padding: 8px 16px; background: none; border: none; color: var(--muted);
       cursor: pointer; transition: all 0.2s; border-bottom: 2px solid transparent;
+      min-height: 44px; white-space: nowrap;
     }
     .install-tab:hover { color: var(--text); }
     .install-tab.active { color: var(--teal); border-bottom-color: var(--teal); }
@@ -1065,13 +1069,97 @@
       <div class="container" style="max-width:896px;">
         <p class="section-label">// get started</p>
         <h2 style="font-size:1.75rem; font-weight:700; margin-bottom:1.5rem;">Installation</h2>
+        <p style="font-size:0.85rem; color:var(--muted); margin-bottom:1.5rem;">
+          Two separate things: the native <strong>FlexAIDdS</strong> engine
+          (Homebrew / CMake / Docker) and the <strong>flexaidds</strong> Python
+          package (analysis CLI). Installing one does not give you the other.
+        </p>
 
         <div class="install-tabs">
-          <button class="install-tab active" data-tab="cli">CLI Build</button>
+          <button class="install-tab active" data-tab="curl">curl</button>
+          <button class="install-tab" data-tab="brew">Homebrew</button>
           <button class="install-tab" data-tab="python">Python</button>
+          <button class="install-tab" data-tab="docker">Docker</button>
+          <button class="install-tab" data-tab="conda">conda</button>
+          <button class="install-tab" data-tab="ci">CI</button>
+          <button class="install-tab" data-tab="hpc">HPC</button>
+          <button class="install-tab" data-tab="cmake">CMake</button>
         </div>
 
-        <div class="install-panel active" id="panel-cli">
+        <div class="install-panel active" id="panel-curl">
+          <div class="code-box">
+            <div class="comment"># first shot — review, then run</div>
+            <div><span class="plain">$</span> <span class="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span class="plain">| bash</span></div>
+            <div><span class="plain">$</span> <span class="cmd">wget</span> -qO- https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/install.sh <span class="plain">| bash</span></div>
+            <div style="margin-top:8px;" class="comment"># update every front already on the machine</div>
+            <div><span class="plain">$</span> <span class="cmd">curl</span> -fsSL https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/main/scripts/update.sh <span class="plain">| bash</span></div>
+            <div><span class="plain">$</span> <span class="cmd">python</span> -m flexaidds --self-update</div>
+          </div>
+        </div>
+
+        <div class="install-panel" id="panel-brew">
+          <div class="code-box">
+            <div class="comment"># native engine only — macOS. first-shot is --HEAD</div>
+            <div><span class="plain">$</span> <span class="cmd">brew tap</span> lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS</div>
+            <div><span class="plain">$</span> <span class="cmd">brew trust</span> --formula lebonhommepharma/flexaidds/flexaidds</div>
+            <div><span class="plain">$</span> <span class="cmd">brew install</span> --HEAD lebonhommepharma/flexaidds/flexaidds</div>
+            <div><span class="plain">$</span> <span class="cmd">FlexAIDdS</span> --help</div>
+          </div>
+        </div>
+
+        <div class="install-panel" id="panel-python">
+          <div class="code-box">
+            <div class="comment"># not on PyPI — git+subdirectory (or uv / pipx)</div>
+            <div><span class="plain">$</span> <span class="cmd">FLEXAIDDS_SKIP_CORE=1 pip install</span> <span class="str">"git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"</span></div>
+            <div><span class="plain">$</span> <span class="cmd">FLEXAIDDS_SKIP_CORE=1 uv tool install</span> <span class="str">"git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"</span></div>
+            <div><span class="plain">$</span> <span class="cmd">FLEXAIDDS_SKIP_CORE=1 pipx install</span> <span class="str">"git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python"</span></div>
+            <div style="margin-top:8px;"><span class="kw">import</span> flexaidds <span class="kw">as</span> fd</div>
+            <div>results = fd.<span class="cmd">dock</span>(receptor=<span class="str">'receptor.pdb'</span>, ligand=<span class="str">'ligand.mol2'</span>, compute_entropy=<span class="kw">True</span>)</div>
+          </div>
+        </div>
+
+        <div class="install-panel" id="panel-docker">
+          <div class="code-box">
+            <div class="comment"># native engine — build works today</div>
+            <div><span class="plain">$</span> <span class="cmd">docker build</span> -f containers/Dockerfile.locked --build-arg FLEXAIDS_GIT_COMMIT="$(git rev-parse --short HEAD)" -t flexaidds:locked .</div>
+            <div><span class="plain">$</span> <span class="cmd">docker run</span> --rm flexaidds:locked --help</div>
+          </div>
+        </div>
+
+        <div class="install-panel" id="panel-conda">
+          <div class="code-box">
+            <div class="comment"># Python package — not a conda-forge feedstock</div>
+            <div><span class="plain">$</span> <span class="cmd">git clone</span> https://github.com/LeBonhommePharma/FlexAIDdS.git <span class="plain">&amp;&amp; cd FlexAIDdS</span></div>
+            <div><span class="plain">$</span> <span class="cmd">conda env create</span> -f environment.yml <span class="plain">&amp;&amp; conda activate flexaidds</span></div>
+            <div><span class="plain">$</span> <span class="cmd">python</span> -c <span class="str">"import flexaidds as fd; print(fd.__version__)"</span></div>
+          </div>
+        </div>
+
+        <div class="install-panel" id="panel-ci">
+          <div class="code-box">
+            <div class="comment"># GitHub Action — Python package, not the engine</div>
+            <div>- uses: LeBonhommePharma/FlexAIDdS/.github/actions/setup-flexaidds@main</div>
+            <div>  with:</div>
+            <div>    from-checkout: <span class="str">"false"</span></div>
+            <div>    skip-core: <span class="str">"true"</span></div>
+            <div style="margin-top:8px;" class="comment"># Dev Container / Codespaces — .devcontainer/ with FLEXAIDDS_SKIP_CORE=1</div>
+            <div><span class="plain">$</span> <span class="cmd">code</span> --reopen-in-container</div>
+          </div>
+        </div>
+
+        <div class="install-panel" id="panel-hpc">
+          <div class="code-box">
+            <div class="comment"># overlays, not upstream Spack / EasyBuild</div>
+            <div class="comment"># copy packaging/spack/package.py into a Spack repo overlay</div>
+            <div class="comment"># copy packaging/easybuild/flexaidds-2.0.3.eb into an EasyBuild robot path</div>
+            <div><span class="plain">$</span> <span class="cmd">eb</span> packaging/easybuild/flexaidds-2.0.3.eb</div>
+            <div><span class="plain">$</span> <span class="cmd">module use</span> $PWD/packaging/modulefiles</div>
+            <div><span class="plain">$</span> <span class="cmd">export</span> FLEXAIDDS_PREFIX=/path/to/install</div>
+            <div><span class="plain">$</span> <span class="cmd">module load</span> flexaidds</div>
+          </div>
+        </div>
+
+        <div class="install-panel" id="panel-cmake">
           <div class="code-box">
             <div><span class="plain">$</span> <span class="cmd">git clone</span> https://github.com/LeBonhommePharma/FlexAIDdS.git <span class="plain">&amp;&amp; cd FlexAIDdS</span></div>
             <div><span class="plain">$</span> <span class="cmd">mkdir</span> build <span class="plain">&amp;&amp; cd build</span></div>
@@ -1092,14 +1180,6 @@
             </tbody>
           </table>
         </div>
-
-        <div class="install-panel" id="panel-python">
-          <div class="code-box">
-            <div><span class="plain">$</span> <span class="cmd">cd</span> python <span class="plain">&amp;&amp; pip install -e .</span></div>
-            <div style="margin-top:8px;"><span class="kw">import</span> flexaidds <span class="kw">as</span> fd</div>
-            <div>results = fd.<span class="cmd">dock</span>(receptor=<span class="str">'receptor.pdb'</span>, ligand=<span class="str">'ligand.mol2'</span>, compute_entropy=<span class="kw">True</span>)</div>
-          </div>
-        </div>
       </div>
     </section>
 
@@ -1113,7 +1193,7 @@
           Benchmark <span class="text-gold">status</span>
         </h2>
         <p style="font-size:0.85rem; color:var(--muted); margin-bottom:1.5rem; max-width:640px;">
-          This page publishes no validated FlexAID∆S success rate. Astex-85, ITC-187, CASF, and CNS figures are unverified / pending receipt until a METHODOLOGY.md §0 receipted blind campaign exists. JCIM 2015 Table 2 (top-1 45.2% / top-10 66.7%) is a literature comparator, not ours.
+          This page publishes no validated FlexAID∆S success rate. Benchmarks are still rolling — do not cite a former rate at or above 90%. Astex-85, ITC-187, CASF, and CNS figures are unverified / pending receipt until a METHODOLOGY.md §0 receipted blind campaign exists. JCIM 2015 Table 2 (top-1 45.2% / top-10 66.7%) is a literature comparator, not ours.
         </p>
       </div>
     </section>

--- a/tests/test_check_published_astex_rates.py
+++ b/tests/test_check_published_astex_rates.py
@@ -196,6 +196,35 @@ def test_scanner_allows_jcim_table2_literature_comparator() -> None:
     assert unqualified_claim_hits(text, source="fixture") == []
 
 
+def test_public_product_docs_do_not_restate_ninety_plus_success_rates() -> None:
+    """Public how-tos must not restate ≥90% FlexAID∆S rates while campaigns roll."""
+    banned = ("91.8%", "94.1%", "92%")
+    surfaces = (
+        ROOT / "README.md",
+        ROOT / "docs" / "INSTALL.md",
+        ROOT / "docs" / "USERGUIDE.md",
+        ROOT / "docs" / "BENCHMARK.md",
+        ROOT / "site" / "FlexAIDdS" / "index.html",
+        ROOT / "site" / "FlexAIDdS" / "sections.jsx",
+    )
+    failures: list[str] = []
+    for path in surfaces:
+        text = path.read_text(encoding="utf-8")
+        rel = str(path.relative_to(ROOT))
+        for token in banned:
+            if token in text:
+                failures.append(f"{rel} restates {token}")
+        if path.name == "sections.jsx":
+            assert "no validated FlexAID∆S success rate" in text
+            assert "Benchmarks are still rolling" in text
+        if path.name == "BENCHMARK.md":
+            assert "Benchmarks are still rolling" in text
+            assert "at or above 90%" in text
+    assert failures == [], "public surfaces still restate ≥90% rates:\n" + "\n".join(
+        failures
+    )
+
+
 def test_site_does_not_headline_live_affinity_or_binding_mode_rates() -> None:
     banned = (
         "Pearson r = 0.93",

--- a/tests/test_check_published_astex_rates.py
+++ b/tests/test_check_published_astex_rates.py
@@ -206,6 +206,7 @@ def test_public_product_docs_do_not_restate_ninety_plus_success_rates() -> None:
         ROOT / "docs" / "BENCHMARK.md",
         ROOT / "site" / "FlexAIDdS" / "index.html",
         ROOT / "site" / "FlexAIDdS" / "sections.jsx",
+        ROOT / "site" / "entropy-driven" / "index.html",
     )
     failures: list[str] = []
     for path in surfaces:
@@ -215,6 +216,9 @@ def test_public_product_docs_do_not_restate_ninety_plus_success_rates() -> None:
             if token in text:
                 failures.append(f"{rel} restates {token}")
         if path.name == "sections.jsx":
+            assert "no validated FlexAID∆S success rate" in text
+            assert "Benchmarks are still rolling" in text
+        if path.name == "index.html" and "entropy-driven" in rel:
             assert "no validated FlexAID∆S success rate" in text
             assert "Benchmarks are still rolling" in text
         if path.name == "BENCHMARK.md":

--- a/tests/test_install_matrix.py
+++ b/tests/test_install_matrix.py
@@ -6,11 +6,15 @@ Reads the shipped files. Does not re-implement the support matrix.
 
 from __future__ import annotations
 
+import ast
+import hashlib
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
+import tarfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,6 +24,7 @@ FORMULA = ROOT / "Formula" / "flexaidds.rb"
 PYPROJECT = ROOT / "python" / "pyproject.toml"
 SETUP_PY = ROOT / "python" / "setup.py"
 INSTALL_SH = ROOT / "scripts" / "install.sh"
+UPDATE_SH = ROOT / "scripts" / "update.sh"
 CURL_URL = (
     "https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/"
     "main/scripts/install.sh"
@@ -165,6 +170,122 @@ def test_curl_installer_is_documented_and_dry_run_safe() -> None:
     assert "FLEXAIDDS_SKIP_CORE=1" in out
     assert "pip install flexaidds\n" not in out
     assert "done." in out
+
+
+def test_unified_updater_dry_run() -> None:
+    assert UPDATE_SH.is_file()
+    howto = HOWTO.read_text(encoding="utf-8")
+    assert "scripts/update.sh" in howto
+    assert "python -m flexaidds --self-update" in howto
+    proc = subprocess.run(
+        ["bash", str(UPDATE_SH), "--dry-run"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    out = proc.stdout
+    assert "brew upgrade --fetch-HEAD" in out or "engine:" in out
+    assert "pip install flexaidds\n" not in out or "unpublished" in out
+    assert "done." in out
+    script = UPDATE_SH.read_text(encoding="utf-8")
+    assert "subdirectory=python" in script
+    assert "brew install --HEAD" in script
+
+
+def test_installer_uv_pipx_release_dry_runs() -> None:
+    for extra in (["--python-only", "--uv"], ["--python-only", "--pipx"],
+                  ["--from-release", "latest"]):
+        proc = subprocess.run(
+            ["bash", str(INSTALL_SH), "--dry-run", *extra],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, extra + [proc.stderr, proc.stdout]
+    uv = subprocess.run(
+        ["bash", str(INSTALL_SH), "--dry-run", "--python-only", "--uv"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    )
+    assert "uv tool install" in uv.stdout
+    assert "subdirectory=python" in uv.stdout
+    pipx = subprocess.run(
+        ["bash", str(INSTALL_SH), "--dry-run", "--python-only", "--pipx"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    )
+    assert "pipx install" in pipx.stdout
+    rel = subprocess.run(
+        ["bash", str(INSTALL_SH), "--dry-run", "--from-release", "v2.2.0"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    )
+    assert "SHA256SUMS.txt" in rel.stdout
+
+
+def test_from_archive_rejects_bad_hash_and_accepts_good(tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    binary = dist / "FlexAIDdS"
+    binary.write_text("#!/bin/sh\necho Usage: stub\n", encoding="utf-8")
+    binary.chmod(0o755)
+    archive = tmp_path / "flexaidds-macos.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(binary, arcname="dist/FlexAIDdS")
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    prefix = tmp_path / "prefix"
+
+    bad = subprocess.run(
+        ["bash", str(INSTALL_SH), "--from-archive", str(archive),
+         "--sha256", "0" * 64, "--prefix", str(prefix)],
+        cwd=ROOT, capture_output=True, text=True, check=False,
+    )
+    assert bad.returncode != 0
+    assert "SHA-256 mismatch" in bad.stderr + bad.stdout
+
+    good = subprocess.run(
+        ["bash", str(INSTALL_SH), "--from-archive", str(archive),
+         "--sha256", digest, "--prefix", str(prefix)],
+        cwd=ROOT, capture_output=True, text=True, check=False,
+    )
+    assert good.returncode == 0, good.stderr + good.stdout
+    installed = prefix / "bin" / "FlexAIDdS"
+    assert installed.exists()
+
+
+def test_extra_install_fronts_exist_and_parse() -> None:
+    files = {
+        ROOT / ".github" / "actions" / "setup-flexaidds" / "action.yml",
+        ROOT / ".github" / "workflows" / "ghcr.yml",
+        ROOT / ".github" / "workflows" / "homebrew-bottle.yml",
+        ROOT / ".devcontainer" / "devcontainer.json",
+        ROOT / ".devcontainer" / "Dockerfile",
+        ROOT / "packaging" / "spack" / "package.py",
+        ROOT / "packaging" / "easybuild" / "flexaidds-2.0.3.eb",
+        ROOT / "packaging" / "modulefiles" / "flexaidds.lua",
+        ROOT / "conda" / "conda-forge.md",
+    }
+    for path in files:
+        assert path.is_file(), path
+    action = (
+        ROOT / ".github" / "actions" / "setup-flexaidds" / "action.yml"
+    ).read_text(encoding="utf-8")
+    assert "using: composite" in action
+    assert "pip install" in action
+    json.loads((ROOT / ".devcontainer" / "devcontainer.json").read_text(encoding="utf-8"))
+    ast.parse((ROOT / "packaging" / "spack" / "package.py").read_text(encoding="utf-8"))
+    ast.parse(
+        (ROOT / "packaging" / "easybuild" / "flexaidds-2.0.3.eb").read_text(encoding="utf-8")
+    )
+    formula = FORMULA.read_text(encoding="utf-8")
+    assert re.search(r"^\s*bottle do\b", formula, flags=re.M) is None
+    howto = HOWTO.read_text(encoding="utf-8")
+    assert "wget -qO-" in howto
+    assert "uv tool install" in howto
+    assert "pipx install" in howto
+    assert "ghcr.io/lebonhommepharma/flexaidds" in howto
+    release = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "SHA256SUMS.txt" in release
 
 
 def test_setup_py_first_shot_has_no_package_owned_warning_prints() -> None:

--- a/tests/test_install_matrix.py
+++ b/tests/test_install_matrix.py
@@ -15,9 +15,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HOWTO = ROOT / "docs" / "INSTALL.md"
+README = ROOT / "README.md"
 FORMULA = ROOT / "Formula" / "flexaidds.rb"
 PYPROJECT = ROOT / "python" / "pyproject.toml"
 SETUP_PY = ROOT / "python" / "setup.py"
+INSTALL_SH = ROOT / "scripts" / "install.sh"
+CURL_URL = (
+    "https://raw.githubusercontent.com/LeBonhommePharma/FlexAIDdS/"
+    "main/scripts/install.sh"
+)
 
 
 def _section(text: str, heading: str) -> str:
@@ -125,6 +131,40 @@ def test_formula_shell_output_matches_homebrew_api() -> None:
         f"status argument: {bad.group(0)!r}"
     )
     assert 'shell_output("#{bin/"FlexAIDdS"} --help")' in formula
+
+
+def test_curl_installer_is_documented_and_dry_run_safe() -> None:
+    howto = HOWTO.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    script = INSTALL_SH.read_text(encoding="utf-8")
+    assert INSTALL_SH.is_file()
+    assert CURL_URL in howto
+    assert CURL_URL in readme
+    assert "brew install --HEAD" in script
+    assert "subdirectory=python" in script
+    assert "FLEXAIDDS_SKIP_CORE=1" in script
+    # Must not present unpublished PyPI or refused stable brew as first-shot.
+    assert not re.search(r"^\s*pip install flexaidds\s*$", script, flags=re.M)
+    assert "brew install --HEAD" in script
+    assert not re.search(
+        r"brew install (?!--HEAD)lebonhommepharma/flexaidds/flexaidds",
+        script,
+    )
+
+    proc = subprocess.run(
+        ["bash", str(INSTALL_SH), "--dry-run"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    out = proc.stdout
+    assert "brew install --HEAD" in out
+    assert "subdirectory=python" in out
+    assert "FLEXAIDDS_SKIP_CORE=1" in out
+    assert "pip install flexaidds\n" not in out
+    assert "done." in out
 
 
 def test_setup_py_first_shot_has_no_package_owned_warning_prints() -> None:

--- a/tests/test_install_matrix.py
+++ b/tests/test_install_matrix.py
@@ -286,6 +286,76 @@ def test_extra_install_fronts_exist_and_parse() -> None:
     assert "ghcr.io/lebonhommepharma/flexaidds" in howto
     release = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     assert "SHA256SUMS.txt" in release
+    ver_py = (ROOT / "python" / "flexaidds" / "__version__.py").read_text(encoding="utf-8")
+    ver = re.search(r'__version__\s*=\s*"([^"]+)"', ver_py)
+    assert ver, "python/flexaidds/__version__.py missing __version__"
+    meta = (ROOT / "conda" / "meta.yaml").read_text(encoding="utf-8")
+    assert "load_file_regex" in meta
+    assert "../python/flexaidds/__version__.py" in meta
+    assert f'version = "{ver.group(1)}"' not in meta
+    eb = (ROOT / "packaging" / "easybuild" / "flexaidds-2.0.3.eb").read_text(encoding="utf-8")
+    assert f"version = '{ver.group(1)}'" in eb
+    formula_sha = re.search(r'^  sha256 "([0-9a-f]{64})"', formula, flags=re.M)
+    spack = (ROOT / "packaging" / "spack" / "package.py").read_text(encoding="utf-8")
+    assert formula_sha and formula_sha.group(1) in spack
+    assert formula_sha.group(1) in eb
+
+
+def _pages_install_section() -> str:
+    text = (ROOT / "site" / "FlexAIDdS" / "sections.jsx").read_text(encoding="utf-8")
+    match = re.search(
+        r"function InstallSection\(\) \{.*?\n\}\n\n// ─── BENCHMARKS",
+        text,
+        flags=re.S,
+    )
+    assert match, "InstallSection missing from site/FlexAIDdS/sections.jsx"
+    return match.group(0)
+
+
+def test_pages_install_shows_first_shot_and_extra_fronts() -> None:
+    """Drive the shipped Pages #install source, not a restated command list."""
+    section = _pages_install_section()
+    required = (
+        "scripts/install.sh",
+        'cmd">wget</span> -qO-',
+        "brew install</span> --HEAD lebonhommepharma/flexaidds/flexaidds",
+        "subdirectory=python",
+        "uv tool install",
+        "pipx install",
+        "scripts/update.sh",
+        "python</span> -m flexaidds --self-update",
+        "Two separate things",
+        "flexaidds</span> Python",
+        "--from-release latest",
+        "SHA256SUMS.txt",
+        "ghcr.io/lebonhommepharma/flexaidds",
+        "Dockerfile.locked",
+        "environment.yml",
+        "setup-flexaidds",
+        ".devcontainer/",
+        "packaging/spack/package.py",
+        "packaging/easybuild/flexaidds-2.0.3.eb",
+        "packaging/modulefiles",
+        "not on PyPI",
+        "no bottle do",
+        "not a conda-forge feedstock",
+        "install-tabs",
+        "code-box",
+        "cmake-table",
+        "binding-blurb",
+    )
+    missing = [token for token in required if token not in section]
+    assert missing == [], f"Pages #install missing tokens: {missing}"
+    assert 'maxWidth: "896px"' in section
+    assert re.search(r"pip install flexaidds(?![^\n]*subdirectory=python)", section) is None
+    assert "pip install flexaidds" not in section
+    assert re.search(
+        r"brew install(?![\s\S]{0,20}--HEAD)[\s\S]{0,80}lebonhommepharma/flexaidds/flexaidds",
+        section,
+    ) is None
+    assert "conda install -c conda-forge flexaidds" not in section
+    for tab in ("curl", "Homebrew", "Python", "Docker", "conda", "CI", "HPC", "CMake"):
+        assert tab in section
 
 
 def test_setup_py_first_shot_has_no_package_owned_warning_prints() -> None:

--- a/tests/test_install_matrix.py
+++ b/tests/test_install_matrix.py
@@ -93,6 +93,40 @@ def test_support_matrix_does_not_checkmark_broken_first_shots() -> None:
     assert git_rows and all("✅" in row for row in git_rows)
 
 
+def _homebrew_assertions_rb() -> Path:
+    prefix = subprocess.check_output(["brew", "--prefix"], text=True).strip()
+    path = Path(prefix) / "Library" / "Homebrew" / "formula_assertions.rb"
+    assert path.is_file(), f"Homebrew assertions missing at {path}"
+    return path
+
+
+def test_formula_shell_output_matches_homebrew_api() -> None:
+    """shell_output(cmd, result=0) — 2nd arg is exit status, not a CLI flag.
+
+    Homebrew formula_assertions.rb is the shipped API. A Pathname cmd is
+    exec'd with no argv, so `shell_output(bin/"FlexAIDdS", "--help")` never
+    passes --help and fails brew test.
+    """
+    api = _homebrew_assertions_rb().read_text(encoding="utf-8")
+    sig = re.search(
+        r"def shell_output\(cmd,\s*result\s*=\s*0\)",
+        api,
+    )
+    assert sig, "Homebrew shell_output(cmd, result=0) signature missing"
+    assert "params(cmd: T.any(Pathname, String), result: Integer)" in api
+
+    formula = FORMULA.read_text(encoding="utf-8")
+    bad = re.search(
+        r'shell_output\(\s*bin/"[^"]+"\s*,\s*"[^"]+"\s*\)',
+        formula,
+    )
+    assert bad is None, (
+        "Formula/flexaidds.rb passes a CLI flag as shell_output's result= "
+        f"status argument: {bad.group(0)!r}"
+    )
+    assert 'shell_output("#{bin/"FlexAIDdS"} --help")' in formula
+
+
 def test_setup_py_first_shot_has_no_package_owned_warning_prints() -> None:
     setup = SETUP_PY.read_text(encoding="utf-8")
     assert "[source-guard] Warning" not in setup

--- a/tests/test_install_matrix.py
+++ b/tests/test_install_matrix.py
@@ -312,9 +312,18 @@ def _pages_install_section() -> str:
     return match.group(0)
 
 
-def test_pages_install_shows_working_first_shots_only() -> None:
-    """Drive the shipped Pages #install source. No public-index 404 commands."""
-    section = _pages_install_section()
+def _entropy_install_section() -> str:
+    text = (ROOT / "site" / "entropy-driven" / "index.html").read_text(encoding="utf-8")
+    match = re.search(
+        r'<section id="install".*?</section>',
+        text,
+        flags=re.S,
+    )
+    assert match, "#install missing from site/entropy-driven/index.html"
+    return match.group(0)
+
+
+def _assert_working_first_shot_install(section: str, *, source: str) -> None:
     required = (
         "scripts/install.sh",
         'cmd">wget</span> -qO-',
@@ -325,7 +334,6 @@ def test_pages_install_shows_working_first_shots_only() -> None:
         "scripts/update.sh",
         "python</span> -m flexaidds --self-update",
         "Two separate things",
-        "flexaidds</span> Python",
         "Dockerfile.locked",
         "environment.yml",
         "setup-flexaidds",
@@ -337,23 +345,47 @@ def test_pages_install_shows_working_first_shots_only() -> None:
         "install-tabs",
         "code-box",
         "cmake-table",
-        "binding-blurb",
     )
     missing = [token for token in required if token not in section]
-    assert missing == [], f"Pages #install missing tokens: {missing}"
-    assert 'maxWidth: "896px"' in section
+    assert missing == [], f"{source} #install missing tokens: {missing}"
+    assert "896px" in section
     assert "pip install flexaidds" not in section
     assert re.search(
         r"brew install(?![\s\S]{0,20}--HEAD)[\s\S]{0,80}lebonhommepharma/flexaidds/flexaidds",
         section,
     ) is None
     assert "conda install -c conda-forge flexaidds" not in section
-    # These are real channels later; they 404 today. Do not paste them as first-shot.
     assert "docker pull" not in section
     assert "ghcr.io/lebonhommepharma/flexaidds" not in section
     assert "--from-release" not in section
     for tab in ("curl", "Homebrew", "Python", "Docker", "conda", "CI", "HPC", "CMake"):
-        assert tab in section
+        assert tab in section, f"{source} missing tab {tab!r}"
+
+
+def test_pages_install_shows_working_first_shots_only() -> None:
+    """Drive the shipped product Pages #install source."""
+    section = _pages_install_section()
+    _assert_working_first_shot_install(section, source="site/FlexAIDdS/sections.jsx")
+    assert "binding-blurb" in section
+    assert 'maxWidth: "896px"' in section
+
+
+def test_entropy_driven_install_matches_working_first_shots() -> None:
+    """Drive the shipped entropy-driven #install block, not a restated copy."""
+    section = _entropy_install_section()
+    _assert_working_first_shot_install(section, source="site/entropy-driven/index.html")
+    css = (ROOT / "site" / "entropy-driven" / "index.html").read_text(encoding="utf-8")
+    assert ".install-tabs" in css
+    assert ".code-box" in css
+    assert ".cmake-table" in css
+
+
+def test_install_chrome_not_restyled() -> None:
+    product_css = (ROOT / "site" / "FlexAIDdS" / "styles.css").read_text(encoding="utf-8")
+    assert ".install-tabs {" in product_css
+    assert ".code-box {" in product_css
+    assert ".cmake-table {" in product_css
+    assert ".install-tab.active" in product_css
 
 
 def test_setup_py_first_shot_has_no_package_owned_warning_prints() -> None:

--- a/tests/test_install_matrix.py
+++ b/tests/test_install_matrix.py
@@ -312,8 +312,8 @@ def _pages_install_section() -> str:
     return match.group(0)
 
 
-def test_pages_install_shows_first_shot_and_extra_fronts() -> None:
-    """Drive the shipped Pages #install source, not a restated command list."""
+def test_pages_install_shows_working_first_shots_only() -> None:
+    """Drive the shipped Pages #install source. No public-index 404 commands."""
     section = _pages_install_section()
     required = (
         "scripts/install.sh",
@@ -326,9 +326,6 @@ def test_pages_install_shows_first_shot_and_extra_fronts() -> None:
         "python</span> -m flexaidds --self-update",
         "Two separate things",
         "flexaidds</span> Python",
-        "--from-release latest",
-        "SHA256SUMS.txt",
-        "ghcr.io/lebonhommepharma/flexaidds",
         "Dockerfile.locked",
         "environment.yml",
         "setup-flexaidds",
@@ -337,8 +334,6 @@ def test_pages_install_shows_first_shot_and_extra_fronts() -> None:
         "packaging/easybuild/flexaidds-2.0.3.eb",
         "packaging/modulefiles",
         "not on PyPI",
-        "no bottle do",
-        "not a conda-forge feedstock",
         "install-tabs",
         "code-box",
         "cmake-table",
@@ -347,13 +342,16 @@ def test_pages_install_shows_first_shot_and_extra_fronts() -> None:
     missing = [token for token in required if token not in section]
     assert missing == [], f"Pages #install missing tokens: {missing}"
     assert 'maxWidth: "896px"' in section
-    assert re.search(r"pip install flexaidds(?![^\n]*subdirectory=python)", section) is None
     assert "pip install flexaidds" not in section
     assert re.search(
         r"brew install(?![\s\S]{0,20}--HEAD)[\s\S]{0,80}lebonhommepharma/flexaidds/flexaidds",
         section,
     ) is None
     assert "conda install -c conda-forge flexaidds" not in section
+    # These are real channels later; they 404 today. Do not paste them as first-shot.
+    assert "docker pull" not in section
+    assert "ghcr.io/lebonhommepharma/flexaidds" not in section
+    assert "--from-release" not in section
     for tab in ("curl", "Homebrew", "Python", "Docker", "conda", "CI", "HPC", "CMake"):
         assert tab in section
 

--- a/tests/test_install_matrix.py
+++ b/tests/test_install_matrix.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Bind the landing install how-to to Formula/flexaidds.rb and pyproject.toml.
+
+Reads the shipped files. Does not re-implement the support matrix.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOWTO = ROOT / "docs" / "INSTALL.md"
+FORMULA = ROOT / "Formula" / "flexaidds.rb"
+PYPROJECT = ROOT / "python" / "pyproject.toml"
+SETUP_PY = ROOT / "python" / "setup.py"
+
+
+def _section(text: str, heading: str) -> str:
+    match = re.search(
+        rf"^## {re.escape(heading)}\n(.*?)(?=^## |\Z)",
+        text,
+        flags=re.M | re.S,
+    )
+    assert match, f"missing how-to section {heading!r}"
+    return match.group(1)
+
+
+def _first_bash_fence(section: str) -> str:
+    match = re.search(r"```bash\n(.*?)```", section, flags=re.S)
+    assert match, "missing bash fence"
+    return match.group(1)
+
+
+def test_howto_homebrew_first_shot_is_head_and_matches_formula() -> None:
+    howto = HOWTO.read_text(encoding="utf-8")
+    formula = FORMULA.read_text(encoding="utf-8")
+    brew_sec = _section(howto, "Engine: Homebrew (lowest friction on macOS)")
+    fence = _first_bash_fence(brew_sec)
+
+    assert "brew tap lebonhommepharma/flexaidds https://github.com/LeBonhommePharma/FlexAIDdS" in fence
+    assert "brew trust --formula lebonhommepharma/flexaidds/flexaidds" in fence
+    assert "brew install --HEAD lebonhommepharma/flexaidds/flexaidds" in fence
+    assert "FlexAIDdS --help" in fence
+    assert re.search(r"^brew install lebonhommepharma/flexaidds/flexaidds\s*$", fence, re.M) is None
+
+    head = re.search(r'head "([^"]+)", branch: "([^"]+)"', formula)
+    assert head, "formula missing head URL/branch"
+    assert head.group(1) == "https://github.com/LeBonhommePharma/FlexAIDdS.git"
+    assert head.group(2) == "main"
+    url = re.search(r'^  url "([^"]+)"', formula, flags=re.M)
+    assert url and "v2.0.3.tar.gz" in url.group(1)
+    assert "unless build.head?" in formula
+    assert "brew install --HEAD lebonhommepharma/flexaidds/flexaidds" in formula
+
+
+def test_howto_pip_first_shot_is_not_unpublished_pypi() -> None:
+    howto = HOWTO.read_text(encoding="utf-8")
+    pyproject = PYPROJECT.read_text(encoding="utf-8")
+    pip_sec = _section(howto, "Python: pip")
+    fence = _first_bash_fence(pip_sec)
+
+    assert "not on public PyPI" in pip_sec or "unpublished" in pip_sec.lower()
+    assert "git+https://github.com/LeBonhommePharma/FlexAIDdS.git#subdirectory=python" in fence
+    assert "FLEXAIDDS_SKIP_CORE=1" in fence
+    assert "flexaidds --help" in fence
+    assert re.search(r"^\s*pip install flexaidds\s*$", fence, flags=re.M) is None
+
+    version = re.search(r'^version = "([^"]+)"', pyproject, flags=re.M)
+    assert version, "pyproject.toml missing static [project] version"
+    assert version.group(1) == "2.0.3"
+
+
+def test_support_matrix_does_not_checkmark_broken_first_shots() -> None:
+    howto = HOWTO.read_text(encoding="utf-8")
+    matrix = _section(howto, "Support matrix")
+    # Homebrew first-shot is --HEAD, not an unqualified formula ✅.
+    assert "brew install --HEAD" in matrix
+    assert "v2.0.3" in matrix and "provenance refuse" in matrix
+    # PyPI pip is unpublished, not a working first-shot.
+    pypi_rows = [
+        line for line in matrix.splitlines() if "pip install flexaidds" in line and "PyPI" in line
+    ]
+    assert pypi_rows, "matrix must have an explicit PyPI pip row"
+    for row in pypi_rows:
+        assert "✅" not in row
+        assert "unpublished" in row
+    git_rows = [line for line in matrix.splitlines() if "git+subdirectory" in line]
+    assert git_rows and all("✅" in row for row in git_rows)
+
+
+def test_setup_py_first_shot_has_no_package_owned_warning_prints() -> None:
+    setup = SETUP_PY.read_text(encoding="utf-8")
+    assert "[source-guard] Warning" not in setup
+    skip_block = setup.split("if _skip_core_requested():", 1)[1][:400]
+    assert "warnings.warn" not in skip_block
+
+
+def test_setup_py_isolated_skip_core_is_silent(tmp_path: Path) -> None:
+    """Drive shipped setup.py as an sdist would: no scripts/, SKIP_CORE=1."""
+    dest = tmp_path / "python"
+    shutil.copytree(
+        ROOT / "python",
+        dest,
+        ignore=shutil.ignore_patterns(
+            "dist", "build", "*.egg-info", "__pycache__", "LIB", ".pytest_cache"
+        ),
+    )
+    env = os.environ.copy()
+    env["FLEXAIDDS_SKIP_CORE"] = "1"
+    env.pop("FORCE_COLOR", None)
+    proc = subprocess.run(
+        [sys.executable, str(dest / "setup.py"), "--name"],
+        cwd=dest,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "flexaidds"
+    assert "[source-guard] Warning" not in proc.stderr
+    assert "UserWarning" not in proc.stderr
+    assert "FLEXAIDDS_SKIP_CORE set" not in proc.stderr


### PR DESCRIPTION
Document `brew install --HEAD` as the working macOS engine path; stable
v2.0.3 is refused immediately (no provenance JSON). Pip first-shot is
git+subdirectory / local wheel with `FLEXAIDDS_SKIP_CORE=1` — PyPI is
unpublished. Silence `setup.py` source-guard and SKIP_CORE UserWarnings
on sdist/wheel installs. Bind the matrix to the formula and pyproject
in `tests/test_install_matrix.py`.

Product and entropy-driven `#install` UIs paste only commands that run
today (curl/wget installer, brew `--HEAD`, git/uv/pipx, Docker **build**,
conda env from `environment.yml`, GitHub Action / Dev Container, HPC
overlays, CMake, unified updater). They do not paste unpublished
`pip install flexaidds`, stable brew without `--HEAD`, `docker pull ghcr.io/…`,
or `install.sh --from-release`.

## Summary

First-shot install honesty plus Pages/subpage copy that matches it.
`main` still showed CMake + `pip install -e .` and stable brew without
`--HEAD`. This PR is the installer, formula, silent wheel path, and
the existing tab/code-box UI — not a restyle.

## Change class (pick **one** primary)

- [ ] **Fix** — bug; default path unchanged, or fail-closed
- [ ] **Science enhancement** — opt-in; env-gated **OFF** (`flexaids::env_bool`)
- [ ] **Engine/code** — LIB/src behavior that is not a science gate
- [ ] **Docs / audit / swarm pack** — `docs/swarm/`, `docs/audit/` (own PR; do not mix with LIB)
- [ ] **Benchmark harness / frozen referee**
- [x] **CI / hygiene**

`python3 scripts/classify_diff.py origin/main HEAD` → **VERDICT: CI / hygiene** (not MIXED).

## Science-Impact

- [x] none (cannot move docked coordinates or CF ranking)
- [ ] gated OFF — flag name: `FLEXAIDDS_…`
- [ ] default-path (requires METHODOLOGY.md §1 parity)

## Scope

- [ ] Core 1.0 supported surface
- [ ] Experimental surface only
- [ ] Documentation only
- [x] CI / release engineering
- [ ] Security hardening
- [ ] Benchmark / reproducibility

## Release impact

- [ ] affects CLI behavior
- [x] affects Python package behavior
- [ ] affects configuration schema or defaults
- [ ] affects benchmark or metric reporting
- [x] affects installation instructions
- [ ] no user-facing release impact

Python: silent `FLEXAIDDS_SKIP_CORE=1` / source-guard on sdist/wheel; `--self-update` CLI. No scoring/ranking change.

## Validation

- [x] unit tests
- [ ] integration tests
- [ ] smoke benchmark
- [x] documentation review
- [x] manual validation

`python3 -m pytest tests/test_install_matrix.py tests/test_check_published_astex_rates.py tests/test_site_publish_scripts.py` — 45 passed.
Live checks of unpublished PyPI / GHCR / release assets are **not** first-shot; those commands are kept out of the Pages copy-paste boxes.

## Security and safety

- [x] no new third-party dependency
- [ ] third-party dependency added and documented
- [x] no known security-sensitive parsing change
- [ ] security-sensitive parsing change reviewed

## Reproducibility

- [x] no benchmark claim involved
- [ ] benchmark claim updated with reproducibility artifact
- [x] benchmark language remains preliminary

Public pages no longer restate 91.8% / 94.1% / 92%. Copy is unverified / pending receipt / benchmarks still rolling. JCIM Table 2 45.2% / 66.7% stays as a literature comparator.

## Notes

- Does **not** publish PyPI, GHCR, bottles, or conda-forge.
- Does **not** merge itself or dispatch Deploy Site.
- Live https://thebonhomme.com/FlexAIDdS/ updates only after merge + Deploy Site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly docs, installers, and CI/release wiring; no docking or scoring changes. Duplicate `setup-action-smoke` job in `packaging.yml` may break or confuse workflow parsing until deduplicated.
> 
> **Overview**
> This PR makes **first-shot install paths honest** across docs, the marketing site, Homebrew, and new shell tooling: `scripts/install.sh` / `update.sh` (curl/wget), macOS engine via `brew install --HEAD`, Python via git+subdirectory with `FLEXAIDDS_SKIP_CORE=1`, and checksum-gated `--from-release` once tagged releases ship assets.
> 
> **Release/CI plumbing** adds a composite `setup-flexaidds` action, Dev Container config, workflows for GHCR publish, Homebrew bottles, `release-all` dispatch, and a `release.yml` job that uploads platform archives plus `SHA256SUMS.txt` to GitHub Releases. The Homebrew formula **refuses stable v2.0.3** without build provenance, documents `--HEAD` only, and fixes `brew test` `shell_output` usage.
> 
> **Python UX**: `--self-update` / `update_all()` refresh Homebrew, pip/uv/pipx, and local GHCR images; `setup.py` stays quiet on SKIP_CORE and skips the source guard outside full checkouts. HPC overlay recipes (Spack/EasyBuild/Lmod) and expanded `#install` tabs on product pages mirror the same working commands.
> 
> **Benchmark copy** tightens withdrawal language (no ≥90% rates) with an added guard test. Note: `packaging.yml` currently defines **`setup-action-smoke` twice** (duplicate job id).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c86638b30a039b70ba1626e7fa8bf5f2b75678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->