### PR TITLE
Fix: packaging workflow parse + skip install-only Tier-1 docks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
       - name: Check tracked secrets and hardcoded agent paths
         run: python3 scripts/check_repo_hygiene.py
       - name: Root run-artifact guard and diff classifier
-        run: python3 -m pytest tests/test_check_root_artifacts.py tests/test_classify_diff.py tests/test_tier1_pr_needs_dock.py tests/test_coverage_gate.py tests/test_site_publish_scripts.py -q --tb=line
+        run: python3 -m pytest tests/test_check_root_artifacts.py tests/test_classify_diff.py tests/test_tier1_pr_needs_dock.py tests/test_github_workflows.py tests/test_coverage_gate.py tests/test_site_publish_scripts.py -q --tb=line
       - name: Validate public thermodynamic claims and provenance firewall
         run: |
           python3 scripts/validate_thermo_claims.py

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -57,6 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.11"
+
       - name: actionlint
         run: |
           set -euo pipefail
@@ -65,24 +69,11 @@ jobs:
           # a *parse* failure is not.
           ./actionlint -color -shellcheck= -pyflakes= || true
           echo "--- strict YAML parse (this is the blocking check) ---"
-          python3 - <<'PY'
-          import pathlib, sys
-          import yaml
-          bad = []
-          for f in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
-              try:
-                  d = yaml.safe_load(f.read_text(encoding="utf-8"))
-              except Exception as exc:
-                  bad.append(f"{f}: {type(exc).__name__}: {exc}")
-                  continue
-              if not isinstance(d, dict) or "jobs" not in d:
-                  bad.append(f"{f}: parsed but has no 'jobs' mapping")
-          if bad:
-              print("UNPARSEABLE WORKFLOW FILES:")
-              print("\n".join(bad))
-              sys.exit(1)
-          print("all workflow files parse and declare jobs")
-          PY
+          # yaml.safe_load silently keeps the last duplicate key, which is
+          # exactly how a duplicated job id produced 0-second GitHub startup
+          # failures with no jobs (workflow name shown as the file path).
+          python3 -m pip install --quiet pyyaml
+          python3 scripts/check_github_workflows.py
 
   # ── Gate 1b: the Homebrew formula is Ruby, and nothing here ever read it ──
   # Formula/** is in this workflow's path filter, so editing the formula starts
@@ -427,22 +418,6 @@ jobs:
               print("unpinned run deps (reproducibility):", unpinned); sys.exit(1)
           print("all run deps carry a version constraint")
           PY
-
-  setup-action-smoke:
-    name: composite action installs flexaidds
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
-        with:
-          python-version: "3.11"
-      - uses: ./.github/actions/setup-flexaidds
-        with:
-          from-checkout: "true"
-          skip-core: "true"
-      - name: CLI works
-        run: python -m flexaidds --help
-
 
   setup-action-smoke:
     name: composite action installs flexaidds

--- a/scripts/check_github_workflows.py
+++ b/scripts/check_github_workflows.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Reject GitHub workflow YAML that GitHub itself will not parse.
+
+GitHub fails the whole run in 0s (no jobs, workflow name becomes the file
+path) when a workflow has duplicate mapping keys — most commonly a
+duplicated job id. PyYAML's ``safe_load`` silently keeps the last
+duplicate, so a parse gate that uses it cannot see the class of breakage
+it exists to catch.
+
+Usage:
+  python3 scripts/check_github_workflows.py
+  python3 scripts/check_github_workflows.py --root /path/to/repo
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(
+        "PyYAML is required: python3 -m pip install pyyaml"
+    ) from exc
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """SafeLoader that errors on duplicate mapping keys."""
+
+
+def _no_duplicates_constructor(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            mark = key_node.start_mark
+            raise yaml.constructor.ConstructorError(
+                None,
+                None,
+                f"duplicate YAML key {key!r} at line {mark.line + 1} "
+                f"column {mark.column + 1}",
+                mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _no_duplicates_constructor,
+)
+
+
+def load_unique(text: str):
+    """Parse YAML and raise on duplicate keys."""
+    return yaml.load(text, Loader=UniqueKeyLoader)
+
+
+def iter_github_yaml(root: Path) -> list[Path]:
+    files: list[Path] = []
+    workflows = root / ".github" / "workflows"
+    if workflows.is_dir():
+        files.extend(sorted(workflows.glob("*.yml")))
+        files.extend(sorted(workflows.glob("*.yaml")))
+    actions = root / ".github" / "actions"
+    if actions.is_dir():
+        files.extend(sorted(actions.glob("**/action.yml")))
+        files.extend(sorted(actions.glob("**/action.yaml")))
+    return files
+
+
+def check_file(path: Path, root: Path) -> list[str]:
+    rel = path.relative_to(root).as_posix()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{rel}: cannot read: {exc}"]
+    try:
+        data = load_unique(text)
+    except yaml.YAMLError as exc:
+        return [f"{rel}: {exc}"]
+    if not isinstance(data, dict):
+        return [f"{rel}: parsed but is not a mapping"]
+    errors: list[str] = []
+    if path.parent.name == "workflows" or "/workflows/" in rel:
+        # GitHub stores `on:` as a boolean under YAML 1.1; only `jobs` is
+        # required for a runnable workflow file.
+        if "jobs" not in data:
+            errors.append(f"{rel}: parsed but has no 'jobs' mapping")
+        else:
+            jobs = data["jobs"]
+            if not isinstance(jobs, dict) or not jobs:
+                errors.append(f"{rel}: 'jobs' must be a non-empty mapping")
+    elif path.name in {"action.yml", "action.yaml"}:
+        if "runs" not in data:
+            errors.append(f"{rel}: composite/javascript action missing 'runs'")
+    return errors
+
+
+def collect_errors(root: Path) -> list[str]:
+    files = iter_github_yaml(root)
+    if not files:
+        return [f"{root}: no .github/workflows/*.yml files found"]
+    errors: list[str] = []
+    for path in files:
+        errors.extend(check_file(path, root))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repository root (default: inferred from this script)",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    errors = collect_errors(root)
+    if errors:
+        print("UNPARSEABLE GITHUB YAML:")
+        print("\n".join(errors))
+        return 1
+    n = len(iter_github_yaml(root))
+    print(f"ok: {n} GitHub YAML files parse with unique mapping keys")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tier1_pr_needs_dock.py
+++ b/scripts/tier1_pr_needs_dock.py
@@ -35,6 +35,14 @@ _SKIP_EXACT = frozenset(
         "README.md",
         "scripts/tier1_pr_needs_dock.py",
         "tests/test_tier1_pr_needs_dock.py",
+        "python/README.md",
+        "python/flexaidds/updater.py",
+        "python/pyproject.toml",
+        "python/setup.py",
+        "scripts/install.sh",
+        "scripts/update.sh",
+        "scripts/validate_install_patterns.sh",
+        "scripts/check_github_workflows.py",
     }
 )
 _SKIP_PREFIXES = (
@@ -43,6 +51,12 @@ _SKIP_PREFIXES = (
     "python/tests/",
     "docs/",
     ".github/",
+    "Formula/",
+    "packaging/",
+    "conda/",
+    "containers/",
+    ".devcontainer/",
+    "site/",
 )
 
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,0 +1,71 @@
+"""GitHub workflow YAML must parse the way GitHub parses it.
+
+Duplicate mapping keys (especially duplicated job ids) make GitHub reject
+the file at startup: 0s, no jobs, workflow name = the file path.
+yaml.safe_load cannot catch that class — it keeps the last duplicate.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_github_workflows as gw  # noqa: E402
+
+
+def test_repo_workflows_and_actions_parse_with_unique_keys():
+    errors = gw.collect_errors(REPO_ROOT)
+    assert errors == [], "\n".join(errors)
+
+
+def test_packaging_job_ids_are_unique():
+    text = (REPO_ROOT / ".github/workflows/packaging.yml").read_text(encoding="utf-8")
+    data = gw.load_unique(text)
+    jobs = data["jobs"]
+    assert "setup-action-smoke" in jobs
+    assert list(jobs).count("setup-action-smoke") == 1
+
+
+def test_duplicate_job_id_is_rejected(tmp_path: Path):
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "dup.yml").write_text(
+        "name: Dup\n"
+        "on: push\n"
+        "jobs:\n"
+        "  lint:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: true\n"
+        "  lint:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: true\n",
+        encoding="utf-8",
+    )
+    errors = gw.collect_errors(tmp_path)
+    assert errors, "duplicate job id must fail the gate"
+    assert any("duplicate YAML key" in e and "lint" in e for e in errors)
+
+
+def test_safe_load_misses_the_duplicate_that_github_rejects():
+    text = (
+        "jobs:\n"
+        "  a:\n"
+        "    runs-on: ubuntu-latest\n"
+        "  a:\n"
+        "    runs-on: windows-latest\n"
+    )
+    silent = yaml.safe_load(text)
+    assert list(silent["jobs"]) == ["a"]
+    with pytest.raises(yaml.YAMLError, match="duplicate YAML key"):
+        gw.load_unique(text)
+
+
+def test_cli_ok_on_this_repo():
+    assert gw.main(["--root", str(REPO_ROOT)]) == 0

--- a/tests/test_tier1_pr_needs_dock.py
+++ b/tests/test_tier1_pr_needs_dock.py
@@ -60,6 +60,31 @@ def test_skip_gate_ci_files_do_not_dock():
     assert gate.files_need_dock(files) is False
 
 
+def test_install_only_paths_skip_dock():
+    files = [
+        "Formula/flexaidds.rb",
+        "packaging/spack/package.py",
+        "conda/meta.yaml",
+        "containers/Dockerfile.locked",
+        ".devcontainer/devcontainer.json",
+        "python/flexaidds/updater.py",
+        "python/README.md",
+        "python/pyproject.toml",
+        "python/setup.py",
+        "scripts/install.sh",
+        "scripts/update.sh",
+        "site/FlexAIDdS/index.html",
+    ]
+    assert all(gate.is_post_election_path(p) for p in files)
+    assert gate.files_need_dock(files) is False
+
+
+def test_updater_plus_results_still_docks():
+    assert gate.files_need_dock(
+        ["python/flexaidds/updater.py", "python/flexaidds/results.py"]
+    ) is True
+
+
 def test_cli_files_flag(capsys, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     github_output = tmp_path / "github_output"


### PR DESCRIPTION
## Why

Every push that loaded `.github/workflows/packaging.yml` for the last few hours failed in **0 seconds with no jobs**. GitHub showed the workflow name as the file path (`.github/workflows/packaging.yml`) instead of `Packaging`. That is GitHub’s unparseable-workflow startup failure.

Cause: `setup-action-smoke` was pasted twice in the same `jobs:` map (landed in `9e3a1be3`). GitHub rejects duplicate job ids. The existing Gate 1 used `yaml.safe_load`, which **silently keeps the last duplicate**, so the gate that exists to catch this class could not see it.

A second, related red: install/docs PRs that also touched `python/**` still ran the 4-target Astex Tier-1 dock (~55 min) and failed the **aspirational** `docking_power_top1: 0.70` gate. Those files cannot move RMSD ranking.

## What

1. Remove the duplicated `setup-action-smoke` job so GitHub can parse the file.
2. Replace Gate 1’s `safe_load` with `scripts/check_github_workflows.py` (unique-key loader). FlexAID CI `repo_hygiene` now runs the same check, so this class is caught even when packaging.yml itself cannot start.
3. Skip the Tier-1 Astex dock for install-only paths (Formula, conda, packaging, updater, pyproject, setup.py, install/update scripts). `python/flexaidds/results.py` and engine paths still dock. **Did not lower `expected_baselines.docking_power_top1`.**

## Not in this PR

- The 0.70 top-1 quality bar on engine PRs. That is the current 4-target accuracy (last docs PR: top-1 = 0.00, mean RMSD = 5.62 Å). Workflow comments already call this aspirational and forbid lowering the baseline.
- Deploy Site (2026-09-08 18:06Z) stats timeout — later runs on main are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of automation configuration to detect duplicate or malformed entries before execution.
  * Updated change classification so installation, packaging, container, site, and workflow-only updates are handled appropriately by quality gates.

* **Tests**
  * Expanded automated coverage for workflow validation and change classification.
  * Added checks confirming that changes affecting update and results functionality continue to receive the required quality review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->