### PR TITLE
test(ci): fix two stale C++ assertions that outlived the code they checked

### DIFF
--- a/tests/test_dataset_runner.cpp
+++ b/tests/test_dataset_runner.cpp
@@ -23,6 +23,8 @@
 #include "DatasetThermoLog.h"
 #include "rmsd_crosscheck_engine.h"   // engine calc_Hungarian_RMSD, for the cross-check
 #undef private
+#include "generated/dataset_codes.inc"  // declared source records for the generated rosters
+#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <chrono>
@@ -173,9 +175,44 @@ TEST(DatasetRunnerCodes, AstexDiverse85SpecificCodes) {
     EXPECT_TRUE(has("2BM2"));
 }
 
+// This repository's casf2016 roster is 283 codes. a0fef2bf removed "3QGS" and
+// "3RP3" from a 285-code list after both resolved as WDRN against data.rcsb.org:
+// an ID was reserved, the deposition was withdrawn before release, no
+// coordinates were ever published. Neither appears in the removed-entry list, so
+// there is no successor code to substitute and removal was the only option.
+//
+// 283 is asserted here as the size of THIS REPOSITORY'S roster. It is NOT
+// asserted to be the published CASF-2016 core set, and the two are not the same
+// list: a prior audit measured only 115 of these 283 overlapping the published
+// core set, and the generator records this roster's own provenance as
+// EXTRACTED_FROM_CODE / primary_source=UNVERIFIED -- i.e. the declared source
+// was lifted out of the C++ literal and proves only what the code already said.
+// Roster identity is an open question tracked separately; nothing in this test
+// speaks to it.
 TEST(DatasetRunnerCodes, CASF2016Count) {
     auto codes = DatasetRunner::casf2016_codes();
-    EXPECT_EQ(codes.size(), 285u);
+    EXPECT_EQ(codes.size(), 283u);
+
+    // The compiled list must agree with the count its OWN generated source
+    // record declares. A hand-edit to LIB/generated/dataset_codes.inc that adds
+    // or drops a code without rerunning scripts/gen_dataset_codes.py fails here
+    // even if someone also updates the literal above.
+    EXPECT_EQ(codes.size(),
+              flexaids::generated::dataset_code_source("casf2016").count);
+}
+
+// Withdrawn depositions must stay out BY NAME. A count assertion alone cannot
+// see 3QGS being re-added while some other code is dropped -- the size is
+// conserved and the roster is still wrong.
+TEST(DatasetRunnerCodes, CASF2016ExcludesWithdrawnDepositions) {
+    auto codes = DatasetRunner::casf2016_codes();
+    for (const char* withdrawn : {"3QGS", "3RP3"}) {
+        const bool present =
+            std::find(codes.begin(), codes.end(), withdrawn) != codes.end();
+        EXPECT_FALSE(present)
+            << withdrawn << " is a WDRN deposition (never released; removed in "
+            << "a0fef2bf) and must not appear in the executed roster";
+    }
 }
 
 TEST(DatasetRunnerCodes, CASF2016NoDuplicates) {

--- a/tests/test_protocol_config.cpp
+++ b/tests/test_protocol_config.cpp
@@ -570,7 +570,15 @@ TEST(RunReceipt, BuildJsonHasRequiredKeys) {
     in.protocol.restarts = 5;
 
     const std::string json = flexaids::build_run_receipt_json(in);
-    EXPECT_NE(json.find("\"schema_version\": 1"), std::string::npos);
+    // Assert against the constant, not a literal. This test hardcoded "1" and
+    // went red when 3a4fa608 bumped kRunReceiptSchemaVersion to 2 to add
+    // executed_codes / executed_codes_sha256 / dataset_source_*. The Python gate
+    // (tests/test_run_receipt_codes.py) reads the constant and rode the bump
+    // without edit; this one did not. A literal here checks a number, not the
+    // writer -- and the next bump would break it again for no reason.
+    EXPECT_NE(json.find("\"schema_version\": "
+                        + std::to_string(flexaids::kRunReceiptSchemaVersion)),
+              std::string::npos);
     EXPECT_NE(json.find("\"run_id\": \"unit_test_run\""), std::string::npos);
     EXPECT_NE(json.find("\"mode\": \"defined-cleft-redock\""), std::string::npos);
     EXPECT_NE(json.find("\"temperature_K\":"), std::string::npos);


### PR DESCRIPTION
Fixes the identical `2 tests failed out of 105` ctest failure across **FlexAID CI** (`linux-gcc`, `linux-clang`, `linux-gcc-mpi`, `linux-gcc-asan`, `macOS CPU tests (blocking)`), **Code Coverage**, **tsan** and **Sanitizers** — four red workflows, one shared cause pair, no races.

`4bc2326` did not fix this: Code Coverage and tsan went red again on it, and both failures reproduce locally at `HEAD = 4bc2326f`, deterministically, across repeated runs.

## The two failures

| test | file:line | was |
|---|---|---|
| `DatasetRunnerCodes.CASF2016Count` | `tests/test_dataset_runner.cpp:178` | `codes.size()` = **283**, expected **285** |
| `RunReceipt.BuildJsonHasRequiredKeys` | `tests/test_protocol_config.cpp:573` | `"schema_version": 1` → `npos` |

**Both are stale tests. Neither is an engine regression.** The code changes they disagree with were deliberate, evidenced and correct.

- `a0fef2bf` removed `3QGS` and `3RP3` (285 → 283) after both resolved **WDRN** against `data.rcsb.org` — IDs reserved, depositions withdrawn before release, no coordinates ever published, and absent from the removed-entry list so no successor code exists to substitute.
- `3a4fa608` bumped `kRunReceiptSchemaVersion` 1 → 2 to add `executed_codes` / `executed_codes_sha256` / `dataset_source_*`. The bump is what lets a pre-S2 receipt be told apart from a tampered schema-2 one.

They landed unseen because `push` is scoped to `main`, so the whole `dataset-remediation` branch arrived in a single push at `f534131` and CI saw twelve commits at once. `SYSTEMIC_FIX_REPORT.md` says it outright: *"The C++ test suite and the rest of the CI matrix were not executed."*

### Why `linux-gcc-avx512` passed while everything else failed

It doesn't run tests. Its matrix entry carries `-DBUILD_TESTING=OFF` (which wins over the earlier `-DBUILD_TESTING=ON` on the same cmake line) plus `allow_failure: true`. Step list: **Test — skipped**, Smoke — skipped. Its log is 1390 lines against gcc's 5476, with no test output at all. Compile-only job; zero signal, not a flags-sensitivity clue.

## What changed

Not a swap of `285` for `283` — that would launder the divergence into the new normal and see nothing next time. `CASF2016Count` now asserts the roster **is 283** *and* **agrees with the count its own generated source record declares**, so a hand-edit to `LIB/generated/dataset_codes.inc` that skips `scripts/gen_dataset_codes.py` fails even if the literal is updated too. A new test asserts `3QGS` and `3RP3` are absent **by name**, closing the hole where a withdrawn code is re-added while another is dropped — size conserved, roster wrong, count assertion blind.

`BuildJsonHasRequiredKeys` now asserts against `kRunReceiptSchemaVersion` instead of a literal, matching what the Python gate (`tests/test_run_receipt_codes.py`) already does — which is exactly why the Python suite rode the bump untouched while this one went red.

**The test comment does not claim the 283 are the CASF-2016 core set.** They substantially aren't — see the roster-identity issue linked below. It states only what is true: 283 is the size of *this repository's* roster.

## Proof each new assertion can still fail

Every changed or added assertion was broken deliberately and watched go red, then restored.

**A — writer emits a `schema_version` disagreeing with the constant** (`RunReceipt.cpp`, emit `99`):
```
tests/test_protocol_config.cpp:581: Failure
Expected: (json.find("\"schema_version\": " + std::to_string(flexaids::kRunReceiptSchemaVersion))) != (std::string::npos)
[  FAILED  ] RunReceipt.BuildJsonHasRequiredKeys
```

**B — drop a third code (`1A30`) from the roster** — both sub-assertions fire:
```
tests/test_dataset_runner.cpp:194: Failure   Which is: 282   Which is: 283
tests/test_dataset_runner.cpp:201: Failure   Which is: 282   Which is: 283
[  FAILED  ] DatasetRunnerCodes.CASF2016Count
```

**C — desync declared count 283 → 284, roster untouched** — isolates the declared-count assertion; the literal still passes, only line 201 fires:
```
tests/test_dataset_runner.cpp:201: Failure   Which is: 283   Which is: 284
[  FAILED  ] DatasetRunnerCodes.CASF2016Count
```

**D — re-add `3QGS` in place of `3QAA`, size conserved at 283** — the case a count alone cannot see:
```
--- count assertion ---
[       OK ] DatasetRunnerCodes.CASF2016Count          <-- blind, as predicted
--- absence assertion ---
Value of: present
  Actual: true
Expected: false
3QGS is a WDRN deposition (never released; removed in a0fef2bf) and must not appear in the executed roster
[  FAILED  ] DatasetRunnerCodes.CASF2016ExcludesWithdrawnDepositions
```

After restoring each break, all four tests green.

## Out of scope, tracked separately

Only **115 of the 283** codes overlap the published CASF-2016 core set, and the generator records this roster's provenance as `EXTRACTED_FROM_CODE` / `primary_source=UNVERIFIED`. That is a real scientific defect and is deliberately **not** folded into this CI fix — see the linked issue.

Note also: the `3QGS`/`3RP3` WDRN evidence above is **`a0fef2bf`'s, not independently re-verified here**. `web_fetch` returned empty bodies for both the test code *and* the control, so it cannot discriminate a 404 from a fetch failure; browser access could not be approved in a non-interactive session. Flagged in the issue.

## Verification

Built and run on macOS/arm64 from a clean worktree off `origin/main`. All four transitions red → green; all four deliberate breaks red → restored green.

---

Roster identity tracked separately in #482.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated dataset validation to reflect the current CASF2016 roster, including exclusion of withdrawn depositions.
  - Added checks ensuring roster totals match the declared dataset records.
  - Updated run receipt validation to remain aligned with the active schema version automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->