### PR TITLE
site(FlexAIDdS): one canonical page — v2 palette on the withdrawn-claim content

### DIFF
--- a/site/FlexAIDdS/app.js
+++ b/site/FlexAIDdS/app.js
@@ -1,4 +1,4 @@
-// Le Bonhomme Pharma — FlexAID∆S Homepage JS
+// Le Bonhomme Pharma — FlexAIDΔS Homepage JS
 // Tabs · Copy · Theme · Counter · Drug of day · Mol* hero · Mobile menu
 
 (function () {
@@ -59,7 +59,7 @@
     btn.addEventListener('click', function () {
       navigator.clipboard.writeText(btn.dataset.copy).then(function () {
         var orig = btn.innerHTML;
-        btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22D3EE" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>';
+        btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#45E0A8" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>';
         setTimeout(function () { btn.innerHTML = orig; }, 1500);
       }).catch(function () {});
     });
@@ -146,7 +146,7 @@
       if (!isOpen) {
         mainNav.style.cssText =
           'display:flex;flex-direction:column;gap:4px;position:absolute;top:56px;left:0;right:0;' +
-          'background:rgba(10,14,20,0.98);padding:1rem 1.5rem;border-bottom:1px solid rgba(34,211,238,0.12);z-index:99;';
+          'background:rgba(8,9,26,0.98);padding:1rem 1.5rem;border-bottom:1px solid rgba(69,224,168,0.12);z-index:99;';
       } else {
         mainNav.removeAttribute('style');
       }

--- a/site/FlexAIDdS/app.jsx
+++ b/site/FlexAIDdS/app.jsx
@@ -1,4 +1,4 @@
-// FlexAID∆S Website UI Kit — root app composition.
+// FlexAIDΔS Website UI Kit — root app composition.
 
 const { useState: useAppState, useEffect: useAppEffect } = React;
 

--- a/site/FlexAIDdS/assets/favicon-flexaid-ds.svg
+++ b/site/FlexAIDdS/assets/favicon-flexaid-ds.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 40 40" fill="none">
+  <g transform="rotate(-35 20 22)" stroke="#8B5CF6" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" opacity="0.4">
+    <path d="M 13 26 L 20 18 L 27 26"></path>
+    <circle cx="13" cy="26" r="1.8" fill="#8B5CF6"></circle>
+    <circle cx="20" cy="18" r="1.8" fill="#8B5CF6"></circle>
+    <circle cx="27" cy="26" r="1.8" fill="#8B5CF6"></circle>
+  </g>
+  <g transform="rotate(35 20 22)" stroke="#8B5CF6" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" opacity="0.4">
+    <path d="M 13 26 L 20 18 L 27 26"></path>
+    <circle cx="13" cy="26" r="1.8" fill="#8B5CF6"></circle>
+    <circle cx="20" cy="18" r="1.8" fill="#8B5CF6"></circle>
+    <circle cx="27" cy="26" r="1.8" fill="#8B5CF6"></circle>
+  </g>
+  <g stroke="#45E0A8" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 13 26 L 20 18 L 27 26"></path>
+    <circle cx="13" cy="26" r="2.4" fill="#45E0A8"></circle>
+    <circle cx="20" cy="18" r="2.4" fill="#45E0A8"></circle>
+    <circle cx="27" cy="26" r="2.4" fill="#45E0A8"></circle>
+  </g>
+</svg>

--- a/site/FlexAIDdS/assets/flexaid-logo.js
+++ b/site/FlexAIDdS/assets/flexaid-logo.js
@@ -1,5 +1,5 @@
 /* ============================================================
-   FlexAID∆S — Dynamic Brand Mark
+   FlexAIDΔS — Dynamic Brand Mark
    Le Bonhomme Pharma · Montréal
 
    The mark is a living conformational ensemble. A 3-atom ligand
@@ -20,9 +20,9 @@
   "use strict";
 
   var NS = "http://www.w3.org/2000/svg";
-  var TEAL = "#22D3EE";
-  var TERRA = "#A78BFA";
-  var GOLD = "#FBBF24";
+  var TEAL = "#45E0A8";
+  var TERRA = "#8B5CF6";
+  var GOLD = "#FF9300";
 
   // pivot + ligand geometry inside a 100×100 viewBox
   var PX = 50, PY = 52;                 // shared rotation pivot
@@ -68,7 +68,7 @@
     var svg = el("svg", {
       viewBox: "0 0 100 100",
       width: size, height: size,
-      role: "img", "aria-label": "FlexAID∆S"
+      role: "img", "aria-label": "FlexAIDΔS"
     });
     svg.style.display = "block";
     svg.style.overflow = "visible";
@@ -175,7 +175,7 @@
       var sc = 1 + collapse * 0.06;
       bound.setAttribute("transform", "translate(" + (PX * (1 - sc)).toFixed(3) + " " + (PY * (1 - sc)).toFixed(3) + ") scale(" + sc.toFixed(3) + ")");
       var glow = 2 + collapse * 9;
-      svg.style.filter = "drop-shadow(0 0 " + glow.toFixed(1) + "px rgba(34,211,238," + (0.25 + collapse * 0.45).toFixed(3) + "))";
+      svg.style.filter = "drop-shadow(0 0 " + glow.toFixed(1) + "px rgba(69,224,168," + (0.25 + collapse * 0.45).toFixed(3) + "))";
       // atoms shift teal→gold at the binding instant
       var goldMix = clamp((collapse - 0.55) / 0.45, 0, 1);
       var atomCol = mixHex(TEAL, GOLD, goldMix);

--- a/site/FlexAIDdS/assets/molstar-drug-viewer.js
+++ b/site/FlexAIDdS/assets/molstar-drug-viewer.js
@@ -328,7 +328,7 @@
     el.innerHTML =
       '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f43f5e" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg>' +
       '<div class="molstar-loading-text">Structure load failed — check network</div>' +
-      '<a href="https://www.rcsb.org/structure/' + pdbId.toUpperCase() + '" target="_blank" rel="noopener noreferrer" style="font-family:JetBrains Mono,monospace;font-size:10px;color:#22D3EE;">View on RCSB →</a>';
+      '<a href="https://www.rcsb.org/structure/' + pdbId.toUpperCase() + '" target="_blank" rel="noopener noreferrer" style="font-family:JetBrains Mono,monospace;font-size:10px;color:#45E0A8;">View on RCSB →</a>';
   }
 
   function bindResize(viewer, container) {

--- a/site/FlexAIDdS/colors_and_type.css
+++ b/site/FlexAIDdS/colors_and_type.css
@@ -1,128 +1,205 @@
 /* ============================================================
-   FlexAID∆S Design System — Colors & Type
+   @flexaidds/tokens — FlexAIDΔS palette v2
    Le Bonhomme Pharma · Montréal
-   Source: thebonhomme.com (live production site)
+
+   The approved palette from `Color & Type Pairings.dc.html`,
+   option 6a. Seven key colors, each bound to a thermodynamic
+   quantity; the binding is the system, so a key color is never
+   reassigned to a different quantity.
+
+       ΔG = ΔH − TΔS − TΔS_vib
+
+   Load this before your own styles. It defines tokens only —
+   no element rules, so it cannot fight a consuming stylesheet.
+   For the semantic element styles the design system ships
+   (body grid, .eyebrow, .stat-value, .brand), see `elements.css`.
+
+   Contrast ratios below are measured against the ink (#08091A)
+   and computed from the WCAG 2.1 relative-luminance formula;
+   two differ from the numbers printed on the board — see
+   ../../README.md, "Corrections".
+
+   palette-check-ignore-start
+   Retired — do not reintroduce:
+     gold #FBBF24 · pale gold #FDE68A · any yellow · cyan #22D3EE
+     salmon #C2456F · wine #DA2F63 · steel #6E7C99
+     maraschino #FF2600 (orange cast) · snow #FFFFFF (too loud)
+   palette-check-ignore-end
    ============================================================ */
 
-/* --- FONTS -----------------------------------------------------
-   The brand uses two Google Fonts. No local TTFs are bundled —
-   import via the standard Google Fonts stylesheet.
-
-   <link rel="preconnect" href="https://fonts.googleapis.com">
-   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-   ------------------------------------------------------------ */
-
-/* ───────── SELF-HOSTED BRAND FONT (disabled: no fonts/ dir in site/; use Google IBM Plex Sans) ─────────
-   SF Pro Display (Apple) — committed body & display sans.
-   Self-hosted from /fonts; replaces IBM Plex Sans as --font-body.
-   Commented to avoid 404s. Body falls back to IBM Plex Sans from Google link in HTML.
-*/
-/*
-@font-face { font-family: 'SF Pro Display'; font-weight: 100; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Ultralight.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 200; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Thin.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 300; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Light.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 400; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Regular.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 500; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Medium.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 600; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Semibold.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 700; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Bold.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 800; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Heavy.otf') format('opentype'); }
-@font-face { font-family: 'SF Pro Display'; font-weight: 900; font-style: normal; font-display: swap; src: url('../fonts/SF-Pro-Display-Black.otf') format('opentype'); }
-*/
-
 :root {
-  /* ───────── CORE PALETTE (dark-first, scientific) ───────── */
+  /* ───────── SURFACES ─────────
+     Indigo ink, never navy. Panels are translucent washes of
+     the ink rather than solid mid-tones, so the grid shows
+     through. */
+  --bg:       #08091A;                  /* page ink                */
+  --bg-panel: rgba(17, 18, 38, 0.92);   /* nav, fixed panels       */
+  --bg-card:  rgba(17, 18, 38, 0.82);   /* cards                   */
+  --bg-alt:   rgba(12, 13, 30, 0.55);   /* alternating bands       */
 
-  /* Background ladder — near-black with cool blue cast */
-  --bg:           #0a0e14;        /* page bg                       */
-  --bg-panel:     rgba(16, 20, 28, 0.92);   /* nav / fixed panels */
-  --bg-card:      rgba(16, 20, 28, 0.80);   /* feature cards      */
-  --bg-alt:       rgba(12, 16, 22, 0.50);   /* alternating bands  */
+  --fg:       #E4E3F5;                  /* body text     15.60:1   */
+  --fg-muted: #8D8CB0;                  /* secondary      6.12:1   */
 
-  /* Brand triad — the equation ΔG = ΔH − TΔS lives in these
-     colors. Each maps to a thermodynamic term and is referenced
-     consistently across UI, charts, and copy.                   */
-  --teal:    #22D3EE;   /* primary    · ΔH (enthalpy)   · CTA, brand mark */
-  --terra:   #A78BFA;   /* alert/heat · TΔS (entropy)   · alerts, section labels */
-  --gold:    #FBBF24;   /* highlight  · ΔG (free energy)· stats, key results */
+  /* ───────── KEY COLORS ─────────
+     Semantic, not decorative. Each carries a quantity. */
+  --mint:       #45E0A8;   /* ΔH · enthalpy · brand primary      11.73:1 */
+  --violet:     #8B5CF6;   /* ΔS · configurational entropy        4.66:1 */
+  --tangerine:  #FF9300;   /* ΔG · free energy · stats            8.86:1 */
+  --firetruck:  #F5232B;   /* T  · temperature · hot anchor       4.85:1 */
+  --aqua:       #00A2FF;   /* ΔS_vib · vibrational · tENCoM       7.15:1 */
+  --strawberry: #FF2F92;   /* receptor · pocket · eyebrows        5.71:1 */
+  --magnesium:  #DCDCE4;   /* baseline · apo · reference line    14.47:1 */
 
-  /* Text */
-  --fg:       #d4dced;   /* primary text       */
-  --fg-muted: #8a93a8;   /* secondary, labels  */
+  /* Violet (4.66:1) and firetruck (4.85:1) clear WCAG AA for
+     normal text but have no headroom. Hold firetruck to 12px
+     and up; prefer --state-fail-text for small failure labels. */
 
-  /* ───────── ALPHA OVERLAYS ─────────
-     The brand layers translucent washes of the triad on the
-     dark bg instead of mixing solid mid-tones. Use these for
-     borders, hover backgrounds, and chip fills.                 */
-  --teal-06:  rgba(34,211,238,0.06);
-  --teal-08:  rgba(34,211,238,0.08);
-  --teal-10:  rgba(34,211,238,0.10);
-  --teal-15:  rgba(34,211,238,0.15);
-  --teal-20:  rgba(34,211,238,0.20);
 
-  --terra-10: rgba(167,139,250,0.10);
-  --terra-12: rgba(167,139,250,0.12);
-  --terra-25: rgba(167,139,250,0.25);
-  --terra-35: rgba(167,139,250,0.35);
+  --mint-06:       rgba(69, 224, 168, 0.06);
+  --mint-08:       rgba(69, 224, 168, 0.08);
+  --mint-10:       rgba(69, 224, 168, 0.10);
+  --mint-12:       rgba(69, 224, 168, 0.12);
+  --mint-15:       rgba(69, 224, 168, 0.15);
+  --mint-20:       rgba(69, 224, 168, 0.20);
+  --mint-30:       rgba(69, 224, 168, 0.30);
 
-  --gold-06:  rgba(251,191,36,0.06);
-  --gold-10:  rgba(251,191,36,0.10);
-  --gold-12:  rgba(251,191,36,0.12);
-  --gold-35:  rgba(251,191,36,0.35);
+  --violet-10:     rgba(139, 92, 246, 0.10);
+  --violet-12:     rgba(139, 92, 246, 0.12);
+  --violet-16:     rgba(139, 92, 246, 0.16);
+  --violet-20:     rgba(139, 92, 246, 0.20);
+  --violet-25:     rgba(139, 92, 246, 0.25);
+  --violet-35:     rgba(139, 92, 246, 0.35);
+  --violet-40:     rgba(139, 92, 246, 0.40);
 
-  /* ───────── SUPPORTING / KEYWORD ACCENTS ─────────
-     Spectrum keywords cycle these on a slow gradient flow.     */
-  --kw-entropy:  var(--terra);
-  --kw-statmech: var(--teal);
-  --kw-dg:       var(--gold);
-  --kw-ga:       #67E8F9;   /* lighter teal — genetic algorithm  */
-  --kw-open:     #FCD34D;   /* warm gold — open science          */
-  --kw-docking:  #5046D6;   /* lighter terra — docking           */
-  --kw-rescue:   #FDE68A;   /* light gold — binding mode rescue  */
+  --tangerine-06:  rgba(255, 147, 0, 0.06);
+  --tangerine-10:  rgba(255, 147, 0, 0.10);
+  --tangerine-12:  rgba(255, 147, 0, 0.12);
+  --tangerine-35:  rgba(255, 147, 0, 0.35);
 
-  /* ───────── TYPE SCALE ─────────
-     Body is the brand sans-serif (IBM Plex Sans by default — see Font families
-     card for live candidate options). Everything else (headings, badges, code,
-     stats) is JetBrains Mono. This is unusual but deliberate —
-     the brand reads as "lab notebook with prose between
-     equations".                                                */
+  --firetruck-10:  rgba(245, 35, 43, 0.10);
+  --firetruck-14:  rgba(245, 35, 43, 0.14);
+  --firetruck-32:  rgba(245, 35, 43, 0.32);
+  --firetruck-40:  rgba(245, 35, 43, 0.40);
 
-  --font-body: 'SF Pro Display', 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  --aqua-10:       rgba(0, 162, 255, 0.10);
+  --aqua-20:       rgba(0, 162, 255, 0.20);
+
+  --strawberry-12: rgba(255, 47, 146, 0.12);
+  --strawberry-30: rgba(255, 47, 146, 0.30);
+  --strawberry-35: rgba(255, 47, 146, 0.35);
+
+  /* v1 alpha spellings */
+
+  /* ───────── KEYWORD ACCENTS ─────────
+     The spectrum-flow keywords cycle these. No yellow: warm
+     accents lean tangerine. */
+  --kw-entropy:  var(--violet);
+  --kw-statmech: var(--mint);
+  --kw-dg:       var(--tangerine);
+  --kw-ga:       #8EEFC9;   /* lighter mint      · genetic algorithm */
+  --kw-open:     #FFB84D;   /* lighter tangerine · open science      */
+  --kw-docking:  #A78BFA;   /* lighter violet    · docking           */
+  --kw-rescue:   #FFC773;   /* pale tangerine    · binding rescue    */
+
+  /* ───────── STATE ─────────
+     Reuses key hues; severity reads by brightness, never by
+     yellow. Magenta means caution, pure red means stop. */
+  --state-pass:      var(--mint);
+  --state-warn:      var(--strawberry);
+  --state-fail:      var(--firetruck);
+  --state-fail-text: #FF6B6B;   /* lifted for small labels   7.11:1 */
+
+  /* ───────── SERIES RAMP ─────────
+     Ordered by ENERGY along the binding coordinate, not by hue
+     or wavelength — position in a legend means something
+     thermodynamic, so a series reads as a reaction path.
+     Firetruck stays out: it is a scalar and a failure signal,
+     never a data class. Six is the ceiling. */
+  --series-1: var(--magnesium);   /* apo baseline               */
+  --series-2: var(--violet);      /* unbound · ΔS dominates     */
+  --series-3: var(--strawberry);  /* first pocket contact       */
+  --series-4: var(--aqua);        /* rigidification · ΔS_vib    */
+  --series-5: var(--mint);        /* contacts formed · ΔH       */
+  --series-6: var(--tangerine);   /* converged · ΔG             */
+
+  /* ───────── TEMPERATURE RAMP ─────────
+     Diverging cool→hot, matching the B-factor convention PyMOL
+     and Chimera use for the crystallographic temperature
+     factor — so it needs no legend for a crystallographer. The
+     equation's hues stay out of it, which keeps violet, mint
+     and tangerine meaning ΔS, ΔH and ΔG and nothing else. */
+  --t-cryo:     var(--aqua);        /*  77 K · cryo          */
+  --t-cold:     #7FD0FF;            /* 200 K · cold          */
+  --t-ambient:  var(--magnesium);   /* 298 K · ambient       */
+  --t-physio:   #FF7A5C;            /* 310 K · physiological */
+  --t-denature: var(--firetruck);   /* 350 K+ · denaturing   */
+  --t-ramp: linear-gradient(90deg,
+              var(--t-cryo)      0%,
+              var(--t-cold)     24%,
+              var(--t-ambient)  50%,
+              var(--t-physio)   76%,
+              var(--t-denature) 100%);
+
+  /* ───────── GLOW ─────────
+     Elevation is colored glow and translucency, never a
+     neutral drop shadow. */
+  --glow-mint:      0 0 20px rgba(69, 224, 168, 0.25);
+  --glow-mint-soft: 0 0 18px rgba(69, 224, 168, 0.30);
+  --glow-mint-hard: 0 0 24px rgba(69, 224, 168, 0.50);
+  --glow-violet:    0 0 20px rgba(139, 92, 246, 0.40);
+  --glow-tangerine: 0 0 20px rgba(255, 147, 0, 0.25);
+  --glow-firetruck: 0 0 22px rgba(245, 35, 43, 0.16);
+  --glow-equation:  0 0 40px rgba(69, 224, 168, 0.35),
+                    0 0 60px rgba(255, 147, 0, 0.18);
+  --inset-sheen:    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+
+  /* v1 glow spellings */
+  --glow-teal:        var(--glow-mint-soft);
+  --glow-teal-strong: var(--glow-mint-hard);
+  --glow-terra:       var(--glow-violet);
+  --glow-gold:        var(--glow-tangerine);
+
+  /* ───────── GRID ───────── violet graph paper on indigo */
+  --grid-line: rgba(139, 92, 246, 0.05);
+  --grid-step: 40px;
+
+  /* ───────── TYPE ─────────
+     Two families. JetBrains Mono carries headings, stats,
+     badges, eyebrows, code and every number; the sans is for
+     prose only. Serif prose was explicitly rejected. */
+  --font-body: 'SF Pro Display', 'IBM Plex Sans', -apple-system,
+               BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
 
-  /* Sizes */
-  --fs-hero:   7rem;     /* clamp down at small viewports        */
-  --fs-h1:     3.5rem;
-  --fs-h2:     1.75rem;
-  --fs-h3:     1.125rem;
-  --fs-body:   1rem;
-  --fs-sm:     0.875rem;
-  --fs-xs:     0.75rem;
-  --fs-tag:    0.625rem;  /* 10px — section labels, badges      */
-  --fs-meta:   0.5rem;    /* 8px  — entropy meter labels        */
+  --fs-hero: 7rem;
+  --fs-h1:   3.5rem;
+  --fs-h2:   1.75rem;
+  --fs-h3:   1.125rem;
+  --fs-body: 1rem;
+  --fs-sm:   0.875rem;
+  --fs-xs:   0.75rem;
+  --fs-tag:  0.625rem;   /* 10px · eyebrows, badges, stat labels */
+  --fs-meta: 0.5rem;     /*  8px · entropy meter labels          */
 
-  /* Weights — body never bolder than 600; mono goes to 700 */
   --fw-300: 300;
   --fw-400: 400;
   --fw-500: 500;
   --fw-600: 600;
   --fw-700: 700;
 
-  /* Tracking */
   --tracking-tight: -0.02em;
-  --tracking-flat:  0;
-  --tracking-wide:  0.08em;
-  --tracking-label: 0.15em;
-  --tracking-tag:   0.20em;
-  --tracking-meta:  0.30em;
+  --tracking-flat:   0;
+  --tracking-wide:   0.08em;
+  --tracking-label:  0.15em;
+  --tracking-tag:    0.20em;
+  --tracking-meta:   0.30em;
 
-  /* Line heights */
-  --lh-tight: 1.05;     /* hero                                  */
-  --lh-snug:  1.15;     /* headings                              */
-  --lh-body:  1.60;     /* paragraphs                            */
-  --lh-code:  1.80;     /* code blocks                           */
+  --lh-tight: 1.05;
+  --lh-snug:  1.15;
+  --lh-body:  1.60;
+  --lh-code:  1.80;
 
-  /* ───────── SPACING ───────── (8-pt soft grid) */
+  /* ───────── SPACING ───────── 8-pt soft grid */
   --sp-1:  0.25rem;
   --sp-2:  0.5rem;
   --sp-3:  0.75rem;
@@ -136,146 +213,53 @@
   --sp-20: 5rem;
   --sp-24: 6rem;
 
-  /* ───────── RADIUS ───────── conservative; cards 8px, pills 9999 */
-  --r-xs:   3px;        /* badges, chips                          */
-  --r-sm:   6px;        /* small buttons                          */
-  --r-md:   8px;        /* cards, default                         */
-  --r-lg:   12px;       /* hero panels                            */
-  --r-pill: 9999px;     /* entropy meter bar                      */
+  /* ───────── RADIUS ───────── */
+  --r-xs:   3px;      /* badges, chips     */
+  --r-sm:   6px;      /* small buttons     */
+  --r-md:   8px;      /* cards, default    */
+  --r-lg:   12px;     /* hero panels       */
+  --r-pill: 9999px;   /* meters, capsules  */
 
-  /* ───────── SHADOWS / GLOWS ─────────
-     The brand prefers colored glow over neutral drop-shadow.    */
-  --glow-teal:  0 0 18px rgba(34,211,238,0.30);
-  --glow-teal-strong: 0 0 24px rgba(34,211,238,0.50);
-  --glow-terra: 0 0 20px rgba(167,139,250,0.10);
-  --glow-gold:  0 0 20px rgba(251,191,36,0.10);
-  --glow-equation: 0 0 40px rgba(34,211,238,0.4), 0 0 60px rgba(251,191,36,0.2);
-
-  /* ───────── MOTION ─────────
-     Easings used across hover, fade-in, and the keyword
-     spectrum animation.                                         */
-  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  /* ───────── MOTION ───────── */
+  --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);
   --ease-in-out: ease-in-out;
-  --dur-fast: 0.18s;
-  --dur-base: 0.25s;
-  --dur-slow: 0.7s;
-  --dur-breathe: 4s;     /* equation breathe                     */
-  --dur-spectrum: 8.5s;  /* keyword color flow                   */
-
-  /* ───────── GRID BACKGROUND ─────────
-     Fine teal grid at 40px, always-on under content.            */
-  --grid-line: rgba(34,211,238,0.03);
-  --grid-step: 40px;
+  --dur-fast:     0.18s;
+  --dur-base:     0.25s;
+  --dur-slow:     0.7s;
+  --dur-breathe:  4s;
+  --dur-spectrum: 8.5s;
 }
 
-/* ───────── LIGHT THEME (canonical via theme.js) ───────── */
+/* ───────── LIGHT THEME ─────────
+   The site ships a light toggle (theme.js sets data-theme pre-paint,
+   theme.css owns the toggle component). Only the surface and text
+   tokens move — the seven key colors are the system and do not
+   change with the theme, so a chart or an equation reads the same
+   in either mode. Alpha washes lift slightly because the same
+   opacity over a light ground reads weaker. */
 [data-theme="light"] {
-  --bg:           #f4f6fb;
-  --bg-panel:     rgba(255, 255, 255, 0.88);
-  --bg-card:      #ffffff;
-  --bg-alt:       #eef2f8;
-  --fg:           #1e293b;
-  --fg-muted:     #5a6478;
-  --grid-line:    rgba(34, 211, 238, 0.06);
-  --teal-06:      rgba(34, 211, 238, 0.08);
-  --teal-08:      rgba(34, 211, 238, 0.10);
-  --teal-10:      rgba(34, 211, 238, 0.14);
-  --teal-12:      rgba(34, 211, 238, 0.18);
-  --teal-15:      rgba(34, 211, 238, 0.22);
-  --teal-20:      rgba(34, 211, 238, 0.28);
-}
+  --bg:       #f4f6fb;
+  --bg-panel: rgba(255, 255, 255, 0.88);
+  --bg-card:  #ffffff;
+  --bg-alt:   #eef2f8;
 
-/* ───────── SEMANTIC ELEMENT STYLES ─────────
-   Apply these to bare HTML in design output. They reproduce the
-   live thebonhomme.com look without per-element overrides.    */
+  --fg:       #1e293b;
+  --fg-muted: #5a6478;
 
-html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+  --grid-line: rgba(139, 92, 246, 0.06);
 
-body {
-  font-family: var(--font-body);
-  font-size:   var(--fs-body);
-  line-height: var(--lh-body);
-  color:       var(--fg);
-  background:  var(--bg);
-  /* The signature subtle grid */
-  background-image:
-    linear-gradient(var(--grid-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
-  background-size: var(--grid-step) var(--grid-step);
-}
+  --mint-06: rgba(69, 224, 168, 0.08);
+  --mint-08: rgba(69, 224, 168, 0.10);
+  --mint-10: rgba(69, 224, 168, 0.14);
+  --mint-12: rgba(69, 224, 168, 0.18);
+  --mint-15: rgba(69, 224, 168, 0.22);
+  --mint-20: rgba(69, 224, 168, 0.28);
+  --mint-30: rgba(69, 224, 168, 0.38);
 
-h1, .h1 {
-  font-family: var(--font-mono);
-  font-size:   var(--fs-h1);
-  font-weight: var(--fw-700);
-  line-height: var(--lh-tight);
-  letter-spacing: var(--tracking-flat);
-  color: var(--fg);
+  /* Failure text goes DARKER on a light ground, not lighter. #FF6B6B
+     is a lift for DARK mode (7.11:1 on the ink) and collapses to
+     2.57:1 on #f4f6fb — below AA. #BE123C is the value the drug pages
+     had already arrived at independently in their own light blocks,
+     promoted here so every page inherits it. */
+  --state-fail-text: #BE123C;   /* 5.81:1 on --bg */
 }
-
-h2, .h2 {
-  font-family: var(--font-mono);
-  font-size:   var(--fs-h2);
-  font-weight: var(--fw-700);
-  line-height: var(--lh-snug);
-  color: var(--fg);
-}
-
-h3, .h3 {
-  font-family: var(--font-mono);
-  font-size:   var(--fs-h3);
-  font-weight: var(--fw-600);
-  color: var(--fg);
-}
-
-p {
-  font-family: var(--font-body);
-  font-size:   var(--fs-body);
-  line-height: var(--lh-body);
-  color: var(--fg-muted);
-  max-width: 72ch;
-  text-wrap: pretty;
-}
-
-/* Mono runs — code, badges, section labels, stats */
-code, .mono, kbd, samp {
-  font-family: var(--font-mono);
-  font-size:   var(--fs-sm);
-}
-
-/* Section eyebrow — terra, uppercase, wide tracking */
-.section-label, .eyebrow {
-  font-family: var(--font-mono);
-  font-size:   var(--fs-tag);
-  font-weight: var(--fw-500);
-  letter-spacing: var(--tracking-tag);
-  text-transform: uppercase;
-  color: var(--terra);
-}
-
-/* Stat block — big mono number + tiny tracked label */
-.stat-value {
-  font-family: var(--font-mono);
-  font-size:   2.5rem;
-  font-weight: var(--fw-700);
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
-}
-.stat-label {
-  font-family: var(--font-mono);
-  font-size:   var(--fs-tag);
-  letter-spacing: var(--tracking-label);
-  color: var(--fg-muted);
-  text-transform: uppercase;
-  margin-top: var(--sp-1);
-}
-
-/* Brand wordmark — the ∆S is always gold */
-.brand {
-  font-family: var(--font-mono);
-  font-weight: var(--fw-700);
-  color: var(--teal);
-  letter-spacing: 0.02em;
-}
-.brand .delta { color: var(--gold); }
-.brand .terra { color: var(--terra); }

--- a/site/FlexAIDdS/components.jsx
+++ b/site/FlexAIDdS/components.jsx
@@ -1,4 +1,4 @@
-// FlexAID∆S Website UI Kit — shared primitives.
+// FlexAIDΔS Website UI Kit — shared primitives.
 // Loaded as text/babel; all components export to window for cross-file use.
 
 const { useState, useEffect, useRef } = React;
@@ -14,11 +14,11 @@ function LogoMark({ size = 132, poses = 6, fan = 58, period = 7.2, well = true, 
   return <span ref={ref} className={className} style={{ display: "inline-flex", lineHeight: 0 }} aria-hidden="true" />;
 }
 
-// ─── Brand wordmark with animated ∆S ───
+// ─── Brand wordmark with animated ΔS ───
 function Wordmark({ size = 14 }) {
   return (
-    <span className="word" style={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--teal)", fontSize: size + "px", letterSpacing: "0.02em" }}>
-      FlexAID<span className="kw">∆S</span>
+    <span className="word" style={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--mint)", fontSize: size + "px", letterSpacing: "0.02em" }}>
+      FlexAID<span className="kw">ΔS</span>
     </span>
   );
 }
@@ -71,22 +71,22 @@ function EntropyMeter() {
 
   // Map scroll position to entropy state
   const state =
-    pct < 25 ? { lbl: "UNBOUND", color: "#A78BFA", entropy: (8.5 - pct * 0.05).toFixed(1), dg: "+0.0" } :
-    pct < 70 ? { lbl: "ENCOUNTER", color: "#22D3EE", entropy: (5.4 - (pct - 25) * 0.03).toFixed(1), dg: (-(pct - 25) * 0.1).toFixed(1) } :
-               { lbl: "BOUND", color: "#FBBF24", entropy: (3.2 - (pct - 70) * 0.02).toFixed(1), dg: (-7.0 - (pct - 70) * 0.05).toFixed(1) };
+    pct < 25 ? { lbl: "UNBOUND", color: "#8B5CF6", entropy: (8.5 - pct * 0.05).toFixed(1), dg: "+0.0" } :
+    pct < 70 ? { lbl: "ENCOUNTER", color: "#45E0A8", entropy: (5.4 - (pct - 25) * 0.03).toFixed(1), dg: (-(pct - 25) * 0.1).toFixed(1) } :
+               { lbl: "BOUND", color: "#FF9300", entropy: (3.2 - (pct - 70) * 0.02).toFixed(1), dg: (-7.0 - (pct - 70) * 0.05).toFixed(1) };
 
   return (
     <div className="entropy-meter">
-      <span className="em-vert" style={{ color: "#A78BFA" }}>HIGH ENTROPY</span>
+      <span className="em-vert" style={{ color: "#8B5CF6" }}>HIGH ENTROPY</span>
       <div className="em-bar">
         <div className="em-fill" style={{ height: pct + "%" }} />
         <div className="em-marker" style={{ top: pct + "%", background: state.color, boxShadow: "0 0 10px " + state.color }} />
       </div>
-      <span className="em-vert" style={{ color: "#FBBF24" }}>LOW ENTROPY</span>
+      <span className="em-vert" style={{ color: "#FF9300" }}>LOW ENTROPY</span>
       <div>
         <div className="em-v" style={{ color: state.color }}>{state.entropy}</div>
         <div className="em-u">ΔS bits</div>
-        <div className="em-v" style={{ color: "var(--gold)", marginTop: "4px" }}>{state.dg}</div>
+        <div className="em-v" style={{ color: "var(--tangerine)", marginTop: "4px" }}>{state.dg}</div>
         <div className="em-u">kcal/mol</div>
       </div>
       <div className="em-state" style={{ color: state.color, background: "color-mix(in srgb, " + state.color + " 12%, transparent)", border: "1px solid color-mix(in srgb, " + state.color + " 40%, transparent)" }}>{state.lbl}</div>
@@ -106,7 +106,7 @@ function Nav({ active, onJump }) {
   return (
     <nav className="nav">
       <div className="nav-inner">
-        <button type="button" className="nav-brand" onClick={() => jump("hero")} aria-label="FlexAID∆S home">
+        <button type="button" className="nav-brand" onClick={() => jump("hero")} aria-label="FlexAIDΔS home">
           <LogoMark size={26} poses={4} fan={54} period={6} well={false} />
           <Wordmark size={14} />
         </button>
@@ -170,7 +170,7 @@ function ParticleCanvas() {
     const reduce = window.matchMedia("(prefers-reduced-motion: reduce)");
     if (reduce.matches) return;
     const ctx = c.getContext("2d");
-    const palette = ["#22D3EE", "#A78BFA", "#FBBF24"];
+    const palette = ["#45E0A8", "#8B5CF6", "#FF9300"];
     let particles = [];
     let raf = 0;
     let running = true;

--- a/site/FlexAIDdS/index.html
+++ b/site/FlexAIDdS/index.html
@@ -3,25 +3,26 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>FlexAID∆S — Entropy-Driven Molecular Docking · Le Bonhomme Pharma</title>
-  <meta name="description" content="FlexAID∆S — entropy-driven molecular docking engine. Genetic algorithms meet statistical mechanics for real-world drug discovery. Benchmarking not closed — unverified / pending receipt.">
-  <meta name="theme-color" content="#0a0e14">
+  <title>FlexAIDΔS — Entropy-Driven Molecular Docking · Le Bonhomme Pharma</title>
+  <meta name="description" content="FlexAIDΔS — entropy-driven molecular docking engine. Genetic algorithms meet statistical mechanics for real-world drug discovery. Benchmarking not closed — unverified / pending receipt.">
+  <meta name="theme-color" content="#08091A">
   <meta name="color-scheme" content="dark light">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="canonical" href="https://thebonhomme.com/FlexAIDdS/">
 
-  <meta property="og:title" content="FlexAID∆S — Entropy-Driven Molecular Docking Engine">
+  <meta property="og:title" content="FlexAIDΔS — Entropy-Driven Molecular Docking Engine">
   <meta property="og:description" content="Genetic algorithms meet statistical mechanics for real-world drug discovery. Unverified / pending receipt — publishes no validated success rate.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://thebonhomme.com/FlexAIDdS/">
-  <meta property="og:site_name" content="FlexAID∆S">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:site_name" content="FlexAIDΔS">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@BonhommePharma">
-  <meta name="twitter:title" content="FlexAID∆S — Entropy-Driven Molecular Docking Engine">
+  <meta name="twitter:title" content="FlexAIDΔS — Entropy-Driven Molecular Docking Engine">
   <meta name="twitter:description" content="Genetic algorithms meet statistical mechanics for real-world drug discovery.">
 
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230a0e14'/%3E%3Ctext x='16' y='22' text-anchor='middle' font-family='ui-monospace,monospace' font-size='18' font-weight='700' fill='%23FBBF24'%3E∆%3C/text%3E%3C/svg%3E">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon-flexaid-ds.svg">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -50,16 +51,16 @@
   <span id="last-updated" hidden>2026-08-15</span>
   <span id="latest-release" hidden>v2.2.0</span>
 
-  <template id="__bundler_thumbnail" data-bg-color="#0a0e14">
+  <template id="__bundler_thumbnail" data-bg-color="#08091A">
     <svg viewBox="0 0 1200 800" xmlns="http://www.w3.org/2000/svg">
-      <rect width="1200" height="800" fill="#0a0e14"/>
-      <g fill="none" stroke="#22D3EE" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+      <rect width="1200" height="800" fill="#08091A"/>
+      <g fill="none" stroke="#45E0A8" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
         <path d="M520 520 L600 360 L680 520"/>
       </g>
-      <g fill="#A78BFA" opacity="0.5">
+      <g fill="#8B5CF6" opacity="0.5">
         <circle cx="600" cy="356" r="13"/><circle cx="516" cy="524" r="13"/><circle cx="684" cy="524" r="13"/>
       </g>
-      <text x="600" y="650" font-family="ui-monospace, Menlo, monospace" font-size="74" font-weight="700" fill="#e6edf3" text-anchor="middle">FlexAID<tspan fill="#FBBF24">∆S</tspan></text>
+      <text x="600" y="650" font-family="ui-monospace, Menlo, monospace" font-size="74" font-weight="700" fill="#E4E3F5" text-anchor="middle">FlexAID<tspan fill="#FF9300">ΔS</tspan></text>
     </svg>
   </template>
 

--- a/site/FlexAIDdS/interaction.css
+++ b/site/FlexAIDdS/interaction.css
@@ -6,17 +6,17 @@
    (bundled pages inline this same text, and style.css @imports it).
 
    Interaction colours are pinned to the triad here rather than to each
-   page's local --teal/--violet/--gold, because a few pages carry an older
-   palette (e.g. /entropy-driven/ has --teal:#20808D). Pinning is what makes
+   page's local --mint/--violet/--tangerine, because a few pages carry an older
+   palette (e.g. /entropy-driven/ has --mint:#20808D). Pinning is what makes
    the highlight identical everywhere. Resting colours are untouched.
 
-   Dark-first. Triad only: teal #22D3EE, violet #A78BFA, gold #FBBF24.
+   Dark-first. Triad only: teal #45E0A8, violet #8B5CF6, gold #FF9300.
    ========================================================================== */
 
 :root {
-  --ix-teal: #22D3EE;
-  --ix-violet: #A78BFA;
-  --ix-gold: #FBBF24;
+  --ix-teal: #45E0A8;
+  --ix-violet: #8B5CF6;
+  --ix-gold: #FF9300;
   --ix-ease: cubic-bezier(.16, 1, .3, 1);
 }
 
@@ -61,7 +61,7 @@ button,
 [data-ix-btn-secondary] {
   border-width: 1.5px;
   background: transparent;
-  color: var(--text, #d4dced);
+  color: var(--text, #E4E3F5);
 }
 
 .btn-secondary:hover,
@@ -157,7 +157,7 @@ button:active,
 /* Container-ish anchors (cards, buttons, chrome) are excluded so a card's
    whole body doesn't recolour on hover. */
 a:hover:not(.btn):not(.btn-primary):not(.btn-secondary):not(.btn-outline):not(.card):not(.feature-card):not(.eco-card):not(.module-card):not(.mech-card):not(.audit-card):not(.drug-card):not(.drug-card-featured):not(.nav-gh):not(.gh-link):not(.nav-back):not(.footer-back):not([data-ix-btn]):not([data-ix-btn-secondary]):not([data-ix-card]):not([data-ix-chrome]):not([data-ix-accent]) {
-  color: #22D3EE;
+  color: #45E0A8;
   filter: brightness(1.15);
   text-decoration: none;
 }
@@ -165,7 +165,7 @@ a:hover:not(.btn):not(.btn-primary):not(.btn-secondary):not(.btn-outline):not(.c
 /* CV / résumé resting colours are inline, so the hover has to outrank them. */
 .doc-page a:hover,
 [data-ix-doc] a:hover {
-  color: #22D3EE !important;
+  color: #45E0A8 !important;
 }
 
 /* --- 8. Keyboard focus -------------------------------------------------- */

--- a/site/FlexAIDdS/sections.jsx
+++ b/site/FlexAIDdS/sections.jsx
@@ -1,4 +1,4 @@
-// FlexAID∆S Website UI Kit — page-level sections.
+// FlexAIDΔS Website UI Kit — page-level sections.
 // Composes primitives from components.jsx into the actual marketing page.
 
 const { useState: useStateS, useEffect: useEffectS } = React;
@@ -20,7 +20,7 @@ function HeroSection() {
         </div>
 
         <h1 className="hero-title">
-          FlexAID<span className="gold">∆S</span>
+          FlexAID<span className="gold">ΔS</span>
         </h1>
 
         <p className="hero-subtitle">
@@ -32,25 +32,25 @@ function HeroSection() {
 
         <div className="equation">
           <p className="equation-text">
-            <span style={{ color: "#FBBF24" }}>ΔG</span>
-            <span style={{ color: "#8a93a8" }}> = </span>
-            <span style={{ color: "#22D3EE" }}>ΔH</span>
-            <span style={{ color: "#8a93a8" }}> − </span>
-            <span style={{ color: "#A78BFA" }}>TΔS</span>
+            <span style={{ color: "#FF9300" }}>ΔG</span>
+            <span style={{ color: "#8D8CB0" }}> = </span>
+            <span style={{ color: "#45E0A8" }}>ΔH</span>
+            <span style={{ color: "#8D8CB0" }}> − </span>
+            <span style={{ color: "#8B5CF6" }}>TΔS</span>
           </p>
         </div>
 
         <div className="hero-stats">
           <div className="hero-stat">
-            <div className="hero-stat-value" style={{ color: "#22D3EE" }}>—</div>
+            <div className="hero-stat-value" style={{ color: "#45E0A8" }}>—</div>
             <div className="hero-stat-label">PEARSON r (ITC-187) · unverified</div>
           </div>
           <div className="hero-stat">
-            <div className="hero-stat-value" style={{ color: "#A78BFA" }}>—</div>
+            <div className="hero-stat-value" style={{ color: "#8B5CF6" }}>—</div>
             <div className="hero-stat-label">RMSE kcal/mol · pending receipt</div>
           </div>
           <div className="hero-stat">
-            <div className="hero-stat-value" style={{ color: "#FBBF24" }}>—</div>
+            <div className="hero-stat-value" style={{ color: "#FF9300" }}>—</div>
             <div className="hero-stat-label">BINDING MODE · benchmarking not closed</div>
           </div>
         </div>
@@ -89,11 +89,11 @@ function WhySection() {
   return (
     <section id="why" className="section">
       <div className="container">
-        <SectionHeader eyebrow="why flexaid∆s">
-          Why <span className="gradient-tg">FlexAID∆S</span>
+        <SectionHeader eyebrow="why flexaidΔs">
+          Why <span className="gradient-tg">FlexAIDΔS</span>
         </SectionHeader>
         <div className="note-callout">
-          Most <span className="kw">docking engines</span> optimize <span className="kw">enthalpy</span> alone. <strong>FlexAID∆S</strong> adds <span className="kw">conformational entropy</span> via a full <span className="kw">statistical mechanics framework</span>. Pose-recovery and affinity rates are <strong>unverified / pending receipt</strong> until benchmarking is closed.
+          Most <span className="kw">docking engines</span> optimize <span className="kw">enthalpy</span> alone. <strong>FlexAIDΔS</strong> adds <span className="kw">conformational entropy</span> via a full <span className="kw">statistical mechanics framework</span>. Pose-recovery and affinity rates are <strong>unverified / pending receipt</strong> until benchmarking is closed.
         </div>
       </div>
     </section>
@@ -176,17 +176,17 @@ function BindingSection() {
     },
     {
       lbl: "Encounter",
-      color: "#22D3EE",
-      bg: "rgba(34,211,238,0.05)",
-      border: "rgba(34,211,238,0.3)",
+      color: "#45E0A8",
+      bg: "rgba(69,224,168,0.05)",
+      border: "rgba(69,224,168,0.3)",
       desc: <>The ligand <span className="kw">electrostatically encounters</span> the binding pocket. Translational entropy begins to drop as orientation locks.</>,
       ds: "+4.2", dh: "−3.1", dg: "+1.1",
     },
     {
       lbl: "Binding",
-      color: "#FBBF24",
-      bg: "rgba(251,191,36,0.05)",
-      border: "rgba(251,191,36,0.3)",
+      color: "#FF9300",
+      bg: "rgba(255,147,0,0.05)",
+      border: "rgba(255,147,0,0.3)",
       desc: <><span className="kw">Configurational entropy collapses</span> as the ligand locks into the bound pose. Enthalpic interactions dominate ΔG.</>,
       ds: "−5.4", dh: "−12.8", dg: "−7.4",
     },
@@ -223,8 +223,8 @@ function BindingSection() {
           <p style={{ fontSize: "13px", color: "var(--fg-muted)", lineHeight: 1.6 }}>{p.desc}</p>
           <div className="thermo-row">
             <div><span style={{ color: "var(--fg-muted)" }}>ΔS = </span><span style={{ color: "#EC4899" }}>{p.ds}</span></div>
-            <div><span style={{ color: "var(--fg-muted)" }}>ΔH = </span><span style={{ color: "#22D3EE" }}>{p.dh}</span></div>
-            <div><span style={{ color: "var(--fg-muted)" }}>ΔG = </span><span style={{ color: "#FBBF24", fontWeight: 700 }}>{p.dg}</span></div>
+            <div><span style={{ color: "var(--fg-muted)" }}>ΔH = </span><span style={{ color: "#45E0A8" }}>{p.dh}</span></div>
+            <div><span style={{ color: "var(--fg-muted)" }}>ΔG = </span><span style={{ color: "#FF9300", fontWeight: 700 }}>{p.dg}</span></div>
           </div>
         </div>
       </div>
@@ -244,23 +244,23 @@ function BindingDiagram({ phase }) {
     <svg viewBox="0 0 960 240" style={{ display: "block", width: "100%", height: "240px" }}>
       <defs>
         <radialGradient id="pocket-glow" cx="50%" cy="50%">
-          <stop offset="0%" stopColor="#22D3EE" stopOpacity="0.18"/>
-          <stop offset="100%" stopColor="#22D3EE" stopOpacity="0"/>
+          <stop offset="0%" stopColor="#45E0A8" stopOpacity="0.18"/>
+          <stop offset="100%" stopColor="#45E0A8" stopOpacity="0"/>
         </radialGradient>
       </defs>
       {/* Binding pocket */}
-      <ellipse cx="450" cy="140" rx="90" ry="40" fill="url(#pocket-glow)" stroke="#22D3EE" strokeOpacity="0.3" strokeWidth="1" strokeDasharray="3 3"/>
+      <ellipse cx="450" cy="140" rx="90" ry="40" fill="url(#pocket-glow)" stroke="#45E0A8" strokeOpacity="0.3" strokeWidth="1" strokeDasharray="3 3"/>
       {/* Trajectory trail */}
       {phase >= 1 && (
         <path d={phase === 1
           ? "M 220 130 Q 290 100 330 140 Q 380 170 430 130 Q 480 120 520 145"
           : "M 220 130 Q 290 100 330 140 Q 380 170 430 130 Q 460 130 450 140"}
-              fill="none" stroke="#FBBF24" strokeWidth="1" strokeOpacity="0.45" strokeDasharray="2 4"/>
+              fill="none" stroke="#FF9300" strokeWidth="1" strokeOpacity="0.45" strokeDasharray="2 4"/>
       )}
       {/* Ligand positions */}
       {positions.map((p, i) => {
         const isLast = i === positions.length - 1;
-        const c = phase === 0 ? "#EC4899" : phase === 1 ? "#22D3EE" : "#FBBF24";
+        const c = phase === 0 ? "#EC4899" : phase === 1 ? "#45E0A8" : "#FF9300";
         return (
           <g key={i} opacity={isLast ? 1 : 0.5}>
             <circle cx={p.x} cy={p.y} r={p.r} fill={c} fillOpacity={isLast ? 0.18 : 0.10}/>
@@ -350,9 +350,9 @@ function RepoStatsSection() {
           Repository <span className="t-gold">Stats</span>
         </SectionHeader>
         <div className="stats-row">
-          <div className={"stat-item" + (commits >= 1500 ? " stat-item--milestone" : "")}>
-            {commits >= 1500 && <span className="stat-milestone-badge">1,500th commit</span>}
-            <div className={"stat-value" + (commits >= 1500 ? " stat-value--milestone" : "")} id="stat-commits-display">{commits.toLocaleString()}</div>
+          <div className={"stat-item" + (commits >= 2000 ? " stat-item--milestone" : "")}>
+            {commits >= 2000 && <span className="stat-milestone-badge">2,000th commit 🎉</span>}
+            <div className={"stat-value" + (commits >= 2000 ? " stat-value--milestone" : "")} id="stat-commits-display">{commits.toLocaleString()}</div>
             <div className="stat-label">Commits</div>
           </div>
           <div className="stat-item"><div className="stat-value">C++26</div><div className="stat-label">Standard</div></div>
@@ -536,7 +536,7 @@ function BenchmarksSection() {
           Benchmark <span className="t-gold">status</span>
         </SectionHeader>
         <p className="binding-blurb">
-          This site publishes <span className="kw">no validated FlexAID∆S success rate</span>. Benchmarks are still rolling — do not cite a former rate at or above 90%. Astex-85, ITC-187, CASF, and CNS figures are <span className="kw">unverified / pending receipt</span> until a METHODOLOGY.md §0 receipted blind campaign exists. Literature comparators (JCIM 2015 Table 2 top-1 45.2% / top-10 66.7%) are someone else’s published numbers, not ours.
+          This site publishes <span className="kw">no validated FlexAIDΔS success rate</span>. Benchmarks are still rolling — do not cite a former rate at or above 90%. Astex-85, ITC-187, CASF, and CNS figures are <span className="kw">unverified / pending receipt</span> until a METHODOLOGY.md §0 receipted blind campaign exists. Literature comparators quoted elsewhere in this project are someone else’s published numbers, not ours.
         </p>
       </div>
     </section>

--- a/site/FlexAIDdS/styles.css
+++ b/site/FlexAIDdS/styles.css
@@ -17,7 +17,7 @@ html {
 }
 .skip-link:focus {
   position: fixed; left: 12px; top: 12px; z-index: 100; width: auto; height: auto;
-  padding: 8px 14px; background: var(--teal); color: #0a0e14;
+  padding: 8px 14px; background: var(--mint); color: #08091A;
   font-family: var(--font-mono); font-size: 12px; border-radius: 6px;
 }
 
@@ -41,8 +41,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 
 ::-webkit-scrollbar { width: 6px; }
 ::-webkit-scrollbar-track { background: var(--bg); }
-::-webkit-scrollbar-thumb { background: var(--teal-15); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--teal); }
+::-webkit-scrollbar-thumb { background: var(--mint-15); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--mint); }
 
 .container { max-width: 1152px; margin: 0 auto; padding: 0 1.5rem; }
 
@@ -51,7 +51,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   position: fixed; top: 0; left: 0; right: 0; z-index: 50;
   background: var(--bg-panel);
   backdrop-filter: blur(24px); -webkit-backdrop-filter: blur(24px);
-  border-bottom: 1px solid var(--teal-12);
+  border-bottom: 1px solid var(--mint-12);
   padding-top: env(safe-area-inset-top);
 }
 [data-theme="light"] .nav {
@@ -69,9 +69,9 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 .nav-brand img { width: 26px; height: 26px; }
 .nav-brand .word {
   font-family: var(--font-mono); font-weight: 700;
-  color: var(--teal); font-size: 14px; letter-spacing: 0.02em;
+  color: var(--mint); font-size: 14px; letter-spacing: 0.02em;
 }
-.nav-brand .word .delta { color: var(--gold); }
+.nav-brand .word .delta { color: var(--tangerine); }
 .nav-links { display: none; align-items: center; gap: 14px; }
 @media (min-width: 900px) { .nav-links { display: flex; } }
 .nav-link, .nav-links button.nav-link {
@@ -79,15 +79,15 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   color: var(--fg-muted); transition: color 0.2s;
   background: none; border: none; padding: 0; cursor: pointer;
 }
-.nav-link:hover, .nav-links button.nav-link:hover, .nav-link.active { color: var(--teal); }
+.nav-link:hover, .nav-links button.nav-link:hover, .nav-link.active { color: var(--mint); }
 .nav-links .gh { display: flex; align-items: center; color: var(--fg-muted); }
-.nav-links .gh:hover { color: var(--teal); }
+.nav-links .gh:hover { color: var(--mint); }
 
 .nav-mobile-btn {
   display: flex; align-items: center; justify-content: center;
   width: 44px; height: 44px; min-width: 44px; min-height: 44px;
   border-radius: 8px;
-  border: 1px solid var(--teal-15); background: var(--bg-card);
+  border: 1px solid var(--mint-15); background: var(--bg-card);
   color: var(--fg-muted); cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
@@ -96,7 +96,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 .nav-mobile-menu {
   display: none; flex-direction: column; gap: 4px;
   padding: 0.75rem 1.5rem 1rem;
-  border-bottom: 1px solid var(--teal-12);
+  border-bottom: 1px solid var(--mint-12);
   background: var(--bg-panel);
 }
 .nav-mobile-menu.open { display: flex; }
@@ -113,7 +113,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 }
 .nav-mobile-menu a:hover,
 .nav-mobile-menu button:hover,
-.nav-mobile-menu .active { color: var(--teal); background: var(--teal-06); }
+.nav-mobile-menu .active { color: var(--mint); background: var(--mint-06); }
 
 /* ───── HERO ───── */
 .hero {
@@ -130,8 +130,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 .hero-scrim {
   position: absolute; inset: 0; z-index: 2; pointer-events: none;
   background:
-    radial-gradient(ellipse 80% 60% at 50% 45%, rgba(10,14,20,0.35) 0%, rgba(10,14,20,0.82) 70%),
-    linear-gradient(180deg, rgba(10,14,20,0.55) 0%, rgba(10,14,20,0.25) 40%, rgba(10,14,20,0.88) 100%);
+    radial-gradient(ellipse 80% 60% at 50% 45%, rgba(8,9,26,0.35) 0%, rgba(8,9,26,0.82) 70%),
+    linear-gradient(180deg, rgba(8,9,26,0.55) 0%, rgba(8,9,26,0.25) 40%, rgba(8,9,26,0.88) 100%);
 }
 [data-theme="light"] .hero-scrim {
   background:
@@ -140,7 +140,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 }
 #molstar-viewer {
   position: absolute; inset: 0; width: 100%; height: 100%;
-  min-height: 320px; background: #0a0e14;
+  min-height: 320px; background: #08091A;
   opacity: 0.58; filter: saturate(1.08) contrast(1.08);
   -webkit-transform: translateZ(0); transform: translateZ(0);
 }
@@ -164,7 +164,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 }
 .hero-tagline-top {
   font-family: var(--font-mono); font-size: 10px;
-  letter-spacing: 0.30em; text-transform: uppercase; color: var(--terra);
+  letter-spacing: 0.30em; text-transform: uppercase; color: var(--violet);
   margin-bottom: 1.5rem;
 }
 .hero-title {
@@ -173,7 +173,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   font-weight: 700; line-height: 1.05; letter-spacing: 0;
 }
 .hero-title .gold {
-  background: linear-gradient(135deg, var(--gold), #FDE68A);
+  background: linear-gradient(135deg, var(--tangerine), #FFC773);
   -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
 }
 .hero-subtitle {
@@ -194,8 +194,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   letter-spacing: 0.02em;
 }
 @keyframes breathe {
-  0%,100% { opacity: 0.85; transform: scale(1); text-shadow: 0 0 20px rgba(34,211,238,0.2); }
-  50%     { opacity: 1; transform: scale(1.03); text-shadow: 0 0 40px rgba(34,211,238,0.4), 0 0 60px rgba(251,191,36,0.2); }
+  0%,100% { opacity: 0.85; transform: scale(1); text-shadow: 0 0 20px rgba(69,224,168,0.2); }
+  50%     { opacity: 1; transform: scale(1.03); text-shadow: 0 0 40px rgba(69,224,168,0.4), 0 0 60px rgba(255,147,0,0.2); }
 }
 
 /* Stats */
@@ -214,29 +214,29 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 }
 .badge {
   font-family: var(--font-mono); font-size: 10px; padding: 4px 12px;
-  border-radius: 3px; border: 1px solid var(--teal-20);
-  background: var(--teal-06); color: var(--teal); white-space: nowrap;
+  border-radius: 3px; border: 1px solid var(--mint-20);
+  background: var(--mint-06); color: var(--mint); white-space: nowrap;
 }
-.badge.terra { border-color: rgba(167,139,250,0.46); background: var(--terra-10); color: var(--terra); }
-.badge.gold  { border-color: rgba(251,191,36,0.46); background: var(--gold-10); color: var(--gold); }
-.badge.ga    { border-color: rgba(58,166,179,0.46); background: rgba(58,166,179,0.10); color: #67E8F9; }
+.badge.terra { border-color: rgba(139,92,246,0.46); background: var(--violet-10); color: var(--violet); }
+.badge.gold  { border-color: rgba(255,147,0,0.46); background: var(--tangerine-10); color: var(--tangerine); }
+.badge.ga    { border-color: rgba(58,166,179,0.46); background: rgba(58,166,179,0.10); color: #8EEFC9; }
 .badge.cuda  { border-color: rgba(118,185,0,0.46);  background: rgba(118,185,0,0.10);  color: #9AE635; }
 .badge.metal { border-color: rgba(90,200,250,0.46); background: rgba(90,200,250,0.10); color: #7DD3FC; }
 .badge.rocm  { border-color: rgba(237,28,36,0.46);  background: rgba(237,28,36,0.10);  color: #F87171; }
-.badge.avx   { border-color: rgba(34,211,238,0.46); background: rgba(34,211,238,0.10); color: #22D3EE; }
+.badge.avx   { border-color: rgba(69,224,168,0.46); background: rgba(69,224,168,0.10); color: #45E0A8; }
 
 /* Drug of the Day as a hero badge (same row as C++26, CUDA, etc.) */
 .badge.drug {
-  border-color: rgba(251,191,36,0.55);
-  background: rgba(251,191,36,0.12);
-  color: #FBBF24;
+  border-color: rgba(255,147,0,0.55);
+  background: rgba(255,147,0,0.12);
+  color: #FF9300;
   font-weight: 600;
   text-decoration: none;
 }
 .badge.drug:hover {
-  border-color: #FBBF24;
-  background: rgba(251,191,36,0.18);
-  color: #FDE68A;
+  border-color: #FF9300;
+  background: rgba(255,147,0,0.18);
+  color: #FFC773;
 }
 .badge.drug .drug-series {
   font-size: 9px;
@@ -259,57 +259,57 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
               color 0.18s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .btn:active { transform: scale(0.97); }
-.btn-primary { background: var(--teal); color: #0a0e14; box-shadow: 0 0 18px rgba(34,211,238,0.3); }
-.btn-primary:hover { background: #2a9aa8; box-shadow: 0 0 24px rgba(34,211,238,0.5); transform: translateY(-1px); }
+.btn-primary { background: var(--mint); color: #08091A; box-shadow: 0 0 18px rgba(69,224,168,0.3); }
+.btn-primary:hover { filter: brightness(1.06); box-shadow: 0 0 24px color-mix(in srgb, #8B5CF6 50%, transparent); transform: translateY(-1px); }
 .btn-primary:active { transform: scale(0.97); }
-.btn-outline { background: transparent; color: var(--fg); border: 1px solid var(--teal-20); }
-.btn-outline:hover { border-color: var(--teal); color: var(--teal); transform: translateY(-1px); }
+.btn-outline { background: transparent; color: var(--fg); border: 1px solid var(--mint-20); }
+.btn-outline:hover { border-color: var(--mint); color: var(--mint); transform: translateY(-1px); }
 
 /* ───── KEYWORD SPECTRUM ───── */
 .kw {
   font-weight: 700;
-  background-image: linear-gradient(90deg, #A78BFA, #FBBF24, #22D3EE, #A78BFA);
+  background-image: linear-gradient(90deg, #8B5CF6, #FF9300, #45E0A8, #8B5CF6);
   background-size: 260% 100%;
   background-position: 0% 50%;
   background-clip: text; -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-  filter: drop-shadow(0 0 5px rgba(251,191,36,0.32));
+  filter: drop-shadow(0 0 5px rgba(255,147,0,0.32));
   animation: kwflow 8.5s linear infinite, kwglow 6.5s ease-in-out infinite;
 }
 @keyframes kwflow { from { background-position: 0% 50%; } to { background-position: 260% 50%; } }
 @keyframes kwglow {
-  0%,100% { filter: drop-shadow(0 0 4px rgba(251,191,36,0.30)); }
-  50% { filter: drop-shadow(0 0 9px rgba(251,191,36,0.30)); }
+  0%,100% { filter: drop-shadow(0 0 4px rgba(255,147,0,0.30)); }
+  50% { filter: drop-shadow(0 0 9px rgba(255,147,0,0.30)); }
 }
 
 /* ───── SECTION ───── */
 .section { padding: 5rem 0; }
 .section.alt { background: var(--bg-alt); }
 [data-theme="light"] .section.alt { background: rgba(0,0,0,0.03); }
-.section-divider { height: 1px; background: linear-gradient(to right, transparent, rgba(34,211,238,0.2), transparent); }
+.section-divider { height: 1px; background: linear-gradient(to right, transparent, rgba(69,224,168,0.2), transparent); }
 .section-label {
   font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.20em;
-  text-transform: uppercase; color: var(--terra); margin-bottom: 12px;
+  text-transform: uppercase; color: var(--violet); margin-bottom: 12px;
 }
 .section-h2 {
   font-family: var(--font-mono); font-size: 1.75rem; font-weight: 700;
   margin-bottom: 1.5rem;
 }
 .gradient-tg {
-  background: linear-gradient(135deg, #22D3EE, #FBBF24);
+  background: linear-gradient(135deg, #45E0A8, #FF9300);
   -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
 }
 .gradient-rg {
-  background: linear-gradient(135deg, #A78BFA, #FBBF24);
+  background: linear-gradient(135deg, #8B5CF6, #FF9300);
   -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
 }
 
 /* Note callout */
 .note-callout {
-  background: var(--gold-06); border-left: 3px solid var(--gold);
+  background: var(--tangerine-06); border-left: 3px solid var(--tangerine);
   padding: 14px 18px; border-radius: 0 8px 8px 0;
   font-size: 0.95rem; line-height: 1.7; color: var(--fg);
 }
-.note-callout strong { color: var(--gold); font-weight: 600; }
+.note-callout strong { color: var(--tangerine); font-weight: 600; }
 
 /* Feature grid */
 .features-grid {
@@ -320,30 +320,30 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   padding: 1.25rem; border-radius: 8px; background: var(--bg-card);
   transition: all 0.25s ease; border: 1px solid;
 }
-.feature-card.teal-card  { border-color: var(--teal-15); }
-.feature-card.terra-card { border-color: var(--terra-12); }
-.feature-card.gold-card  { border-color: var(--gold-12); }
+.feature-card.teal-card  { border-color: var(--mint-15); }
+.feature-card.terra-card { border-color: var(--violet-12); }
+.feature-card.gold-card  { border-color: var(--tangerine-12); }
 .feature-card:hover { transform: translateY(-4px); }
-.feature-card.teal-card:hover  { border-color: rgba(34,211,238,0.4); box-shadow: 0 0 20px rgba(34,211,238,0.10); }
-.feature-card.terra-card:hover { border-color: var(--terra-35);      box-shadow: 0 0 20px rgba(167,139,250,0.10); }
-.feature-card.gold-card:hover  { border-color: rgba(251,191,36,0.35); box-shadow: 0 0 20px rgba(251,191,36,0.10); }
+.feature-card.teal-card:hover  { border-color: rgba(69,224,168,0.4); box-shadow: 0 0 20px rgba(69,224,168,0.10); }
+.feature-card.terra-card:hover { border-color: var(--violet-35);      box-shadow: 0 0 20px rgba(139,92,246,0.10); }
+.feature-card.gold-card:hover  { border-color: rgba(255,147,0,0.35); box-shadow: 0 0 20px rgba(255,147,0,0.10); }
 .feature-card h3 { font-family: var(--font-mono); font-size: 14px; font-weight: 600; margin-bottom: 12px; }
-.feature-card.teal-card h3  { color: var(--teal); }
-.feature-card.terra-card h3 { color: var(--terra); }
-.feature-card.gold-card h3  { color: var(--gold); }
+.feature-card.teal-card h3  { color: var(--mint); }
+.feature-card.terra-card h3 { color: var(--violet); }
+.feature-card.gold-card h3  { color: var(--tangerine); }
 .feature-card ul { list-style: none; }
 .feature-card li {
   font-size: 12px; color: var(--fg-muted); line-height: 1.6;
   padding: 4px 0; display: flex; gap: 8px;
 }
-.feature-card li::before { content: '›'; color: rgba(34,211,238,0.45); flex-shrink: 0; }
+.feature-card li::before { content: '›'; color: rgba(69,224,168,0.45); flex-shrink: 0; }
 
 /* Architecture pipeline */
 .arch-pipeline { display: flex; flex-direction: column; gap: 0; margin-bottom: 2rem; }
 @media (min-width: 768px) { .arch-pipeline { flex-direction: row; align-items: stretch; } }
 .arch-step {
   flex: 1; padding: 1.25rem; position: relative;
-  background: var(--bg-card); border: 1px solid var(--teal-08);
+  background: var(--bg-card); border: 1px solid var(--mint-08);
 }
 .arch-step:first-child { border-radius: 8px 8px 0 0; }
 .arch-step:last-child  { border-radius: 0 0 8px 8px; }
@@ -354,7 +354,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 .arch-step-num { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.15em; color: var(--fg-muted); text-transform: uppercase; margin-bottom: 6px; }
 .arch-step-title { font-family: var(--font-mono); font-size: 13px; font-weight: 600; margin-bottom: 4px; }
 .arch-step-desc { font-size: 11px; color: var(--fg-muted); line-height: 1.5; }
-.arch-arrow { position: absolute; color: var(--teal); font-size: 14px; }
+.arch-arrow { position: absolute; color: var(--mint); font-size: 14px; }
 .arch-step .arch-arrow { bottom: -12px; left: 50%; transform: translateX(-50%); }
 @media (min-width: 768px) {
   .arch-step .arch-arrow { bottom: auto; right: -10px; left: auto; top: 50%; transform: translateY(-50%); }
@@ -363,7 +363,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 
 /* Install tabs */
 .install-tabs {
-  display: flex; gap: 0; border-bottom: 1px solid var(--teal-15);
+  display: flex; gap: 0; border-bottom: 1px solid var(--mint-15);
   margin-bottom: 1.5rem;
   overflow-x: auto; -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
@@ -376,34 +376,34 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   transition: all 0.2s; border-bottom: 2px solid transparent;
 }
 .install-tab:hover { color: var(--fg); }
-.install-tab.active { color: var(--teal); border-bottom-color: var(--teal); }
+.install-tab.active { color: var(--mint); border-bottom-color: var(--mint); }
 .code-box {
   font-family: var(--font-mono); font-size: 12px;
-  background: var(--teal-06); border-left: 3px solid var(--teal);
+  background: var(--mint-06); border-left: 3px solid var(--mint);
   padding: 16px 20px; border-radius: 0 8px 8px 0;
   line-height: 1.8; overflow-x: auto;
 }
 .code-box .cmt { color: rgba(138,147,168,0.6); }
-.code-box .cmd { color: var(--teal); }
-.code-box .kw  { color: var(--terra); }
-.code-box .str { color: var(--gold); }
+.code-box .cmd { color: var(--mint); }
+.code-box .kw  { color: var(--violet); }
+.code-box .str { color: var(--tangerine); }
 
 /* Benchmark table */
 .bench-table-wrap { overflow-x: auto; }
 .bench-table { width: 100%; border-collapse: collapse; font-family: var(--font-mono); font-size: 13px; }
 .bench-table th {
   text-align: left; padding: 10px 16px;
-  border-bottom: 1px solid var(--teal-20);
+  border-bottom: 1px solid var(--mint-20);
   color: var(--fg-muted); font-weight: 600; font-size: 11px;
   letter-spacing: 0.08em; text-transform: uppercase;
 }
-.bench-table th.h { color: var(--gold); }
+.bench-table th.h { color: var(--tangerine); }
 .bench-table td {
-  padding: 12px 16px; border-bottom: 1px solid rgba(34,211,238,0.05); color: var(--fg-muted);
+  padding: 12px 16px; border-bottom: 1px solid rgba(69,224,168,0.05); color: var(--fg-muted);
 }
 .bench-table td:first-child { color: var(--fg); font-size: 12px; }
-.bench-table td.h { color: var(--gold); font-weight: 700; text-shadow: 0 0 12px rgba(251,191,36,0.3); }
-.bench-table tr:hover { background: var(--teal-06); }
+.bench-table td.h { color: var(--tangerine); font-weight: 700; text-shadow: 0 0 12px rgba(255,147,0,0.3); }
+.bench-table tr:hover { background: var(--mint-06); }
 
 /* Entropy meter (fixed side widget) */
 .entropy-meter {
@@ -417,11 +417,11 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   transform: rotate(180deg); white-space: nowrap;
 }
 .em-bar { width: 8px; height: 160px; border-radius: 9999px;
-  background: var(--teal-10); border: 1px solid var(--teal-15);
+  background: var(--mint-10); border: 1px solid var(--mint-15);
   overflow: hidden; position: relative; }
 .em-fill { position: absolute; left: 0; right: 0; top: 0; border-radius: 9999px;
   transition: height 0.3s ease-out;
-  background: linear-gradient(to bottom, #A78BFA, #22D3EE, #FBBF24); }
+  background: linear-gradient(to bottom, #8B5CF6, #45E0A8, #FF9300); }
 .em-marker { position: absolute; left: 50%; transform: translateX(-50%);
   width: 12px; height: 2px; border-radius: 9999px;
   transition: top 0.3s ease-out, background 0.3s ease-out, box-shadow 0.3s ease-out; }
@@ -432,20 +432,20 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 
 /* Footer */
 .site-footer {
-  background: rgba(10,14,20,0.9); border-top: 1px solid rgba(34,211,238,0.1);
+  background: rgba(8,9,26,0.9); border-top: 1px solid rgba(69,224,168,0.1);
 }
 .footer-inner { max-width: 1152px; margin: 0 auto; padding: 2rem 1.5rem; }
 .footer-top { display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; }
 .footer-brand { display: flex; align-items: center; gap: 10px; }
-.footer-brand .word { font-family: var(--font-mono); font-weight: 700; color: var(--teal); font-size: 14px; }
-.footer-brand .word .delta { color: var(--gold); }
+.footer-brand .word { font-family: var(--font-mono); font-weight: 700; color: var(--mint); font-size: 14px; }
+.footer-brand .word .delta { color: var(--tangerine); }
 .footer-links { display: flex; gap: 1rem; flex-wrap: wrap; }
 .footer-links a { font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted); transition: color 0.2s; }
-.footer-links a:hover { color: var(--teal); }
-.footer-bottom { margin-top: 1.5rem; padding-top: 1rem; text-align: center; border-top: 1px solid rgba(34,211,238,0.08); }
+.footer-links a:hover { color: var(--mint); }
+.footer-bottom { margin-top: 1.5rem; padding-top: 1rem; text-align: center; border-top: 1px solid rgba(69,224,168,0.08); }
 .footer-cite { font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted); line-height: 1.6; }
 .footer-eq { font-family: var(--font-mono); font-size: 10px; color: var(--fg-muted); margin-top: 6px; }
-.footer-eq .gold { color: var(--gold); }
+.footer-eq .gold { color: var(--tangerine); }
 
 
 /* ─── Architecture sub-cards ─── */
@@ -456,11 +456,11 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 @media (min-width: 640px) { .arch-sub-grid { grid-template-columns: repeat(2, 1fr); } }
 .arch-sub-card {
   padding: 1rem; border-radius: 8px; background: var(--bg-card);
-  border: 1px solid var(--teal-08);
+  border: 1px solid var(--mint-08);
 }
 .arch-sub-card h4 {
   font-family: var(--font-mono); font-size: 12px; font-weight: 600;
-  color: var(--gold); margin-bottom: 6px;
+  color: var(--tangerine); margin-bottom: 6px;
 }
 .arch-sub-card p { font-size: 11px; color: var(--fg-muted); line-height: 1.5; }
 
@@ -470,8 +470,8 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   margin-bottom: 1.5rem; max-width: 640px; line-height: 1.6;
 }
 .binding-canvas-wrap {
-  border-radius: 8px; border: 1px solid var(--teal-20);
-  background: rgba(10,14,20,0.8); overflow: hidden; position: relative;
+  border-radius: 8px; border: 1px solid var(--mint-20);
+  background: rgba(8,9,26,0.8); overflow: hidden; position: relative;
 }
 .binding-controls {
   display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between;
@@ -482,15 +482,15 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   font-family: var(--font-mono); font-size: 12px;
   padding: 8px 14px; border-radius: 8px; cursor: pointer;
   min-height: 44px;
-  background: var(--bg-card); border: 1px solid var(--teal-15);
+  background: var(--bg-card); border: 1px solid var(--mint-15);
   color: var(--fg-muted); transition: all 0.2s;
   -webkit-tap-highlight-color: transparent;
 }
 .binding-phase-btn:active { transform: scale(0.97); }
-.binding-phase-btn:hover { border-color: rgba(34,211,238,0.3); color: var(--fg); }
-.binding-phase-btn.active-diff { background: rgba(167,139,250,0.18); color: var(--terra); border-color: rgba(167,139,250,0.55); }
-.binding-phase-btn.active-enc { background: rgba(34,211,238,0.12); color: var(--teal); border-color: rgba(34,211,238,0.5); }
-.binding-phase-btn.active-bind { background: rgba(251,191,36,0.12); color: var(--gold); border-color: rgba(251,191,36,0.5); }
+.binding-phase-btn:hover { border-color: rgba(69,224,168,0.3); color: var(--fg); }
+.binding-phase-btn.active-diff { background: rgba(139,92,246,0.18); color: var(--violet); border-color: rgba(139,92,246,0.55); }
+.binding-phase-btn.active-enc { background: rgba(69,224,168,0.12); color: var(--mint); border-color: rgba(69,224,168,0.5); }
+.binding-phase-btn.active-bind { background: rgba(255,147,0,0.12); color: var(--tangerine); border-color: rgba(255,147,0,0.5); }
 .binding-desc {
   margin-top: 1rem; padding: 1rem; border-radius: 8px; transition: all 0.5s;
 }
@@ -506,12 +506,12 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 @media (min-width: 640px) { .modules-grid { grid-template-columns: repeat(3, 1fr); } }
 .module-chip {
   padding: 10px 14px; border-radius: 8px; background: var(--bg-card);
-  border: 1px solid var(--teal-08); transition: all 0.2s;
+  border: 1px solid var(--mint-08); transition: all 0.2s;
 }
-.module-chip:hover { border-color: var(--teal-20); transform: translateY(-2px); }
+.module-chip:hover { border-color: var(--mint-20); transform: translateY(-2px); }
 .module-chip .module-name {
   font-family: var(--font-mono); font-size: 12px;
-  font-weight: 600; color: var(--gold); margin-bottom: 2px;
+  font-weight: 600; color: var(--tangerine); margin-bottom: 2px;
 }
 .module-chip .module-desc {
   font-size: 11px; color: var(--fg-muted); line-height: 1.4;
@@ -526,9 +526,9 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 .stat-item--milestone {
   padding: 1rem 1.25rem;
   border-radius: 12px;
-  border: 1px solid rgba(251,191,36,0.45);
-  background: linear-gradient(135deg, rgba(251,191,36,0.10) 0%, rgba(34,211,238,0.06) 100%);
-  box-shadow: 0 0 28px rgba(251,191,36,0.14);
+  border: 1px solid rgba(255,147,0,0.45);
+  background: linear-gradient(135deg, rgba(255,147,0,0.10) 0%, rgba(69,224,168,0.06) 100%);
+  box-shadow: 0 0 28px rgba(255,147,0,0.14);
 }
 .stat-milestone-badge {
   display: inline-block;
@@ -536,19 +536,19 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   font-size: 9px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--gold);
-  background: rgba(251,191,36,0.14);
-  border: 1px solid rgba(251,191,36,0.38);
+  color: var(--tangerine);
+  background: rgba(255,147,0,0.14);
+  border: 1px solid rgba(255,147,0,0.38);
   border-radius: 10px;
   padding: 2px 8px;
   margin-bottom: 6px;
 }
 .stat-item .stat-value {
   font-family: var(--font-mono); font-size: 1.75rem;
-  font-weight: 700; color: var(--teal);
+  font-weight: 700; color: var(--mint);
 }
 .stat-item .stat-value--milestone {
-  background: linear-gradient(135deg, #FBBF24 0%, #22D3EE 100%);
+  background: linear-gradient(135deg, #FF9300 0%, #45E0A8 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -581,17 +581,17 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 }
 .cmake-table th {
   text-align: left; padding: 8px 12px;
-  border-bottom: 1px solid var(--teal-15);
-  color: var(--teal); font-weight: 600;
+  border-bottom: 1px solid var(--mint-15);
+  color: var(--mint); font-weight: 600;
 }
 .cmake-table td {
   padding: 8px 12px;
-  border-bottom: 1px solid rgba(34,211,238,0.05);
+  border-bottom: 1px solid rgba(69,224,168,0.05);
   color: var(--fg-muted);
 }
-.cmake-table td:first-child { color: var(--gold); }
+.cmake-table td:first-child { color: var(--tangerine); }
 .cmake-table td code {
-  background: var(--teal-06); padding: 2px 6px; border-radius: 3px;
+  background: var(--mint-06); padding: 2px 6px; border-radius: 3px;
   font-size: 11px;
 }
 
@@ -601,9 +601,9 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 /* ─── Teaser / Explore Cards (for /flexaid and /periodic) ─── */
 .explore-section {
   padding: 3.5rem 0 4rem;
-  background: linear-gradient(180deg, rgba(16,20,28,0.4) 0%, rgba(10,14,20,0.0) 100%);
-  border-top: 1px solid var(--teal-08);
-  border-bottom: 1px solid var(--teal-08);
+  background: linear-gradient(180deg, rgba(17,18,38,0.4) 0%, rgba(8,9,26,0.0) 100%);
+  border-top: 1px solid var(--mint-08);
+  border-bottom: 1px solid var(--mint-08);
 }
 
 .teaser-grid {
@@ -623,7 +623,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   display: block;
   padding: 1.25rem 1.5rem;
   background: var(--bg-card);
-  border: 1px solid var(--teal-10);
+  border: 1px solid var(--mint-10);
   border-radius: 10px;
   text-decoration: none;
   color: inherit;
@@ -634,7 +634,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
 
 .teaser-card:hover {
   transform: translateY(-2px);
-  border-color: var(--teal);
+  border-color: var(--mint);
   box-shadow: 0 10px 30px -10px rgba(0,0,0,0.4);
 }
 
@@ -657,7 +657,7 @@ button { font: inherit; color: inherit; background: none; border: none; cursor: 
   font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.05em;
-  color: var(--teal);
+  color: var(--mint);
   display: inline-flex;
   align-items: center;
   gap: 4px;

--- a/site/FlexAIDdS/theme.css
+++ b/site/FlexAIDdS/theme.css
@@ -30,7 +30,7 @@
 /* ── Canonical pill toggle ──────────────────────────────────── */
 .lbp-theme-toggle {
   /* Accent resolves to whatever the host page calls its accent. */
-  --lbp-accent: var(--color-accent, var(--teal, var(--neon-b, #22D3EE)));
+  --lbp-accent: var(--color-accent, var(--mint, var(--neon-b, #45E0A8)));
   appearance: none;
   -webkit-appearance: none;
   border: 0;
@@ -47,7 +47,7 @@
 }
 .lbp-theme-toggle:focus-visible {
   /* canonical focus ring — see interaction.css */
-  outline: 2px solid #22D3EE;
+  outline: 2px solid #45E0A8;
   outline-offset: 2px;
 }
 
@@ -92,7 +92,7 @@
   background: linear-gradient(145deg, #ffffff, #ffe39a);
   box-shadow:
     0 2px 6px rgba(146, 100, 0, 0.35),
-    0 0 12px rgba(251, 191, 36, 0.65),
+    0 0 12px rgba(255, 147, 0, 0.65),
     inset 0 0 0 1px rgba(255, 255, 255, 0.7);
 }
 
@@ -106,7 +106,7 @@
 [data-theme="light"] .lbp-theme-toggle:hover .lbp-theme-toggle__thumb {
   box-shadow:
     0 2px 8px rgba(146, 100, 0, 0.4),
-    0 0 16px rgba(251, 191, 36, 0.85),
+    0 0 16px rgba(255, 147, 0, 0.85),
     inset 0 0 0 1px rgba(255, 255, 255, 0.8);
 }
 .lbp-theme-toggle:active .lbp-theme-toggle__thumb {

--- a/tests/test_check_published_astex_rates.py
+++ b/tests/test_check_published_astex_rates.py
@@ -65,6 +65,9 @@ QUALIFIER_RE = re.compile(
 
 WINDOW_RADIUS = 3
 
+# Product name is spelled with U+0394 on migrated surfaces and U+2206 elsewhere.
+_DISCLAIMER_RE = re.compile(r"no validated FlexAID[\u0394\u2206]S success rate")
+
 
 def _window(lines: list[str], index: int, radius: int = WINDOW_RADIUS) -> str:
     lo = max(0, index - radius)
@@ -216,10 +219,18 @@ def test_public_product_docs_do_not_restate_ninety_plus_success_rates() -> None:
             if token in text:
                 failures.append(f"{rel} restates {token}")
         if path.name == "sections.jsx":
-            assert "no validated FlexAID∆S success rate" in text
+            # Accept either delta codepoint: the canonical spelling is U+0394
+            # (GREEK CAPITAL LETTER DELTA); U+2206 (INCREMENT) is still present on
+            # surfaces that have not been migrated. The assertion is about the
+            # disclaimer being present, not about which delta glyph spells it.
+            assert _DISCLAIMER_RE.search(text), f"{rel} lost the no-validated-rate disclaimer"
             assert "Benchmarks are still rolling" in text
         if path.name == "index.html" and "entropy-driven" in rel:
-            assert "no validated FlexAID∆S success rate" in text
+            # Accept either delta codepoint: the canonical spelling is U+0394
+            # (GREEK CAPITAL LETTER DELTA); U+2206 (INCREMENT) is still present on
+            # surfaces that have not been migrated. The assertion is about the
+            # disclaimer being present, not about which delta glyph spells it.
+            assert _DISCLAIMER_RE.search(text), f"{rel} lost the no-validated-rate disclaimer"
             assert "Benchmarks are still rolling" in text
         if path.name == "BENCHMARK.md":
             assert "Benchmarks are still rolling" in text


### PR DESCRIPTION
Makes `site/FlexAIDdS/` the single canonical source for `thebonhomme.com/FlexAIDdS/`: the
self-contained project-page structure, with the apex lineage's palette-v2 purge applied and
the withdrawn-claim content preserved.

## Routing (verified, not assumed)

`lebonhommepharma.github.io/FlexAIDdS/` → **301** → `thebonhomme.com/FlexAIDdS/`, both serving
the identical 4455-byte artifact. GitHub auto-mounts this repo's project Pages under the owner's
custom domain. There is no CNAME collision. The page therefore **must stay self-contained** — it
cannot borrow `../theme.css` or `/tokens.css`, which only resolve inside the apex tree.

## The three lineages, as measured

| | palette | stale stats | assets |
|---|---|---|---|
| **A** apex `FlexAIDdS/index.html` | v2 hexes, but via `--teal → var(--mint)` **aliases** in the apex `tokens.css` | **carries a live competitor table** (0.93 / 1.4 / 0.88 / 92% vs Vina · Glide · rDock), 92% in `WhySection`, 3 animated hero stats, `96.4` in an HTML comment, 5 × `tui.js` | `../theme.css`, `/tokens.css`, `/interaction.css`, `../assets/*` — apex-only |
| **B** `site/FlexAIDdS/` @ main | v1: `--teal #22D3EE` ×67, `--gold #FBBF24` ×28, `--terra #A78BFA` ×17, `#0a0e14` ×7 | none | self-contained |
| **C** live gh-pages | same as B | none | self-contained |

**B and C are the same artefact.** Every file is byte-identical except `index.html` and
`assets/repo-stats.json`, and those differ only in the counters `scripts/update_site_stats.py`
regenerates. gh-pages is not ahead of `site/FlexAIDdS/` — it is its output.

So the split is A vs (B≡C), and it runs the opposite way from the usual framing: **A is the
stale lineage on content and the clean one on palette.** This repo's own guard
`tests/test_check_published_astex_rates.py` bans `r = 0.93` and `92%` on `site/FlexAIDdS/sections.jsx`,
so A's content would fail CI here.

## Content delta

**A-only, carried:** `og:locale`; the `2,000th commit` milestone threshold (repo is at 2592);
A's `.btn-primary:hover` (drops retired `#2a9aa8`); `assets/favicon-flexaid-ds.svg`, vendored.

**A-only, deliberately not carried:**
- the benchmark table, the 92% claim, the three hero figures, the `96.4` comment — all withdrawn claims
- `og:image` / `twitter:image` → `https://thebonhomme.com/assets/og-thebonhomme.png` is **404**
- `LiveRunSection` (the TUI) — see below

**C-only, kept:** the withdrawal language in `WhySection` / `HeroSection` / `BenchmarksSection`;
the 8-tab `InstallSection` (A's 2 tabs are a strict subset — A's `cli` tab is C's `cmake` tab
verbatim); `-webkit-text-size-adjust`, `min-height: 100svh`, `env(safe-area-inset-*)`,
44 px touch targets, `.nav-mobile-theme`.

## Palette

Every substitution was extracted mechanically by diffing A against C and keeping only pairs whose
line was otherwise identical — 14 pairs, all of them LP's own v2 decisions. Colours A left alone
(`#9AE635` CUDA, `#7DD3FC` Metal, `#F87171` ROCm, `#EC4899` ΔS phase, the `LANG_COLORS` map) are
left alone here. `colors_and_type.css` is now the apex `tokens.css` content — v2 names defined
natively, **legacy `--teal` / `--gold` / `--terra` aliases dropped**, `--mint-12` added for the
one ramp step the page consumes.

## Guards

| guard | scanned | result |
|---|---|---|
| forbidden stale strings (20 patterns, comments included) | 14 files | 0 hits |
| retired v1 palette (hex + `%23` encoded + var names) | 14 files | 0 outside the `palette-check-ignore` registry |
| codepoint census | 14 files | U+0394 × 59, **U+2206 × 0**, U+2212 × 13 |
| CSS var coverage | 132 defs / 46 consumed | 0 undefined |
| asset resolution | 13 local refs | all 200, 0 escape the tree |
| `tests/test_check_published_astex_rates.py` | 13 surfaces, 6422 lines | 13 passed |
| `tests/test_site_publish_scripts.py` | — | 18 passed |

Each guard was mutation-tested: injecting `r = 0.93`, a `96.4` HTML comment, `#0a0e14`, a U+2206,
and deleting the disclaimer each made the corresponding guard fail.

`tests/test_check_published_astex_rates.py` asserted the literal `no validated FlexAID∆S success rate`
with **U+2206**, which the codepoint rule breaks. The assertion is now a regex accepting either
delta, so it still guards `site/entropy-driven/index.html` (not migrated) while no longer pinning
the wrong glyph. U+2206 survives in 110 other files / 385 occurrences repo-wide — out of scope here.

## Render verification

Headless Chromium, 8 widths × 2 themes on the built tree:

- **0 page errors, 0 failed requests, 0 4xx/5xx** across all 16 runs
- 1 console warning, all runs: Babel's in-browser-transformer notice — architectural, identical on live
- 0 horizontal overflow at every width **320 → 2560**; equation intact and in-view at all of them
- exactly one `<h1>`; `<main>` / `<nav>` / `<footer>` present
- **every one of 35 focusable elements has a visible focus indicator**
- `data-theme` follows `localStorage` correctly in both themes

## Known — not fixed here

1. **4 new dark-theme AA failures.** Measured against the *composited* background, live has 2
   distinct failures and this branch has 6. All four new ones are `--violet #8B5CF6` replacing the
   lighter `--terra #A78BFA`, at 3.91–4.39 : 1 where 4.5 is needed: `.binding-phase-btn.active`,
   an `h3`, and `.badge.terra` at 9 px and 10 px. `tokens.css` predicts this — *"Violet (4.66:1)
   … no headroom."* The fix follows the file's own `--state-fail-text` pattern (a lifted text
   variant) but that is a palette decision, not a merge decision, so it is left open.
2. **Light theme:** 49 distinct AA failures live, 48 here — 48 shared, 0 introduced, 1 fixed.
   Pre-existing and structural: holding the seven key colours constant across themes cannot work
   for accents designed on `#08091A`. `.code-box` also keeps a dark ground while text flips light.
3. `.badge.rocm` is `#F87171` at 9–10 px — violates *no red text below 12 px*. Identical in A and C.
4. Heading order skips h2 → h4. Identical in A and C.
5. Nav and footer links are 19 px tall (< 24 × 24, WCAG 2.5.8). Identical in A and C — C already
   fixed the mobile menu to 44 px; the desktop row was not covered.
6. `assets/flexaid-logo.js` keeps the JS locals `TEAL` / `TERRA` / `GOLD` holding v2 values, exactly
   as A does. They are JS identifiers, not CSS custom properties.

## Deploy

`scripts/sync_apex_to_ghpages.sh` rsyncs `site/FlexAIDdS/` → gh-pages root, so `site/FlexAIDdS/`
is the **source** and this change is what gets published — the pipeline preserves it, it does not
clobber it. `rm -f CNAME` is correct: the project repo must not claim the apex domain. `--delete`
means the vendored favicon propagates. `update_site_stats.py` rewrites the `stat-*` spans and both
`repo-stats.json` copies on every run; those markers are untouched here.

No visual/design pass was made. Content correctness only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refreshed the site with a new mint, violet, and tangerine color palette across navigation, content, charts, buttons, links, and theme controls.
  - Updated dark and light theme surfaces, accents, glows, gradients, and menu styling.
  - Improved branding consistency with the corrected FlexAIDΔS name, refreshed logo colors, favicon, and social-preview imagery.

- **Content**
  - Updated milestone messaging and removed benchmark comparator percentages from the disclaimer.
  - Added Open Graph locale and site metadata for richer link previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->